### PR TITLE
feat: add multi-monitor workspace_method support

### DIFF
--- a/globals.hpp
+++ b/globals.hpp
@@ -1,5 +1,10 @@
 #pragma once
 
 #include <hyprland/src/plugins/PluginAPI.hpp>
+#include <unordered_map>
+#include <string>
 
 inline HANDLE PHANDLE = nullptr;
+
+// Store monitor-specific workspace method configurations
+inline std::unordered_map<std::string, std::string> g_monitorWorkspaceMethods;

--- a/main.cpp
+++ b/main.cpp
@@ -277,8 +277,8 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     HyprlandAPI::addDispatcherV2(PHANDLE, "hyprexpo:kb_select", ::onKbSelectTokenDispatcher);
     HyprlandAPI::addDispatcherV2(PHANDLE, "hyprexpo:kb_selecti", ::onKbSelectIndexDispatcher);
 
-    HyprlandAPI::addConfigKeyword(PHANDLE, "hyprexpo-gesture", ::expoGestureKeyword, {});
-    HyprlandAPI::addConfigKeyword(PHANDLE, "hyprexpo-workspace-method", ::workspaceMethodKeyword, {});
+    HyprlandAPI::addConfigKeyword(PHANDLE, "hyprexpo_gesture", ::expoGestureKeyword, {});
+    HyprlandAPI::addConfigKeyword(PHANDLE, "workspace_method", ::workspaceMethodKeyword, {});
 
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:columns", Hyprlang::INT{3});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:gaps_in", Hyprlang::INT{5});

--- a/main.cpp
+++ b/main.cpp
@@ -116,6 +116,36 @@ static void failNotif(const std::string& reason) {
     HyprlandAPI::addNotification(PHANDLE, "[hyprexpo] Failure in initialization: " + reason, CHyprColor{1.0, 0.2, 0.2, 1.0}, 5000);
 }
 
+static Hyprlang::CParseResult workspaceMethodKeyword(const char* LHS, const char* RHS) {
+    Hyprlang::CParseResult result;
+
+    if (g_unloading)
+        return result;
+
+    // Parse format: "workspace_method = MONITOR_NAME method workspace"
+    // Example: "workspace_method = DP-1 first 19"
+    CConstVarList data(RHS);
+
+    if (data.size() < 3) {
+        result.setError("workspace_method requires format: MONITOR_NAME <center|first> <workspace>");
+        return result;
+    }
+
+    const std::string monitorName = std::string{data[0]};
+    const std::string methodType = std::string{data[1]};
+    const std::string workspace = std::string{data[2]};
+
+    if (methodType != "center" && methodType != "first") {
+        result.setError(std::format("Invalid method type '{}', expected 'center' or 'first'", methodType).c_str());
+        return result;
+    }
+
+    // Store in global map
+    g_monitorWorkspaceMethods[monitorName] = methodType + " " + workspace;
+
+    return result;
+}
+
 static Hyprlang::CParseResult expoGestureKeyword(const char* LHS, const char* RHS) {
     Hyprlang::CParseResult    result;
 
@@ -248,6 +278,7 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     HyprlandAPI::addDispatcherV2(PHANDLE, "hyprexpo:kb_selecti", ::onKbSelectIndexDispatcher);
 
     HyprlandAPI::addConfigKeyword(PHANDLE, "hyprexpo-gesture", ::expoGestureKeyword, {});
+    HyprlandAPI::addConfigKeyword(PHANDLE, "hyprexpo-workspace-method", ::workspaceMethodKeyword, {});
 
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:columns", Hyprlang::INT{3});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:gaps_in", Hyprlang::INT{5});

--- a/overview.cpp
+++ b/overview.cpp
@@ -233,6 +233,40 @@ static void removeOverview(WP<Hyprutils::Animation::CBaseAnimatedVariable> thisp
     g_pOverview.reset();
 }
 
+// Get workspace method configuration for a specific monitor
+// Returns pair of {isCenter, startWorkspaceID}
+static std::pair<bool, int> getWorkspaceMethodForMonitor(PHLMONITOR monitor) {
+    static auto const* PMETHOD = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:workspace_method")->getDataStaticPtr();
+
+    // Try to get monitor-specific config from global map first
+    const std::string monitorName = monitor->m_name;
+    std::string methodStr;
+
+    auto it = g_monitorWorkspaceMethods.find(monitorName);
+    if (it != g_monitorWorkspaceMethods.end()) {
+        methodStr = it->second;
+    } else {
+        // Use global config
+        methodStr = std::string{*PMETHOD};
+    }
+
+    // Parse the method string
+    bool methodCenter = true;
+    int methodStartID = monitor->activeWorkspaceID();
+
+    CVarList method{methodStr, 0, 's', true};
+    if (method.size() < 2) {
+        Debug::log(ERR, "[he] invalid workspace_method for monitor {}: {}", monitorName, methodStr);
+    } else {
+        methodCenter = method[0] == "center";
+        methodStartID = getWorkspaceIDNameFromString(method[1]).id;
+        if (methodStartID == WORKSPACE_INVALID)
+            methodStartID = monitor->activeWorkspaceID();
+    }
+
+    return {methodCenter, methodStartID};
+}
+
 COverview::~COverview() {
     g_pHyprRenderer->makeEGLCurrent();
     images.clear(); // otherwise we get a vram leak
@@ -249,24 +283,13 @@ COverview::COverview(PHLWORKSPACE startedOn_, bool swipe_) : startedOn(startedOn
     static auto* const* PGAPS    = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:gaps_in")->getDataStaticPtr();
     static auto* const* PCOL     = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:bg_col")->getDataStaticPtr();
     static auto* const* PSKIP    = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:skip_empty")->getDataStaticPtr();
-    static auto const*  PMETHOD  = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:workspace_method")->getDataStaticPtr();
 
     SIDE_LENGTH = **PCOLUMNS;
     GAP_WIDTH   = **PGAPS;
     BG_COLOR    = **PCOL;
 
-    // process the method
-    bool     methodCenter  = true;
-    int      methodStartID = pMonitor->activeWorkspaceID();
-    CVarList method{*PMETHOD, 0, 's', true};
-    if (method.size() < 2)
-        Debug::log(ERR, "[he] invalid workspace_method");
-    else {
-        methodCenter  = method[0] == "center";
-        methodStartID = getWorkspaceIDNameFromString(method[1]).id;
-        if (methodStartID == WORKSPACE_INVALID)
-            methodStartID = pMonitor->activeWorkspaceID();
-    }
+    // Get workspace method for this specific monitor
+    auto [methodCenter, methodStartID] = getWorkspaceMethodForMonitor(pMonitor.lock());
 
     images.resize(SIDE_LENGTH * SIDE_LENGTH);
 


### PR DESCRIPTION
This commit implements Issue #1 by adding per-monitor workspace_method configuration, allowing different workspace layouts for each display.

Changes:
- Added global map g_monitorWorkspaceMethods to store monitor-specific configs
- Created workspaceMethodKeyword custom config parser
- Added helper function getWorkspaceMethodForMonitor() to resolve per-monitor settings
- Refactored COverview constructor to use monitor-specific workspace method
- Registered new config keyword: hyprexpo-workspace-method

Configuration example:
  plugin { hyprexpo { workspace_method = center current  # default for all monitors } }

Per-monitor overrides 

```
workspace_method = DP-1, first, 19 
workspace_method = DP-2, first, 29
```