### PR TITLE
feat: add mouse hover border configuration and visual feedback

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -263,6 +263,7 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:border_width", Hyprlang::INT{2});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:border_color_current", Hyprlang::INT{0xFF66CCFF});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:border_color_focus", Hyprlang::INT{0xFFFFCC66});
+    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:border_color_hover", Hyprlang::INT{0xFFAABBCC});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:label_enable", Hyprlang::INT{1});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:label_color", Hyprlang::INT{0xFFFFFFFF});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:label_font_size", Hyprlang::INT{16});
@@ -277,6 +278,7 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:tile_rounding_power", Hyprlang::FLOAT{2.0f});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:tile_rounding_focus", Hyprlang::INT{-1});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:tile_rounding_current", Hyprlang::INT{-1});
+    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:tile_rounding_hover", Hyprlang::INT{-1});
 
     // (shadows moved to feature/shadows branch)
     // defaults: center/middle within the label container
@@ -309,6 +311,7 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     // hyprland-style gradient borders per state (string like: "rgba(33ccffee) rgba(00ff99ee) 45deg")
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:border_grad_current", Hyprlang::STRING{""});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:border_grad_focus", Hyprlang::STRING{""});
+    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:border_grad_hover", Hyprlang::STRING{""});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:keynav_wrap_h", Hyprlang::INT{1});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:keynav_wrap_v", Hyprlang::INT{1});
     // default off: spatial moves by default

--- a/overview.cpp
+++ b/overview.cpp
@@ -431,6 +431,16 @@ COverview::COverview(PHLWORKSPACE startedOn_, bool swipe_) : startedOn(startedOn
 
         info.cancelled    = true;
         lastMousePosLocal = g_pInputManager->getMouseCoordsInternal() - pMonitor->m_position;
+
+        // Update hovered tile
+        int hx = std::clamp((int)(lastMousePosLocal.x / pMonitor->m_size.x * SIDE_LENGTH), 0, SIDE_LENGTH - 1);
+        int hy = std::clamp((int)(lastMousePosLocal.y / pMonitor->m_size.y * SIDE_LENGTH), 0, SIDE_LENGTH - 1);
+        int newHoveredID = hx + hy * SIDE_LENGTH;
+
+        if (newHoveredID != hoveredID) {
+            hoveredID = newHoveredID;
+            damage();
+        }
     };
 
     auto onCursorSelect = [this](void* self, SCallbackInfo& info, std::any param) {
@@ -834,10 +844,12 @@ void COverview::fullRender() {
     static auto* const* PTOUNDPWR  = (Hyprlang::FLOAT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:tile_rounding_power")->getDataStaticPtr();
     static auto* const* PTILEROUNDF = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:tile_rounding_focus")->getDataStaticPtr();
     static auto* const* PTILEROUNDC = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:tile_rounding_current")->getDataStaticPtr();
+    static auto* const* PTILEROUNDH = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:tile_rounding_hover")->getDataStaticPtr();
 
     const int BASE_ROUND_SCALED   = std::max(0, (int)std::lround((double)**PTILEROUND * pMonitor->m_scale));
     const int FOCUS_ROUND_SCALED  = **PTILEROUNDF >= 0 ? std::max(0, (int)std::lround((double)**PTILEROUNDF * pMonitor->m_scale)) : BASE_ROUND_SCALED;
     const int CURRENT_ROUND_SCALED= **PTILEROUNDC >= 0 ? std::max(0, (int)std::lround((double)**PTILEROUNDC * pMonitor->m_scale)) : BASE_ROUND_SCALED;
+    const int HOVER_ROUND_SCALED  = **PTILEROUNDH >= 0 ? std::max(0, (int)std::lround((double)**PTILEROUNDH * pMonitor->m_scale)) : BASE_ROUND_SCALED;
     const float ROUND_PWR         = **PTOUNDPWR;
 
     // (shadows moved to feature/shadows branch)
@@ -848,12 +860,14 @@ void COverview::fullRender() {
             CBox      texbox{OUTER + x * tileRenderSize.x + x * GAPSIZE, OUTER + y * tileRenderSize.y + y * GAPSIZE, tileRenderSize.x, tileRenderSize.y};
             texbox.scale(pMonitor->m_scale).translate(pos->value());
             texbox.round();
-            // per-tile rounding override for focus/current
+            // per-tile rounding override for focus/current/hover (priority: focus > current > hover)
             int tileRound = BASE_ROUND_SCALED;
             if ((int)id == kbFocusID)
                 tileRound = FOCUS_ROUND_SCALED;
             else if ((int)id == openedID)
                 tileRound = CURRENT_ROUND_SCALED;
+            else if ((int)id == hoveredID)
+                tileRound = HOVER_ROUND_SCALED;
 
             // clamp rounding to tile size
             const int maxCornerPx = std::max(0, (int)std::floor(std::min(texbox.w, texbox.h) / 2.0));
@@ -891,26 +905,23 @@ void COverview::fullRender() {
     static auto* const* PBWIDTH   = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:border_width")->getDataStaticPtr();
     static auto* const* PBCURCOL  = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:border_color_current")->getDataStaticPtr();
     static auto* const* PBFOCCOL  = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:border_color_focus")->getDataStaticPtr();
+    static auto* const* PBHOVCOL  = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:border_color_hover")->getDataStaticPtr();
     static auto  const* PBSTYLE   = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:border_style")->getDataStaticPtr();
     static auto  const* PBGRCUR   = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:border_grad_current")->getDataStaticPtr();
     static auto  const* PBGREFOC  = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:border_grad_focus")->getDataStaticPtr();
+    static auto  const* PBGREHOV  = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:border_grad_hover")->getDataStaticPtr();
 
     // draw labels
     if (**PLABELEN) {
-        // hovered tile (approximate like selectHoveredWorkspace)
-        int hoveredID = -1;
-        if (!closing) {
-            int hx = std::clamp((int)(lastMousePosLocal.x / pMonitor->m_size.x * SIDE_LENGTH), 0, SIDE_LENGTH - 1);
-            int hy = std::clamp((int)(lastMousePosLocal.y / pMonitor->m_size.y * SIDE_LENGTH), 0, SIDE_LENGTH - 1);
-            hoveredID = hx + hy * SIDE_LENGTH;
-        }
+        // use the tracked hoveredID (cleared during closing)
+        const int labelHoveredID = closing ? -1 : hoveredID;
 
         auto shouldShow = [&](int id) -> bool {
             if (std::string{*PLABELSHOW} == "never")
                 return false;
             if (std::string{*PLABELSHOW} == "always")
                 return true;
-            const bool isHover  = id == hoveredID;
+            const bool isHover  = id == labelHoveredID;
             const bool isFocus  = id == kbFocusID;
             const bool isCurr   = id == openedID;
             const std::string mode{*PLABELSHOW};
@@ -931,7 +942,7 @@ void COverview::fullRender() {
                 return 2; // focus
             if (id == openedID)
                 return 3; // current
-            if (id == hoveredID)
+            if (id == labelHoveredID)
                 return 1; // hover
             return 0;     // default
         };
@@ -1090,12 +1101,13 @@ void COverview::fullRender() {
         }
     }
 
-    // draw borders for current and focus (overridden rounding by state below)
+    // draw borders for hover, current and focus (priority order: focus > current > hover)
 
     // pass rounding based on state
     const int RND_CUR = CURRENT_ROUND_SCALED;
     const int RND_FOC = FOCUS_ROUND_SCALED;
-    auto drawBorderForID = [&](int id, bool isFocus, const CHyprColor& colFallback, int roundScaled) {
+    const int RND_HOV = HOVER_ROUND_SCALED;
+    auto drawBorderForID = [&](int id, int stateType, const CHyprColor& colFallback, const std::string& gradSpec, int roundScaled) {
         if (id < 0)
             return;
         const int ix = id % SIDE_LENGTH;
@@ -1107,8 +1119,7 @@ void COverview::fullRender() {
 
         const std::string style{*PBSTYLE};
         if (style == "hyprland") {
-            const std::string specStr = isFocus ? std::string{*PBGREFOC} : std::string{*PBGRCUR};
-            const auto        spec    = parseGradientSpec(specStr);
+            const auto spec = parseGradientSpec(gradSpec);
             if (spec.valid) {
                 CGradientValueData grad;
                 grad.m_colors.clear();
@@ -1153,9 +1164,12 @@ void COverview::fullRender() {
         }
     };
 
-    drawBorderForID(openedID, false, CHyprColor{(uint64_t)**PBCURCOL}, RND_CUR);
+    // Draw borders in order: hover (lowest), then current, then focus (highest priority)
+    if (hoveredID != -1 && hoveredID != openedID && hoveredID != kbFocusID)
+        drawBorderForID(hoveredID, 0, CHyprColor{(uint64_t)**PBHOVCOL}, std::string{*PBGREHOV}, RND_HOV);
+    drawBorderForID(openedID, 1, CHyprColor{(uint64_t)**PBCURCOL}, std::string{*PBGRCUR}, RND_CUR);
     if (kbFocusID != -1)
-        drawBorderForID(kbFocusID, true, CHyprColor{(uint64_t)**PBFOCCOL}, RND_FOC);
+        drawBorderForID(kbFocusID, 2, CHyprColor{(uint64_t)**PBFOCCOL}, std::string{*PBGREFOC}, RND_FOC);
 }
 
 static float lerp(const float& from, const float& to, const float perc) {

--- a/overview.cpp
+++ b/overview.cpp
@@ -425,6 +425,11 @@ COverview::COverview(PHLWORKSPACE startedOn_, bool swipe_) : startedOn(startedOn
 
     lastMousePosLocal = g_pInputManager->getMouseCoordsInternal() - pMonitor->m_position;
 
+    // Initialize hoveredID based on current mouse position
+    int hx = std::clamp((int)(lastMousePosLocal.x / pMonitor->m_size.x * SIDE_LENGTH), 0, SIDE_LENGTH - 1);
+    int hy = std::clamp((int)(lastMousePosLocal.y / pMonitor->m_size.y * SIDE_LENGTH), 0, SIDE_LENGTH - 1);
+    hoveredID = hx + hy * SIDE_LENGTH;
+
     auto onCursorMove = [this](void* self, SCallbackInfo& info, std::any param) {
         if (closing)
             return;

--- a/overview.hpp
+++ b/overview.hpp
@@ -88,6 +88,7 @@ class COverview {
     int                          openedID  = -1;
     int                          closeOnID = -1;
     int                          kbFocusID = -1;
+    int                          hoveredID = -1;
     bool                         submapActive = false;
 
     std::vector<SWorkspaceImage> images;


### PR DESCRIPTION
This commit implements Issue #2 by adding comprehensive mouse hover support with configurable borders and visual feedback.

Changes:
- Added hoveredID member variable to track hovered workspace tile
- Updated mouse move handler to detect and track hover state
- Added configuration options:
  - plugin:hyprexpo:border_color_hover (default: 0xFFAABBCC)
  - plugin:hyprexpo:border_grad_hover (gradient support)
  - plugin:hyprexpo:tile_rounding_hover (per-state rounding)
- Implemented hover border rendering with priority system (focus > current > hover)
- Integrated hover state into existing label system
- Hover detection triggers damage events for smooth updates

The hover state provides immediate visual feedback as users move their mouse over workspace tiles, enhancing the interactive experience without requiring keyboard navigation.