### PR TITLE
fix: don't swallow clicks when expo opened by phantom keybind trigger

### DIFF
--- a/overview.cpp
+++ b/overview.cpp
@@ -594,6 +594,14 @@ COverview::COverview(PHLWORKSPACE startedOn_, bool swipe_) : startedOn(startedOn
         if (closing)
             return;
 
+        // If expo hasn't animated in enough to be visible, close silently without
+        // consuming the event. This prevents phantom triggers (e.g. a bouncing
+        // mouse side-button firing the expo keybind) from swallowing real clicks.
+        if (size->getPercent() < 0.05f) {
+            close();
+            return;
+        }
+
         info.cancelled = true;
 
         selectHoveredWorkspace();


### PR DESCRIPTION
## Problem

When a bouncing mouse side-button (or any spurious input) fires the expo toggle keybind, `COverview` is constructed and `mouseButtonHook` immediately starts setting `info.cancelled = true` on **all** pointer button events — even though expo is invisible (animation progress ≈ 0).

The user sees a normal desktop but cannot click anything. The only recovery is `hyprctl dispatch hyprexpo:expo close && hyprctl dispatch submap reset`.

Reproduced by: G403 HERO keyboard composite device generating phantom `CTRL+ALT+UP` events from a bouncing side-button, repeatedly opening expo silently.

## Fix

In `mouseButtonHook`, check `size->getPercent() < 0.05f` before consuming the event. If expo hasn't animated in enough to be visible, call `close()` silently without setting `info.cancelled`, so the click reaches the intended window.

## Root cause chain (for reference)

1. `logitech-g403-hero-gaming-mouse-keyboard` device generates phantom key events from a bouncing/stuck side button
2. Phantom `CTRL+ALT+UP` fires `hyprexpo:expo toggle`
3. `COverview` constructed → `mouseButtonHook` registered → all clicks cancelled
4. Expo never renders visibly (animation at 0) → user can't dismiss it by clicking
5. Clicks keep getting swallowed until session restart