### PR TITLE
chase hyprland 0.55

### DIFF
--- a/OverviewPassElement.cpp
+++ b/OverviewPassElement.cpp
@@ -6,8 +6,9 @@ COverviewPassElement::COverviewPassElement() {
     ;
 }
 
-void COverviewPassElement::draw(const CRegion& damage) {
+std::vector<UP<IPassElement>> COverviewPassElement::draw() {
     g_pOverview->fullRender();
+    return {};
 }
 
 bool COverviewPassElement::needsLiveBlur() {
@@ -30,4 +31,8 @@ CRegion COverviewPassElement::opaqueRegion() {
         return CRegion{};
 
     return CBox{{}, g_pOverview->pMonitor->m_size};
+}
+
+ePassElementType COverviewPassElement::type() {
+    return EK_CUSTOM;
 }

--- a/OverviewPassElement.hpp
+++ b/OverviewPassElement.hpp
@@ -8,13 +8,14 @@ class COverviewPassElement : public IPassElement {
     COverviewPassElement();
     virtual ~COverviewPassElement() = default;
 
-    virtual void                draw(const CRegion& damage);
-    virtual bool                needsLiveBlur();
-    virtual bool                needsPrecomputeBlur();
-    virtual std::optional<CBox> boundingBox();
-    virtual CRegion             opaqueRegion();
+    virtual std::vector<UP<IPassElement>> draw();
+    virtual bool                          needsLiveBlur();
+    virtual bool                          needsPrecomputeBlur();
+    virtual std::optional<CBox>           boundingBox();
+    virtual CRegion                       opaqueRegion();
+    virtual ePassElementType              type();
 
-    virtual const char*         passName() {
+    virtual const char*                   passName() {
         return "COverviewPassElement";
     }
 };

--- a/main.cpp
+++ b/main.cpp
@@ -385,7 +385,7 @@ APICALL EXPORT void PLUGIN_EXIT() {
 
     g_unloading = true;
 
-    g_pConfigManager->reload(); // we need to reload now to clear all the gestures
+    Config::mgr()->reload(); // we need to reload now to clear all the gestures
 }
 
 //

--- a/overview.cpp
+++ b/overview.cpp
@@ -1,22 +1,39 @@
 #include "overview.hpp"
 #include <any>
 #include <hyprland/src/event/EventBus.hpp>
-#define private public
+#define private   public
+#define protected public
 #include <hyprland/src/render/Renderer.hpp>
 #include <hyprland/src/Compositor.hpp>
 #include <hyprland/src/config/ConfigValue.hpp>
 #include <hyprland/src/config/ConfigManager.hpp>
+#include <hyprland/src/config/shared/actions/ConfigActions.hpp>
+#include <hyprland/src/config/shared/animation/AnimationTree.hpp>
 #include <hyprland/src/managers/animation/AnimationManager.hpp>
 #include <hyprland/src/managers/animation/DesktopAnimationManager.hpp>
 #include <hyprland/src/managers/input/InputManager.hpp>
 #include <hyprland/src/managers/PointerManager.hpp>
 #include <hyprland/src/helpers/time/Time.hpp>
+#include <hyprland/src/helpers/varlist/VarList.hpp>
+#include <hyprland/src/helpers/Format.hpp>
+#include <drm_fourcc.h>
 #undef private
+#undef protected
 #include "OverviewPassElement.hpp"
 #include <hyprland/src/render/OpenGL.hpp>
-#include <hyprland/src/config/ConfigDataValues.hpp>
+#include <hyprland/src/config/shared/complex/ComplexDataTypes.hpp>
 #include <pango/pangocairo.h>
 #include <cmath>
+
+static void clearWithColor(const CHyprColor& color) {
+    glClearColor(color.r, color.g, color.b, color.a);
+    glClear(GL_COLOR_BUFFER_BIT);
+}
+
+static uint32_t framebufferFormatWithAlpha(uint32_t drmFormat) {
+    const auto alphaFormat = NFormatUtils::alphaFormat(drmFormat);
+    return alphaFormat == 0 ? DRM_FORMAT_ABGR8888 : alphaFormat;
+}
 
 static bool isTransformRotated(wl_output_transform t) {
     return t == WL_OUTPUT_TRANSFORM_90 || t == WL_OUTPUT_TRANSFORM_270 ||
@@ -136,7 +153,7 @@ static void renderGradientBorder(const CBox& box, int borderSize, const SHyprGra
         const float cy = r.y + r.h / 2.0;
         const float d  = cx * g.x + cy * g.y;
         const float t  = (d - minD) / range;
-        g_pHyprOpenGL->renderRect(r, mixCol(grad.c1, grad.c2, t), {});
+        Render::GL::g_pHyprOpenGL->renderRect(r, mixCol(grad.c1, grad.c2, t), {});
     };
 
     const double cr = std::clamp((double)round, 0.0, std::min(box.w, box.h) / 2.0);
@@ -162,7 +179,7 @@ static void renderGradientBorder(const CBox& box, int borderSize, const SHyprGra
     }
 }
 
-static void renderNumberTexture(SP<CTexture> out, const std::string& text, const CHyprColor& color, const Vector2D& bufferSize, const float scale, const int fontSize) {
+static SP<Render::ITexture> renderNumberTexture(const std::string& text, const CHyprColor& color, const Vector2D& bufferSize, const float scale, const int fontSize) {
     const auto CAIROSURFACE = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, bufferSize.x, bufferSize.y);
     const auto CAIRO        = cairo_create(CAIROSURFACE);
 
@@ -224,21 +241,16 @@ static void renderNumberTexture(SP<CTexture> out, const std::string& text, const
 
     cairo_surface_flush(CAIROSURFACE);
 
-    const auto DATA = cairo_image_surface_get_data(CAIROSURFACE);
-    out->allocate();
-    glBindTexture(GL_TEXTURE_2D, out->m_texID);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-
-#ifndef GLES2
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_R, GL_BLUE);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_B, GL_RED);
-#endif
-
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, bufferSize.x, bufferSize.y, 0, GL_RGBA, GL_UNSIGNED_BYTE, DATA);
+    auto tex = g_pHyprRenderer->createTexture(CAIROSURFACE);
+    if (tex) {
+        tex->setTexParameter(GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+        tex->setTexParameter(GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    }
 
     cairo_destroy(CAIRO);
     cairo_surface_destroy(CAIROSURFACE);
+
+    return tex;
 }
 
 static void damageMonitor(WP<Hyprutils::Animation::CBaseAnimatedVariable> thisptr) {
@@ -344,11 +356,12 @@ static std::pair<bool, int> getWorkspaceMethodForMonitor(PHLMONITOR monitor) {
 }
 
 COverview::~COverview() {
-    g_pHyprRenderer->makeEGLCurrent();
+    Render::GL::g_pHyprOpenGL->makeEGLCurrent();
     images.clear(); // otherwise we get a vram leak
     g_pPointerManager->resetCursorImage();
     g_pInputManager->simulateMouseMovement();
-    g_pHyprOpenGL->markBlurDirtyForMonitor(pMonitor.lock());
+    if (pMonitor)
+        pMonitor->m_blurFBDirty = true;
     resetSubmapIfNeeded();
 }
 
@@ -435,7 +448,7 @@ COverview::COverview(PHLWORKSPACE startedOn_, bool swipe_) : startedOn(startedOn
         pMonitor->m_activeWorkspace = startedOn;
     }
 
-    g_pHyprRenderer->makeEGLCurrent();
+    Render::GL::g_pHyprOpenGL->makeEGLCurrent();
 
     Vector2D tileSize       = pMonitor->m_size / SIDE_LENGTH;
     Vector2D tileRenderSize = (pMonitor->m_size - Vector2D{GAP_WIDTH * pMonitor->m_scale, GAP_WIDTH * pMonitor->m_scale} * (SIDE_LENGTH - 1)) / SIDE_LENGTH;
@@ -476,12 +489,14 @@ COverview::COverview(PHLWORKSPACE startedOn_, bool swipe_) : startedOn(startedOn
 
     for (size_t i = 0; i < (size_t)(SIDE_LENGTH * SIDE_LENGTH); ++i) {
         COverview::SWorkspaceImage& image = images[i];
-        image.fb.alloc(monbox.w, monbox.h, PMONITOR->m_output->state->state().drmFormat);
+        if (!image.fb)
+            image.fb = g_pHyprRenderer->createFB("hyprexpo");
+        image.fb->alloc(monbox.w, monbox.h, framebufferFormatWithAlpha(PMONITOR->m_output->state->state().drmFormat));
 
         CRegion fakeDamage{0, 0, INT16_MAX, INT16_MAX};
-        g_pHyprRenderer->beginRender(PMONITOR, fakeDamage, RENDER_MODE_FULL_FAKE, nullptr, &image.fb, true);
+        g_pHyprRenderer->beginRender(PMONITOR, fakeDamage, Render::RENDER_MODE_FULL_FAKE, nullptr, image.fb);
 
-        g_pHyprOpenGL->clear(CHyprColor{0, 0, 0, 1.0});
+        clearWithColor(CHyprColor{0, 0, 0, 1.0});
 
         const auto PWORKSPACE = g_pCompositor->getWorkspaceByID(image.workspaceID);
 
@@ -510,7 +525,7 @@ COverview::COverview(PHLWORKSPACE startedOn_, bool swipe_) : startedOn(startedOn
         image.box = {(i % SIDE_LENGTH) * tileRenderSize.x + (i % SIDE_LENGTH) * GAP_WIDTH, (i / SIDE_LENGTH) * tileRenderSize.y + (i / SIDE_LENGTH) * GAP_WIDTH, tileRenderSize.x,
                      tileRenderSize.y};
 
-        g_pHyprOpenGL->m_renderData.blockScreenShader = true;
+        g_pHyprRenderer->m_renderData.blockScreenShader = true;
         g_pHyprRenderer->endRender();
     }
 
@@ -529,10 +544,10 @@ COverview::COverview(PHLWORKSPACE startedOn_, bool swipe_) : startedOn(startedOn
     // zoom on the current workspace.
     // const auto& TILE = images[std::clamp(currentid, 0, SIDE_LENGTH * SIDE_LENGTH)];
 
-    g_pAnimationManager->createAnimation(pMonitor->m_size * pMonitor->m_size / tileSize, size, g_pConfigManager->getAnimationPropertyConfig("windowsMove"), AVARDAMAGE_NONE);
+    g_pAnimationManager->createAnimation(pMonitor->m_size * pMonitor->m_size / tileSize, size, Config::animationTree()->getAnimationPropertyConfig("windowsMove"), AVARDAMAGE_NONE);
     g_pAnimationManager->createAnimation((-((pMonitor->m_size / (double)SIDE_LENGTH) * Vector2D{currentid % SIDE_LENGTH, currentid / SIDE_LENGTH}) * pMonitor->m_scale) *
                                              (pMonitor->m_size / tileSize),
-                                         pos, g_pConfigManager->getAnimationPropertyConfig("windowsMove"), AVARDAMAGE_NONE);
+                                         pos, Config::animationTree()->getAnimationPropertyConfig("windowsMove"), AVARDAMAGE_NONE);
 
     size->setUpdateCallback(damageMonitor);
     pos->setUpdateCallback(damageMonitor);
@@ -810,7 +825,7 @@ void COverview::redrawID(int id, bool forcelowres) {
 
     blockOverviewRendering = true;
 
-    g_pHyprRenderer->makeEGLCurrent();
+    Render::GL::g_pHyprOpenGL->makeEGLCurrent();
 
     id = std::clamp(id, 0, SIDE_LENGTH * SIDE_LENGTH);
 
@@ -840,15 +855,17 @@ void COverview::redrawID(int id, bool forcelowres) {
 
     auto& image = images[id];
 
-    if (image.fb.m_size != monbox.size()) {
-        image.fb.release();
-        image.fb.alloc(monbox.w, monbox.h, pMonitor->m_output->state->state().drmFormat);
+    if (!image.fb)
+        image.fb = g_pHyprRenderer->createFB("hyprexpo");
+    if (image.fb->m_size != monbox.size()) {
+        image.fb->release();
+        image.fb->alloc(monbox.w, monbox.h, framebufferFormatWithAlpha(pMonitor->m_output->state->state().drmFormat));
     }
 
     CRegion fakeDamage{0, 0, INT16_MAX, INT16_MAX};
-    g_pHyprRenderer->beginRender(pMonitor.lock(), fakeDamage, RENDER_MODE_FULL_FAKE, nullptr, &image.fb, true);
+    g_pHyprRenderer->beginRender(pMonitor.lock(), fakeDamage, Render::RENDER_MODE_FULL_FAKE, nullptr, image.fb);
 
-    g_pHyprOpenGL->clear(CHyprColor{0, 0, 0, 1.0});
+    clearWithColor(CHyprColor{0, 0, 0, 1.0});
 
     const auto   PWORKSPACE = image.pWorkspace;
 
@@ -876,7 +893,7 @@ void COverview::redrawID(int id, bool forcelowres) {
     } else
         g_pHyprRenderer->renderWorkspace(pMonitor.lock(), PWORKSPACE, Time::steadyNow(), monbox);
 
-    g_pHyprOpenGL->m_renderData.blockScreenShader = true;
+    g_pHyprRenderer->m_renderData.blockScreenShader = true;
     g_pHyprRenderer->endRender();
 
     // Restore the original monitor state after capture
@@ -961,9 +978,9 @@ void COverview::close() {
         const auto OLDWS = pMonitor->m_activeWorkspace;
 
         if (!NEWIDWS)
-            g_pKeybindManager->changeworkspace(std::to_string(NEWID));
+            Config::Actions::changeWorkspace(std::to_string(NEWID));
         else
-            g_pKeybindManager->changeworkspace(NEWIDWS->getConfigName());
+            Config::Actions::changeWorkspace(NEWIDWS->getConfigName());
 
         g_pDesktopAnimationManager->startAnimation(pMonitor->m_activeWorkspace, CDesktopAnimationManager::ANIMATION_TYPE_IN, true, true);
         g_pDesktopAnimationManager->startAnimation(OLDWS, CDesktopAnimationManager::ANIMATION_TYPE_OUT, false, true);
@@ -1017,7 +1034,7 @@ void COverview::fullRender() {
     Vector2D tileSize       = (SIZE / SIDE_LENGTH);
     Vector2D tileRenderSize = (SIZE - Vector2D{GAPSIZE, GAPSIZE} * (SIDE_LENGTH - 1) - Vector2D{OUTER * 2, OUTER * 2}) / SIDE_LENGTH;
 
-    g_pHyprOpenGL->clear(BG_COLOR.stripA());
+    clearWithColor(BG_COLOR.stripA());
 
     static auto* const* PTILEROUND = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:tile_rounding")->getDataStaticPtr();
     static auto* const* PTOUNDPWR  = (Hyprlang::FLOAT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:tile_rounding_power")->getDataStaticPtr();
@@ -1055,7 +1072,7 @@ void COverview::fullRender() {
             // no shadow in this branch
 
             CRegion damage{0, 0, INT16_MAX, INT16_MAX};
-            g_pHyprOpenGL->renderTextureInternal(images[id].fb.getTexture(), texbox, {.damage = &damage, .a = 1.0, .round = tileRound, .roundingPower = ROUND_PWR});
+            Render::GL::g_pHyprOpenGL->renderTextureInternal(images[id].fb->getTexture(), texbox, {.damage = &damage, .a = 1.0, .round = tileRound, .roundingPower = ROUND_PWR});
         }
     }
 
@@ -1197,14 +1214,12 @@ void COverview::fullRender() {
                 const int         baseF = std::max(8, (int)**PLABELSIZE);
                 const int         st    = resolveState(id);
 
-                auto ensureTex = [&](SP<CTexture>& tex, Vector2D& sz, const CHyprColor& col, float scaleMul) {
-                    if (!tex)
-                        tex = makeShared<CTexture>();
-                    if (tex->m_texID == 0) {
+                auto ensureTex = [&](SP<Render::ITexture>& tex, Vector2D& sz, const CHyprColor& col, float scaleMul) {
+                    if (!tex || tex->m_texID == 0) {
                         const int fsz = std::max(8, (int)std::round(baseF * scaleMul));
                         Vector2D  buf{std::max(32, fsz * 2), std::max(24, fsz + 8)};
-                        sz = buf;
-                        renderNumberTexture(tex, label, col, buf, pMonitor->m_scale, fsz);
+                        sz  = buf;
+                        tex = renderNumberTexture(label, col, buf, pMonitor->m_scale, fsz);
                     }
                 };
 
@@ -1215,7 +1230,7 @@ void COverview::fullRender() {
                 float      scl = 1.0f;
                 static auto* const* PLPIXELSNAP = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:label_pixel_snap")->getDataStaticPtr();
 
-                auto drawWithBG = [&](SP<CTexture>& tex, const Vector2D& tsize) {
+                auto drawWithBG = [&](SP<Render::ITexture>& tex, const Vector2D& tsize) {
                     const int pad = **PLBGPAD;
                     // background size
                     Vector2D bgSize = {tsize.x + pad * 2, tsize.y + pad * 2};
@@ -1234,15 +1249,15 @@ void COverview::fullRender() {
                         lb.round();
                     }
                     // draw
-                    g_pHyprOpenGL->renderRect(bg, CHyprColor{(uint64_t)**PLBGCOL}, {.round = roundPx});
-                    g_pHyprOpenGL->renderTexture(tex, lb, {.a = 1.0});
+                    Render::GL::g_pHyprOpenGL->renderRect(bg, CHyprColor{(uint64_t)**PLBGCOL}, {.round = roundPx});
+                    Render::GL::g_pHyprOpenGL->renderTexture(tex, lb, {.a = 1.0});
                 };
 
-                auto drawNoBG = [&](SP<CTexture>& tex, const Vector2D& tsize) {
+                auto drawNoBG = [&](SP<Render::ITexture>& tex, const Vector2D& tsize) {
                     CBox lb = placeBox(tile, tsize);
                     if (**PLPIXELSNAP)
                         lb.round();
-                    g_pHyprOpenGL->renderTexture(tex, lb, {.a = 1.0});
+                    Render::GL::g_pHyprOpenGL->renderTexture(tex, lb, {.a = 1.0});
                 };
 
                 if (st == 1) { // hover
@@ -1306,13 +1321,13 @@ void COverview::fullRender() {
             // Render as gradient border (hyprland style)
             const auto spec = parseGradientSpec(effectiveSpec);
             if (spec.valid) {
-                CGradientValueData grad;
+                Config::CGradientValueData grad;
                 grad.m_colors.clear();
                 grad.m_colors.push_back(spec.c1);
                 grad.m_colors.push_back(spec.c2);
                 grad.m_angle = spec.angleDeg * (float)M_PI / 180.f;
                 grad.updateColorsOk();
-                g_pHyprOpenGL->renderBorder(box, grad, {.round = roundScaled, .roundingPower = ROUND_PWR, .borderSize = BWIDTH});
+                Render::GL::g_pHyprOpenGL->renderBorder(box, grad, {.round = roundScaled, .roundingPower = ROUND_PWR, .borderSize = BWIDTH});
             }
         } else if (!effectiveSpec.empty()) {
             // Parse as solid color (rgb/hex format)
@@ -1334,7 +1349,7 @@ void COverview::fullRender() {
             }
 
             // Render as simple border
-            g_pHyprOpenGL->renderBorder(box, color, {.round = roundScaled, .roundingPower = ROUND_PWR, .borderSize = BWIDTH});
+            Render::GL::g_pHyprOpenGL->renderBorder(box, color, {.round = roundScaled, .roundingPower = ROUND_PWR, .borderSize = BWIDTH});
         }
     };
 

--- a/overview.hpp
+++ b/overview.hpp
@@ -68,19 +68,19 @@ class COverview {
     bool       damageDirty = false;
 
     struct SWorkspaceImage {
-        CFramebuffer fb;
-        int64_t      workspaceID = -1;
-        PHLWORKSPACE pWorkspace;
-        CBox         box;
+        SP<Render::IFramebuffer> fb;
+        int64_t                  workspaceID = -1;
+        PHLWORKSPACE             pWorkspace;
+        CBox                     box;
         // Label textures per state for customization
-        SP<CTexture> labelTexDefault;
-        SP<CTexture> labelTexHover;
-        SP<CTexture> labelTexFocus;
-        SP<CTexture> labelTexCurrent;
-        Vector2D     labelSizeDefault = {0, 0};
-        Vector2D     labelSizeHover   = {0, 0};
-        Vector2D     labelSizeFocus   = {0, 0};
-        Vector2D     labelSizeCurrent = {0, 0};
+        SP<Render::ITexture>     labelTexDefault;
+        SP<Render::ITexture>     labelTexHover;
+        SP<Render::ITexture>     labelTexFocus;
+        SP<Render::ITexture>     labelTexCurrent;
+        Vector2D                 labelSizeDefault = {0, 0};
+        Vector2D                 labelSizeHover   = {0, 0};
+        Vector2D                 labelSizeFocus   = {0, 0};
+        Vector2D                 labelSizeCurrent = {0, 0};
     };
 
     Vector2D                     lastMousePosLocal = Vector2D{};


### PR DESCRIPTION
## Summary

Port the plugin to **Hyprland 0.55.x**. Upstream `hyprexpo` was dropped from `hyprland-plugins` on 2026-05-12 (commit `3aa21f2`, "drop unmaintained plugins") and never received a 0.55 port — this fork has to chase the API on its own. Without these changes the plugin fails to build against `hyprland 0.55.1` and segfaults at runtime if force-loaded.

## API changes chased

### Render: textures and framebuffers moved into `Render::` namespace
- `CTexture` → `Render::ITexture` (abstract). Concrete instances are created via `g_pHyprRenderer->createTexture(cairo_surface_t*)` instead of `makeShared<CTexture>()` + manual `glTexImage2D`. Side-effect: the cairo-based `renderNumberTexture` now returns `SP<Render::ITexture>` directly rather than filling an out-parameter.
- `CFramebuffer` (value member) → `SP<Render::IFramebuffer>` (created via `g_pHyprRenderer->createFB("hyprexpo")`). All `image.fb.X` call sites become `image.fb->X`, and `&image.fb` arguments become `image.fb`.
- `g_pHyprOpenGL->clear()` removed → local `clearWithColor()` helper using raw `glClearColor`/`glClear`.
- `g_pHyprOpenGL->m_renderData` → `g_pHyprRenderer->m_renderData` (`m_renderData` migrated from the GL impl to the renderer).
- `markBlurDirtyForMonitor()` removed → `pMonitor->m_blurFBDirty = true`.
- `RENDER_MODE_FULL_FAKE` is now in the `Render::` namespace.
- Use `framebufferFormatWithAlpha(drmFormat)` (via `NFormatUtils::alphaFormat`) when allocating the offscreen FB so shadow rendering has a sane format to work with.
- Drop the `simple=true` 6th arg from `beginRender()`. With 0.55's restructured render path, `simple=true` skips state init that `CHyprDropShadowDecoration::render` → `renderRoundedShadow` depends on, causing a SIGSEGV during workspace tile draw.

### Config: legacy globals replaced by namespaced accessors
- `<hyprland/src/config/ConfigDataValues.hpp>` removed → `<hyprland/src/config/shared/complex/ComplexDataTypes.hpp>`.
- `CGradientValueData` moved into `Config::` namespace; `renderBorder()` now takes `Config::CGradientValueData`.
- `g_pConfigManager->reload()` → `Config::mgr()->reload()`.
- `g_pConfigManager->getAnimationPropertyConfig("...")` → `Config::animationTree()->getAnimationPropertyConfig("...")`.
- `g_pKeybindManager->changeworkspace(arg)` → `Config::Actions::changeWorkspace(arg)` (via `<hyprland/src/config/shared/actions/ConfigActions.hpp>`).

### Pass element API
`IPassElement::draw` was rewritten and a new pure-virtual `type()` was added. Updated `COverviewPassElement`:
- `virtual void draw(const CRegion& damage)` → `virtual std::vector<UP<IPassElement>> draw()` (returns `{}`).
- Implemented `virtual ePassElementType type() { return EK_CUSTOM; }`.

### Includes and access shims
- Added `#define protected public` alongside the existing `#define private public` — `beginRender` and `renderWorkspace` are now `protected` in `Render::IHyprRenderer`, and the plugin still needs to call them.
- New required includes: `helpers/varlist/VarList.hpp`, `helpers/Format.hpp`, `config/shared/actions/ConfigActions.hpp`, `config/shared/animation/AnimationTree.hpp`, `<drm_fourcc.h>`.

## Out of scope (intentionally)

- `HyprlandAPI::addConfigValue` / `getConfigValue` still work in 0.55 and produce only `[[deprecated]]` warnings. Migrating every plugin option to `CConfigValue<Config::INTEGER>` is a separate, larger refactor and is not blocking the build.

## Test plan

- [x] `make clean && make` produces `hyprexpo.so` with 0 errors against `hyprland 0.55.1` headers.
- [x] `hyprpm reload` loads the new build without crashing Hyprland.
- [x] Triggering the expo hotkey no longer SIGSEGVs inside `renderRoundedShadow` during workspace tile draw.
- [x] Workspace tiles render, hover/select works, animation closes.
- [x] Keyboard navigation submap still functions (please verify the configured keybinds).
- [x] Per-state label rendering (default/hover/focus/current) still appears with the configured colors and font.
- [x] Border styling for hover/focus/current (solid + gradient) still renders.

## Reference

The known-working community fork at https://github.com/colonelpanic8/hyprexpo was used as a reference for the render-path patterns (`createFB`, `createTexture`, `clearWithColor`, alpha-aware FB format, `beginRender` without `simple=true`). That fork does not include hyprexpo-plus's extra features (multi-state labels, keynav, gradient borders), so the changes here are a manual port keeping those features intact.