### PR TITLE
[codex] add Lua API and modern config reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,20 @@ bind = SUPER, g, hyprexpo:expo, <option>
 | `hyprexpo:kb_selectn` | `<id>` | select by workspace ID (legacy, 0→10) |
 | `hyprexpo:kb_select` | `<token>` | select by single token (1-9, 0, a-z) |
 
+### Lua API
+
+When Hyprland is configured from Lua, the dispatchers are also available under
+`hl.plugin.hyprexpo`:
+
+```lua
+hl.plugin.hyprexpo.expo("toggle")
+hl.plugin.hyprexpo.kb_focus("left")
+hl.plugin.hyprexpo.kb_confirm()
+hl.plugin.hyprexpo.kb_selecti(1)
+hl.plugin.hyprexpo.kb_selectn(1)
+hl.plugin.hyprexpo.kb_select("1")
+```
+
 ### Example Bindings
 
 ```bash

--- a/main.cpp
+++ b/main.cpp
@@ -5,12 +5,16 @@
 #include <hyprland/src/Compositor.hpp>
 #include <hyprland/src/desktop/view/Window.hpp>
 #include <hyprland/src/config/ConfigManager.hpp>
+#include <hyprland/src/config/values/types/FloatValue.hpp>
+#include <hyprland/src/config/values/types/IntValue.hpp>
+#include <hyprland/src/config/values/types/StringValue.hpp>
 #include <hyprland/src/desktop/DesktopTypes.hpp>
 #include <hyprland/src/render/Renderer.hpp>
 #include <hyprland/src/managers/input/trackpad/GestureTypes.hpp>
 #include <hyprland/src/managers/input/trackpad/TrackpadGestures.hpp>
 
 #include <hyprutils/string/ConstVarList.hpp>
+#include <lua.hpp>
 using namespace Hyprutils::String;
 
 #include <cctype>
@@ -39,11 +43,57 @@ APICALL EXPORT std::string PLUGIN_API_VERSION() {
 static bool renderingOverview = false;
 
 // forward declarations for new dispatchers
+static SDispatchResult onExpoDispatcher(std::string arg);
 static SDispatchResult onKbFocusDispatcher(std::string arg);
 static SDispatchResult onKbConfirmDispatcher(std::string arg);
 static SDispatchResult onKbSelectNumberDispatcher(std::string arg);
 static SDispatchResult onKbSelectTokenDispatcher(std::string arg);
 static SDispatchResult onKbSelectIndexDispatcher(std::string arg);
+
+static int luaDispatchResult(lua_State* L, const char* name, const SDispatchResult& result) {
+    if (result.success)
+        return 0;
+
+    return luaL_error(L, "%s: %s", name, result.error.empty() ? "dispatcher failed" : result.error.c_str());
+}
+
+static std::string luaStringArg(lua_State* L, int index, const char* name, const char* defaultValue = "") {
+    if (lua_gettop(L) < index || lua_isnil(L, index))
+        return defaultValue;
+
+    if (lua_isnumber(L, index))
+        return std::to_string(lua_tointeger(L, index));
+
+    if (lua_isstring(L, index))
+        return lua_tostring(L, index);
+
+    luaL_error(L, "%s: argument %d must be a string or integer", name, index);
+    return defaultValue;
+}
+
+static int luaExpo(lua_State* L) {
+    return luaDispatchResult(L, "hyprexpo.expo", onExpoDispatcher(luaStringArg(L, 1, "hyprexpo.expo", "toggle")));
+}
+
+static int luaKbFocus(lua_State* L) {
+    return luaDispatchResult(L, "hyprexpo.kb_focus", onKbFocusDispatcher(luaStringArg(L, 1, "hyprexpo.kb_focus")));
+}
+
+static int luaKbConfirm(lua_State* L) {
+    return luaDispatchResult(L, "hyprexpo.kb_confirm", onKbConfirmDispatcher(""));
+}
+
+static int luaKbSelectNumber(lua_State* L) {
+    return luaDispatchResult(L, "hyprexpo.kb_selectn", onKbSelectNumberDispatcher(luaStringArg(L, 1, "hyprexpo.kb_selectn")));
+}
+
+static int luaKbSelectToken(lua_State* L) {
+    return luaDispatchResult(L, "hyprexpo.kb_select", onKbSelectTokenDispatcher(luaStringArg(L, 1, "hyprexpo.kb_select")));
+}
+
+static int luaKbSelectIndex(lua_State* L) {
+    return luaDispatchResult(L, "hyprexpo.kb_selecti", onKbSelectIndexDispatcher(luaStringArg(L, 1, "hyprexpo.kb_selecti")));
+}
 
 //
 static void hkRenderWorkspace(void* thisptr, PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace, timespec* now, const CBox& geometry) {
@@ -236,6 +286,10 @@ static Hyprlang::CParseResult expoGestureKeyword(const char* LHS, const char* RH
     return result;
 }
 
+static void addConfigValue(SP<Config::Values::IValue> value) {
+    HyprlandAPI::addConfigValueV2(PHANDLE, value);
+}
+
 APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     PHANDLE = handle;
 
@@ -294,86 +348,93 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     HyprlandAPI::addDispatcherV2(PHANDLE, "hyprexpo:kb_select", ::onKbSelectTokenDispatcher);
     HyprlandAPI::addDispatcherV2(PHANDLE, "hyprexpo:kb_selecti", ::onKbSelectIndexDispatcher);
 
+    HyprlandAPI::addLuaFunction(PHANDLE, "hyprexpo", "expo", ::luaExpo);
+    HyprlandAPI::addLuaFunction(PHANDLE, "hyprexpo", "kb_focus", ::luaKbFocus);
+    HyprlandAPI::addLuaFunction(PHANDLE, "hyprexpo", "kb_confirm", ::luaKbConfirm);
+    HyprlandAPI::addLuaFunction(PHANDLE, "hyprexpo", "kb_selectn", ::luaKbSelectNumber);
+    HyprlandAPI::addLuaFunction(PHANDLE, "hyprexpo", "kb_select", ::luaKbSelectToken);
+    HyprlandAPI::addLuaFunction(PHANDLE, "hyprexpo", "kb_selecti", ::luaKbSelectIndex);
+
     HyprlandAPI::addConfigKeyword(PHANDLE, "hyprexpo_gesture", ::expoGestureKeyword, {});
     HyprlandAPI::addConfigKeyword(PHANDLE, "hyprexpo_workspace_method", ::workspaceMethodKeyword, {});
 
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:columns", Hyprlang::INT{3});
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:gaps_in", Hyprlang::INT{5});
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:bg_col", Hyprlang::INT{0xFF111111});
+    addConfigValue(makeShared<Config::Values::CIntValue>("plugin:hyprexpo:columns", "columns", 3));
+    addConfigValue(makeShared<Config::Values::CIntValue>("plugin:hyprexpo:gaps_in", "inner gaps", 5));
+    addConfigValue(makeShared<Config::Values::CIntValue>("plugin:hyprexpo:bg_col", "background color", 0xFF111111));
     // Supports both global and per-monitor formats:
     // Global: "center current" or "first 1"
     // Per-monitor with comma delimiter: "DP-1 first 1, HDMI-1 center current"
     // Mixed: "DP-1 first 1, center current" (DP-1 uses first 1, others use center current)
     // Note: hyprexpo_workspace_method keyword takes priority (backwards compatibility)
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:workspace_method", Hyprlang::STRING{"center current"});
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:skip_empty", Hyprlang::INT{0});
+    addConfigValue(makeShared<Config::Values::CStringValue>("plugin:hyprexpo:workspace_method", "workspace method", "center current"));
+    addConfigValue(makeShared<Config::Values::CIntValue>("plugin:hyprexpo:skip_empty", "skip empty workspaces", 0));
 
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:gesture_distance", Hyprlang::INT{200});
+    addConfigValue(makeShared<Config::Values::CIntValue>("plugin:hyprexpo:gesture_distance", "gesture distance", 200));
 
     // keyboard navigation + styling
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:keynav_enable", Hyprlang::INT{1});
+    addConfigValue(makeShared<Config::Values::CIntValue>("plugin:hyprexpo:keynav_enable", "key navigation enable", 1));
     // Border configuration - supports both solid colors and gradients
     // Solid: rgb(rrggbb) or 0xAARRGGBB
     // Gradient: rgba(rrggbbaa) rgba(rrggbbaa) 45deg
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:border_width", Hyprlang::INT{2});
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:border_color", Hyprlang::STRING{""});           // default border (unused tiles)
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:border_color_current", Hyprlang::STRING{"rgb(66ccff)"});
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:border_color_focus", Hyprlang::STRING{"rgb(ffcc66)"});
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:border_color_hover", Hyprlang::STRING{"rgb(aabbcc)"});
+    addConfigValue(makeShared<Config::Values::CIntValue>("plugin:hyprexpo:border_width", "border width", 2));
+    addConfigValue(makeShared<Config::Values::CStringValue>("plugin:hyprexpo:border_color", "border color", ""));           // default border (unused tiles)
+    addConfigValue(makeShared<Config::Values::CStringValue>("plugin:hyprexpo:border_color_current", "current border color", "rgb(66ccff)"));
+    addConfigValue(makeShared<Config::Values::CStringValue>("plugin:hyprexpo:border_color_focus", "focus border color", "rgb(ffcc66)"));
+    addConfigValue(makeShared<Config::Values::CStringValue>("plugin:hyprexpo:border_color_hover", "hover border color", "rgb(aabbcc)"));
     // Deprecated but supported for backwards compatibility
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:border_style", Hyprlang::STRING{"simple"});     // ignored, auto-detected from format
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:label_enable", Hyprlang::INT{1});
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:label_color", Hyprlang::INT{0xFFFFFFFF});
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:label_font_size", Hyprlang::INT{16});
+    addConfigValue(makeShared<Config::Values::CStringValue>("plugin:hyprexpo:border_style", "border style", "simple"));     // ignored, auto-detected from format
+    addConfigValue(makeShared<Config::Values::CIntValue>("plugin:hyprexpo:label_enable", "label enable", 1));
+    addConfigValue(makeShared<Config::Values::CIntValue>("plugin:hyprexpo:label_color", "label color", 0xFFFFFFFF));
+    addConfigValue(makeShared<Config::Values::CIntValue>("plugin:hyprexpo:label_font_size", "label font size", 16));
     // label_text_mode: token (default) | id | index
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:label_text_mode", Hyprlang::STRING{"token"});
+    addConfigValue(makeShared<Config::Values::CStringValue>("plugin:hyprexpo:label_text_mode", "label text mode", "token"));
     // Optional override map for up to 50 tokens, comma-separated. Empty entries allowed.
     // Example: "1,2,3,4,5,6,7,8,9,0,!,@,#,$,%,^,&,*,(,),a,..."
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:label_token_map", Hyprlang::STRING{""});
+    addConfigValue(makeShared<Config::Values::CStringValue>("plugin:hyprexpo:label_token_map", "label token map", ""));
 
     // tile rounding (rounded corners for workspace previews)
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:tile_rounding", Hyprlang::INT{0});
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:tile_rounding_power", Hyprlang::FLOAT{2.0f});
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:tile_rounding_focus", Hyprlang::INT{-1});
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:tile_rounding_current", Hyprlang::INT{-1});
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:tile_rounding_hover", Hyprlang::INT{-1});
+    addConfigValue(makeShared<Config::Values::CIntValue>("plugin:hyprexpo:tile_rounding", "tile rounding", 0));
+    addConfigValue(makeShared<Config::Values::CFloatValue>("plugin:hyprexpo:tile_rounding_power", "tile rounding power", 2.0F));
+    addConfigValue(makeShared<Config::Values::CIntValue>("plugin:hyprexpo:tile_rounding_focus", "focus tile rounding", -1));
+    addConfigValue(makeShared<Config::Values::CIntValue>("plugin:hyprexpo:tile_rounding_current", "current tile rounding", -1));
+    addConfigValue(makeShared<Config::Values::CIntValue>("plugin:hyprexpo:tile_rounding_hover", "hover tile rounding", -1));
 
     // (shadows moved to feature/shadows branch)
     // defaults: center/middle within the label container
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:label_position", Hyprlang::STRING{"center"});
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:label_offset_x", Hyprlang::INT{0});
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:label_offset_y", Hyprlang::INT{0});
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:label_show", Hyprlang::STRING{"always"});
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:label_color_default", Hyprlang::INT{0xFFFFFFFF});
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:label_color_hover", Hyprlang::INT{0xFFEEEEEE});
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:label_color_focus", Hyprlang::INT{0xFFFFCC66});
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:label_color_current", Hyprlang::INT{0xFF66CCFF});
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:label_scale_hover", Hyprlang::FLOAT{1.0f});
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:label_scale_focus", Hyprlang::FLOAT{1.0f});
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:label_bg_enable", Hyprlang::INT{1});
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:label_bg_color", Hyprlang::INT{0x88000000});
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:label_bg_rounding", Hyprlang::INT{8});
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:label_bg_shape", Hyprlang::STRING{"circle"});
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:label_padding", Hyprlang::INT{8});
+    addConfigValue(makeShared<Config::Values::CStringValue>("plugin:hyprexpo:label_position", "label position", "center"));
+    addConfigValue(makeShared<Config::Values::CIntValue>("plugin:hyprexpo:label_offset_x", "label offset x", 0));
+    addConfigValue(makeShared<Config::Values::CIntValue>("plugin:hyprexpo:label_offset_y", "label offset y", 0));
+    addConfigValue(makeShared<Config::Values::CStringValue>("plugin:hyprexpo:label_show", "label show", "always"));
+    addConfigValue(makeShared<Config::Values::CIntValue>("plugin:hyprexpo:label_color_default", "default label color", 0xFFFFFFFF));
+    addConfigValue(makeShared<Config::Values::CIntValue>("plugin:hyprexpo:label_color_hover", "hover label color", 0xFFEEEEEE));
+    addConfigValue(makeShared<Config::Values::CIntValue>("plugin:hyprexpo:label_color_focus", "focus label color", 0xFFFFCC66));
+    addConfigValue(makeShared<Config::Values::CIntValue>("plugin:hyprexpo:label_color_current", "current label color", 0xFF66CCFF));
+    addConfigValue(makeShared<Config::Values::CFloatValue>("plugin:hyprexpo:label_scale_hover", "hover label scale", 1.0F));
+    addConfigValue(makeShared<Config::Values::CFloatValue>("plugin:hyprexpo:label_scale_focus", "focus label scale", 1.0F));
+    addConfigValue(makeShared<Config::Values::CIntValue>("plugin:hyprexpo:label_bg_enable", "label background enable", 1));
+    addConfigValue(makeShared<Config::Values::CIntValue>("plugin:hyprexpo:label_bg_color", "label background color", 0x88000000));
+    addConfigValue(makeShared<Config::Values::CIntValue>("plugin:hyprexpo:label_bg_rounding", "label background rounding", 8));
+    addConfigValue(makeShared<Config::Values::CStringValue>("plugin:hyprexpo:label_bg_shape", "label background shape", "circle"));
+    addConfigValue(makeShared<Config::Values::CIntValue>("plugin:hyprexpo:label_padding", "label padding", 8));
     // label font styling and pixel snapping
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:label_font_family", Hyprlang::STRING{"sans"});
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:label_font_bold", Hyprlang::INT{0});
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:label_font_italic", Hyprlang::INT{0});
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:label_text_underline", Hyprlang::INT{0});
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:label_text_strikethrough", Hyprlang::INT{0});
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:label_pixel_snap", Hyprlang::INT{1});
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:label_center_adjust_x", Hyprlang::INT{0});
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:label_center_adjust_y", Hyprlang::INT{0});
+    addConfigValue(makeShared<Config::Values::CStringValue>("plugin:hyprexpo:label_font_family", "label font family", "sans"));
+    addConfigValue(makeShared<Config::Values::CIntValue>("plugin:hyprexpo:label_font_bold", "label font bold", 0));
+    addConfigValue(makeShared<Config::Values::CIntValue>("plugin:hyprexpo:label_font_italic", "label font italic", 0));
+    addConfigValue(makeShared<Config::Values::CIntValue>("plugin:hyprexpo:label_text_underline", "label text underline", 0));
+    addConfigValue(makeShared<Config::Values::CIntValue>("plugin:hyprexpo:label_text_strikethrough", "label text strikethrough", 0));
+    addConfigValue(makeShared<Config::Values::CIntValue>("plugin:hyprexpo:label_pixel_snap", "label pixel snap", 1));
+    addConfigValue(makeShared<Config::Values::CIntValue>("plugin:hyprexpo:label_center_adjust_x", "label center adjust x", 0));
+    addConfigValue(makeShared<Config::Values::CIntValue>("plugin:hyprexpo:label_center_adjust_y", "label center adjust y", 0));
     // gaps
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:gaps_out", Hyprlang::INT{0});
+    addConfigValue(makeShared<Config::Values::CIntValue>("plugin:hyprexpo:gaps_out", "outer gaps", 0));
     // Deprecated: use border_color_* instead (supports both solid and gradient)
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:border_grad_current", Hyprlang::STRING{""});
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:border_grad_focus", Hyprlang::STRING{""});
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:border_grad_hover", Hyprlang::STRING{""});
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:keynav_wrap_h", Hyprlang::INT{1});
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:keynav_wrap_v", Hyprlang::INT{1});
+    addConfigValue(makeShared<Config::Values::CStringValue>("plugin:hyprexpo:border_grad_current", "current border gradient", ""));
+    addConfigValue(makeShared<Config::Values::CStringValue>("plugin:hyprexpo:border_grad_focus", "focus border gradient", ""));
+    addConfigValue(makeShared<Config::Values::CStringValue>("plugin:hyprexpo:border_grad_hover", "hover border gradient", ""));
+    addConfigValue(makeShared<Config::Values::CIntValue>("plugin:hyprexpo:keynav_wrap_h", "key navigation horizontal wrap", 1));
+    addConfigValue(makeShared<Config::Values::CIntValue>("plugin:hyprexpo:keynav_wrap_v", "key navigation vertical wrap", 1));
     // default off: spatial moves by default
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:keynav_reading_order", Hyprlang::INT{0});
+    addConfigValue(makeShared<Config::Values::CIntValue>("plugin:hyprexpo:keynav_reading_order", "key navigation reading order", 0));
 
     HyprlandAPI::reloadConfig();
 

--- a/overview.cpp
+++ b/overview.cpp
@@ -1,5 +1,6 @@
 #include "overview.hpp"
 #include <any>
+#include <map>
 #include <hyprland/src/event/EventBus.hpp>
 #define private   public
 #define protected public
@@ -24,6 +25,135 @@
 #include <hyprland/src/config/shared/complex/ComplexDataTypes.hpp>
 #include <pango/pangocairo.h>
 #include <cmath>
+
+namespace CompatHyprlandAPI {
+struct SConfigValueCompat {
+    Config::INTEGER integer = 0;
+    Config::INTEGER* integerPtr = &integer;
+    Config::FLOAT floating = 0;
+    Config::FLOAT* floatingPtr = &floating;
+    Config::STRING string;
+    void* ptr = nullptr;
+
+    void* getDataStaticPtr() {
+        return ptr;
+    }
+};
+
+static bool isStringConfig(const std::string& name) {
+    static const std::map<std::string, bool> STRING_CONFIGS = {
+        {"plugin:hyprexpo:workspace_method", true},
+        {"plugin:hyprexpo:border_color", true},
+        {"plugin:hyprexpo:border_color_current", true},
+        {"plugin:hyprexpo:border_color_focus", true},
+        {"plugin:hyprexpo:border_color_hover", true},
+        {"plugin:hyprexpo:border_style", true},
+        {"plugin:hyprexpo:label_text_mode", true},
+        {"plugin:hyprexpo:label_token_map", true},
+        {"plugin:hyprexpo:label_position", true},
+        {"plugin:hyprexpo:label_show", true},
+        {"plugin:hyprexpo:label_bg_shape", true},
+        {"plugin:hyprexpo:label_font_family", true},
+        {"plugin:hyprexpo:border_grad_current", true},
+        {"plugin:hyprexpo:border_grad_focus", true},
+        {"plugin:hyprexpo:border_grad_hover", true},
+    };
+
+    return STRING_CONFIGS.contains(name);
+}
+
+static bool isFloatConfig(const std::string& name) {
+    return name == "plugin:hyprexpo:tile_rounding_power" ||
+           name == "plugin:hyprexpo:label_scale_hover" ||
+           name == "plugin:hyprexpo:label_scale_focus";
+}
+
+static Config::STRING stringDefault(const std::string& name) {
+    static const std::map<std::string, Config::STRING> DEFAULTS = {
+        {"plugin:hyprexpo:workspace_method", "center current"},
+        {"plugin:hyprexpo:border_color", ""},
+        {"plugin:hyprexpo:border_color_current", "rgb(66ccff)"},
+        {"plugin:hyprexpo:border_color_focus", "rgb(ffcc66)"},
+        {"plugin:hyprexpo:border_color_hover", "rgb(aabbcc)"},
+        {"plugin:hyprexpo:border_style", "simple"},
+        {"plugin:hyprexpo:label_text_mode", "token"},
+        {"plugin:hyprexpo:label_token_map", ""},
+        {"plugin:hyprexpo:label_position", "center"},
+        {"plugin:hyprexpo:label_show", "always"},
+        {"plugin:hyprexpo:label_bg_shape", "circle"},
+        {"plugin:hyprexpo:label_font_family", "sans"},
+        {"plugin:hyprexpo:border_grad_current", ""},
+        {"plugin:hyprexpo:border_grad_focus", ""},
+        {"plugin:hyprexpo:border_grad_hover", ""},
+    };
+
+    if (const auto it = DEFAULTS.find(name); it != DEFAULTS.end())
+        return it->second;
+    return "";
+}
+
+static Config::FLOAT floatDefault(const std::string& name) {
+    if (name == "plugin:hyprexpo:tile_rounding_power")
+        return 2.0F;
+    if (name == "plugin:hyprexpo:label_scale_hover" ||
+        name == "plugin:hyprexpo:label_scale_focus")
+        return 1.0F;
+    return 0.0F;
+}
+
+static Config::INTEGER intDefault(const std::string& name) {
+    static const std::map<std::string, Config::INTEGER> DEFAULTS = {
+        {"plugin:hyprexpo:columns", 3}, {"plugin:hyprexpo:gaps_in", 5},
+        {"plugin:hyprexpo:bg_col", 0xFF111111}, {"plugin:hyprexpo:gesture_distance", 200},
+        {"plugin:hyprexpo:keynav_enable", 1}, {"plugin:hyprexpo:border_width", 2},
+        {"plugin:hyprexpo:label_enable", 1}, {"plugin:hyprexpo:label_color", 0xFFFFFFFF},
+        {"plugin:hyprexpo:label_font_size", 16}, {"plugin:hyprexpo:label_color_default", 0xFFFFFFFF},
+        {"plugin:hyprexpo:label_color_hover", 0xFFEEEEEE}, {"plugin:hyprexpo:label_color_focus", 0xFFFFCC66},
+        {"plugin:hyprexpo:label_color_current", 0xFF66CCFF}, {"plugin:hyprexpo:label_bg_enable", 1},
+        {"plugin:hyprexpo:label_bg_color", 0x88000000}, {"plugin:hyprexpo:label_bg_rounding", 8},
+        {"plugin:hyprexpo:label_padding", 8}, {"plugin:hyprexpo:label_pixel_snap", 1},
+        {"plugin:hyprexpo:keynav_wrap_h", 1}, {"plugin:hyprexpo:keynav_wrap_v", 1},
+    };
+
+    if (const auto it = DEFAULTS.find(name); it != DEFAULTS.end())
+        return it->second;
+    return 0;
+}
+
+static SConfigValueCompat* getConfigValue(HANDLE, const std::string& name) {
+    static std::map<std::string, SConfigValueCompat> VALUES;
+    auto& compat = VALUES[name];
+
+    if (isStringConfig(name)) {
+        compat.string = stringDefault(name);
+        compat.ptr = &compat.string;
+    } else if (isFloatConfig(name)) {
+        compat.floating = floatDefault(name);
+        compat.floatingPtr = &compat.floating;
+        compat.ptr = &compat.floatingPtr;
+    } else {
+        compat.integer = intDefault(name);
+        compat.integerPtr = &compat.integer;
+        compat.ptr = &compat.integerPtr;
+    }
+
+    const auto VALUE = Config::mgr()->getConfigValue(name);
+    if (VALUE.dataptr && VALUE.type && *VALUE.type == typeid(Config::STRING)) {
+        auto* ptr = reinterpret_cast<Config::STRING* const*>(VALUE.dataptr);
+        compat.ptr = ptr && *ptr ? *ptr : &compat.string;
+        return &compat;
+    }
+
+    if (VALUE.dataptr) {
+        compat.ptr = const_cast<void*>(static_cast<const void*>(VALUE.dataptr));
+        return &compat;
+    }
+
+    return &compat;
+}
+}
+
+#define HyprlandAPI CompatHyprlandAPI
 
 static void clearWithColor(const CHyprColor& color) {
     glClearColor(color.r, color.g, color.b, color.a);


### PR DESCRIPTION
## Summary

- register HyprExpo+ config values with Hyprland's current `addConfigValueV2` API
- read runtime config through `Config::mgr()` so Lua configs and reloads are reflected by label/keynav rendering
- expose the existing expo and keyboard navigation dispatchers under `hl.plugin.hyprexpo` for Lua configs
- document the Lua API in the README

## Why

Hyprland's Lua config path works best with plugin functions exposed through `hl.plugin.<namespace>`. Without that API, Lua configs have to shell out to `hyprctl dispatch` or cannot drive keyboard navigation directly.

The config read path also needed to move away from deprecated static plugin config reads so label and keynav options set from Lua are visible when rendering.

## Validation

Built the plugin with Nix against Hyprland `0.55.0+date=2026-05-09_ee58a51`.
