### PR TITLE
Update README HyprExpo references

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > It appears  the PR will never be merged since [HyprExpo was removed as an official plugin](https://github.com/hyprwm/hyprland-plugins/pull/507#issuecomment-4433386463). I intend on continuing to maintain HyprExpo-Plus, as I use it every day and love it.
 
 # HyprExpo+
-HyprExpo+ is a fork of [HyprExpo](https://github.com/hyprwm/hyprland-plugins/tree/main/hyprexpo) that adds additional functionality.
+HyprExpo+ is a fork of HyprExpo that adds additional functionality. The original `hyprland-plugins` copy has since been removed, but the last upstream version is still available in [`hyprwm/hyprland-plugins` pull request #507](https://github.com/hyprwm/hyprland-plugins/pull/507/files#diff-dcf3e4cb819e592701c932f50137cc8d2a99a9348153788dca0e22f659ccaf2d). If you prefer a smaller maintained implementation, [`colonelpanic8/hyprexpo`](https://github.com/colonelpanic8/hyprexpo) is another standalone HyprExpo fork.
 
 https://github.com/user-attachments/assets/861baa26-46b6-4fa8-8d37-65cbb9ecbed4
 


### PR DESCRIPTION
Updates the README to avoid pointing readers at the removed `hyprland-plugins/tree/main/hyprexpo` path, while still preserving a link to the last upstream HyprExpo changes and adding a current standalone upstream reference for users who want a smaller implementation.