### PR TITLE
render-state leak during Hyprexpo preview capture.

### DIFF
--- a/HyprexpoLogic.cpp
+++ b/HyprexpoLogic.cpp
@@ -54,6 +54,36 @@ int tileIndexFromPoint(double x, double y, double width, double height, int side
     return hx + hy * safeSide;
 }
 
+SDropIntentGeometry computeDropIntentGeometry(const SDropIntentInput& input) {
+    SDropIntentGeometry geometry;
+
+    if (!input.targetValid || input.targetTileLocal.w <= 0.0 || input.targetTileLocal.h <= 0.0 || input.workspaceSize.w <= 0.0 || input.workspaceSize.h <= 0.0 || input.windowSize.w <= 0.0 ||
+        input.windowSize.h <= 0.0)
+        return geometry;
+
+    const double ratioX = std::clamp((input.pointerLocal.x - input.targetTileLocal.x) / input.targetTileLocal.w, 0.0, 1.0);
+    const double ratioY = std::clamp((input.pointerLocal.y - input.targetTileLocal.y) / input.targetTileLocal.h, 0.0, 1.0);
+    const double scaleX = input.targetTileLocal.w / input.workspaceSize.w;
+    const double scaleY = input.targetTileLocal.h / input.workspaceSize.h;
+
+    const double minSize = std::max(0.0, input.minProxySize);
+    const double proxyW  = std::clamp(input.windowSize.w * scaleX, std::min(input.targetTileLocal.w, minSize), input.targetTileLocal.w);
+    const double proxyH  = std::clamp(input.windowSize.h * scaleY, std::min(input.targetTileLocal.h, minSize), input.targetTileLocal.h);
+    const double pointX  = input.targetTileLocal.x + ratioX * input.targetTileLocal.w;
+    const double pointY  = input.targetTileLocal.y + ratioY * input.targetTileLocal.h;
+
+    geometry.valid                = true;
+    geometry.targetWorkspacePoint = {ratioX * input.workspaceSize.w, ratioY * input.workspaceSize.h};
+    geometry.targetProxyLocal     = {
+        std::clamp(pointX - input.grabOffset.x * scaleX, input.targetTileLocal.x, input.targetTileLocal.x + input.targetTileLocal.w - proxyW),
+        std::clamp(pointY - input.grabOffset.y * scaleY, input.targetTileLocal.y, input.targetTileLocal.y + input.targetTileLocal.h - proxyH),
+        proxyW,
+        proxyH,
+    };
+
+    return geometry;
+}
+
 std::string fallbackTokenForVisibleIndex(int visibleIndex) {
     if (visibleIndex < 0)
         return "";

--- a/HyprexpoLogic.hpp
+++ b/HyprexpoLogic.hpp
@@ -32,12 +32,46 @@ struct SWorkspaceMethodSpec {
     std::string          error;
 };
 
+struct SPoint {
+    double x = 0.0;
+    double y = 0.0;
+};
+
+struct SSize {
+    double w = 0.0;
+    double h = 0.0;
+};
+
+struct SRect {
+    double x = 0.0;
+    double y = 0.0;
+    double w = 0.0;
+    double h = 0.0;
+};
+
+struct SDropIntentInput {
+    bool   targetValid        = false;
+    SPoint pointerLocal       = {};
+    SRect  targetTileLocal    = {};
+    SSize  workspaceSize      = {};
+    SSize  windowSize         = {};
+    SPoint grabOffset         = {};
+    double minProxySize       = 24.0;
+};
+
+struct SDropIntentGeometry {
+    bool   valid                = false;
+    SPoint targetWorkspacePoint = {};
+    SRect  targetProxyLocal     = {};
+};
+
 std::string              trimString(std::string value);
 std::string              lowerString(std::string value);
 std::vector<std::string> splitCommaList(const std::string& value);
 
 int                      clampGridColumns(int columns);
 int                      tileIndexFromPoint(double x, double y, double width, double height, int sideLength);
+SDropIntentGeometry      computeDropIntentGeometry(const SDropIntentInput& input);
 
 std::string              fallbackTokenForVisibleIndex(int visibleIndex);
 int                      fallbackTokenToVisibleIndex(const std::string& token);

--- a/Overview.cpp
+++ b/Overview.cpp
@@ -372,6 +372,50 @@ void restoreWorkspacePreviewState(const PHLWORKSPACE& workspace, const SWorkspac
     *workspace->m_renderOffset = state.offsetGoal;
 }
 
+std::vector<std::pair<PHLWORKSPACE, SWorkspacePreviewState>> applyExclusiveWorkspacePreviewState(const PHLWORKSPACE& targetWorkspace) {
+    std::vector<std::pair<PHLWORKSPACE, SWorkspacePreviewState>> states;
+
+    for (const auto& workspaceRef : g_pCompositor->getWorkspaces()) {
+        const auto workspace = workspaceRef.lock();
+        if (!workspace)
+            continue;
+
+        states.push_back({
+            workspace,
+            {
+                .visible        = workspace->m_visible,
+                .forceRendering = workspace->m_forceRendering,
+                .alphaValue     = workspace->m_alpha->value(),
+                .alphaGoal      = workspace->m_alpha->goal(),
+                .offsetValue    = workspace->m_renderOffset->value(),
+                .offsetGoal     = workspace->m_renderOffset->goal(),
+            },
+        });
+
+        if (workspace == targetWorkspace) {
+            workspace->m_visible        = true;
+            workspace->m_forceRendering = true;
+            workspace->m_alpha->setValueAndWarp(1.F);
+            *workspace->m_alpha = 1.F;
+        } else {
+            workspace->m_visible        = false;
+            workspace->m_forceRendering = false;
+            workspace->m_alpha->setValueAndWarp(0.F);
+            *workspace->m_alpha = 0.F;
+        }
+
+        workspace->m_renderOffset->setValueAndWarp(Vector2D{});
+        *workspace->m_renderOffset = Vector2D{};
+    }
+
+    return states;
+}
+
+void restoreWorkspacePreviewStates(const std::vector<std::pair<PHLWORKSPACE, SWorkspacePreviewState>>& states) {
+    for (const auto& [workspace, state] : states)
+        restoreWorkspacePreviewState(workspace, state);
+}
+
 bool windowVisibleOnWorkspace(const PHLWINDOW& window, const PHLWORKSPACE& workspace) {
     return window && workspace && window->m_workspace == workspace && window->m_isMapped && !window->isHidden() && !window->m_pinned;
 }
@@ -386,6 +430,20 @@ void settleWorkspaceMoveAnimation(const PHLWINDOW& window) {
     window->alpha(Desktop::View::WINDOW_ALPHA_MOVE_FROM_WORKSPACE)->setValueAndWarp(1.F);
     *window->alpha(Desktop::View::WINDOW_ALPHA_MOVE_FROM_WORKSPACE) = 1.F;
     window->m_monitorMovedFrom                                      = -1;
+}
+
+void settleWorkspaceMoveAnimations() {
+    for (const auto& window : g_pCompositor->m_windows) {
+        if (!window)
+            continue;
+
+        const bool movingWorkspace = window->m_monitorMovedFrom != -1 || window->alpha(Desktop::View::WINDOW_ALPHA_MOVE_TO_WORKSPACE)->isBeingAnimated() ||
+            window->alpha(Desktop::View::WINDOW_ALPHA_MOVE_FROM_WORKSPACE)->isBeingAnimated();
+        if (!movingWorkspace)
+            continue;
+
+        settleWorkspaceMoveAnimation(window);
+    }
 }
 
 void ensureFramebuffer(COverview::SWorkspaceImage& image, const CBox& monbox, uint32_t drmFormat) {
@@ -653,6 +711,7 @@ COverview::COverview(PHLWORKSPACE startedOn_, bool swipe_) : startedOn(startedOn
         PMONITOR->m_activeSpecialWorkspace.reset();
 
     g_pHyprRenderer->m_bBlockSurfaceFeedback = true;
+    settleWorkspaceMoveAnimations();
 
     startedOn->m_visible = false;
 
@@ -673,7 +732,7 @@ COverview::COverview(PHLWORKSPACE startedOn_, bool swipe_) : startedOn(startedOn
         if (PWORKSPACE) {
             image.pWorkspace        = PWORKSPACE;
             const auto previousWS    = activateWorkspaceForPreview(PMONITOR, PWORKSPACE);
-            const auto previewState  = applyWorkspacePreviewState(PWORKSPACE);
+            const auto previewStates = applyExclusiveWorkspacePreviewState(PWORKSPACE);
             const auto windowState   = PWORKSPACE == startedOn ? std::vector<SWindowPreviewState>{} : applyWorkspaceWindowGoalState(PWORKSPACE);
 
             if (PWORKSPACE == startedOn)
@@ -682,7 +741,7 @@ COverview::COverview(PHLWORKSPACE startedOn_, bool swipe_) : startedOn(startedOn
             g_pHyprRenderer->renderWorkspace(PMONITOR, PWORKSPACE, Time::steadyNow(), monbox);
 
             restoreWorkspaceWindowGoalState(windowState);
-            restoreWorkspacePreviewState(PWORKSPACE, previewState);
+            restoreWorkspacePreviewStates(previewStates);
             restoreActiveWorkspaceAfterPreview(PMONITOR, previousWS);
             startedOn->m_visible = false;
 

--- a/Overview.hpp
+++ b/Overview.hpp
@@ -3,6 +3,7 @@
 #define WLR_USE_UNSTABLE
 
 #include "globals.hpp"
+#include "HyprexpoLogic.hpp"
 #include <hyprland/src/desktop/DesktopTypes.hpp>
 #include <hyprland/src/render/Framebuffer.hpp>
 #include <hyprland/src/render/Texture.hpp>
@@ -115,6 +116,8 @@ class COverview {
     bool                         dragMoved      = false;
     Vector2D                     dragGrabOffset = Vector2D{};
     PHLWINDOW                    dragWindow;
+    int                          dropIntentTargetID = -1;
+    Hyprexpo::SDropIntentGeometry dropIntent;
 
     std::vector<int>             queuedRedrawIDs;
     std::vector<int>             settlingRedrawIDs;

--- a/OverviewInteraction.cpp
+++ b/OverviewInteraction.cpp
@@ -162,6 +162,8 @@ void COverview::beginWindowDrag() {
     dragMoved      = false;
     dragWindow     = windowAtTilePoint(dragSourceID, dragStartLocal);
     dragGrabOffset = Vector2D{};
+    dropIntent         = {};
+    dropIntentTargetID = -1;
 
     if (!dragWindow)
         return;
@@ -174,15 +176,16 @@ void COverview::beginWindowDrag() {
 }
 
 void COverview::updateWindowDrag() {
-    if (!dragWindow || dragMoved)
+    if (!dragWindow)
         return;
 
     const auto dx = lastMousePosLocal.x - dragStartLocal.x;
     const auto dy = lastMousePosLocal.y - dragStartLocal.y;
-    if (std::hypot(dx, dy) < 12.0)
+    if (!dragMoved && std::hypot(dx, dy) < 12.0)
         return;
 
-    dragMoved = true;
+    if (!dragMoved)
+        dragMoved = true;
     damage();
 }
 
@@ -211,6 +214,8 @@ bool COverview::finishWindowDrag() {
     dragSourceID   = -1;
     dragMoved      = false;
     dragGrabOffset = Vector2D{};
+    dropIntent         = {};
+    dropIntentTargetID = -1;
     Cursor::overrideController->setOverride("left_ptr", Cursor::CURSOR_OVERRIDE_UNKNOWN);
 
     if (!WINDOW || !MOVED)

--- a/OverviewInternal.hpp
+++ b/OverviewInternal.hpp
@@ -3,6 +3,7 @@
 #include "Overview.hpp"
 
 #include <string>
+#include <utility>
 #include <vector>
 
 struct SHyprGradientSpec {
@@ -45,9 +46,12 @@ SP<Render::ITexture> renderNumberTexture(const std::string& text, const CHyprCol
 
 SWorkspacePreviewState applyWorkspacePreviewState(const PHLWORKSPACE& workspace);
 void restoreWorkspacePreviewState(const PHLWORKSPACE& workspace, const SWorkspacePreviewState& state);
+std::vector<std::pair<PHLWORKSPACE, SWorkspacePreviewState>> applyExclusiveWorkspacePreviewState(const PHLWORKSPACE& workspace);
+void restoreWorkspacePreviewStates(const std::vector<std::pair<PHLWORKSPACE, SWorkspacePreviewState>>& states);
 
 bool windowVisibleOnWorkspace(const PHLWINDOW& window, const PHLWORKSPACE& workspace);
 void settleWorkspaceMoveAnimation(const PHLWINDOW& window);
+void settleWorkspaceMoveAnimations();
 void ensureFramebuffer(COverview::SWorkspaceImage& image, const CBox& monbox, uint32_t drmFormat);
 std::vector<SWindowPreviewState> applyWorkspaceWindowGoalState(const PHLWORKSPACE& workspace);
 void restoreWorkspaceWindowGoalState(const std::vector<SWindowPreviewState>& states);

--- a/OverviewRender.cpp
+++ b/OverviewRender.cpp
@@ -32,6 +32,7 @@ void COverview::redrawID(int id, bool forcelowres) {
     blockOverviewRendering = true;
 
     Render::GL::g_pHyprOpenGL->makeEGLCurrent();
+    settleWorkspaceMoveAnimations();
 
     id = std::clamp(id, 0, SIDE_LENGTH * SIDE_LENGTH - 1);
 
@@ -79,7 +80,7 @@ void COverview::redrawID(int id, bool forcelowres) {
 
     if (PWORKSPACE) {
         const auto previousWS    = activateWorkspaceForPreview(pMonitor.lock(), PWORKSPACE);
-        const auto previewState  = applyWorkspacePreviewState(PWORKSPACE);
+        const auto previewStates = applyExclusiveWorkspacePreviewState(PWORKSPACE);
         const auto windowState   = PWORKSPACE == startedOn ? std::vector<SWindowPreviewState>{} : applyWorkspaceWindowGoalState(PWORKSPACE);
 
         if (PWORKSPACE == startedOn)
@@ -88,7 +89,7 @@ void COverview::redrawID(int id, bool forcelowres) {
         g_pHyprRenderer->renderWorkspace(pMonitor.lock(), PWORKSPACE, Time::steadyNow(), monbox);
 
         restoreWorkspaceWindowGoalState(windowState);
-        restoreWorkspacePreviewState(PWORKSPACE, previewState);
+        restoreWorkspacePreviewStates(previewStates);
         restoreActiveWorkspaceAfterPreview(pMonitor.lock(), previousWS);
 
         if (PWORKSPACE == startedOn)
@@ -541,6 +542,38 @@ void COverview::fullRender() {
         }
     };
 
+    auto drawProxyBorder = [&](const CBox& proxy, int round, int borderWidth, const std::string& borderSpec, const std::string& fallbackSpec) {
+        if (borderWidth <= 0)
+            return;
+
+        std::string effectiveSpec = borderSpec.empty() ? fallbackSpec : borderSpec;
+        if (effectiveSpec.empty())
+            return;
+
+        if (isGradientBorderSpec(effectiveSpec)) {
+            const auto spec = parseGradientSpec(effectiveSpec);
+            if (!spec.valid)
+                return;
+
+            Config::CGradientValueData grad;
+            grad.m_colors.clear();
+            grad.m_colors.push_back(spec.c1);
+            grad.m_colors.push_back(spec.c2);
+            grad.m_angle = spec.angleDeg * (float)M_PI / 180.f;
+            grad.updateColorsOk();
+            Render::GL::g_pHyprOpenGL->renderBorder(proxy, grad, {.round = round, .roundingPower = ROUND_PWR, .borderSize = borderWidth});
+            return;
+        }
+
+        Hyprexpo::SColorRGBA parsedColor;
+        if (Hyprexpo::parseSolidColorSpec(effectiveSpec, parsedColor)) {
+            Config::CGradientValueData grad{CHyprColor{parsedColor.r, parsedColor.g, parsedColor.b, parsedColor.a}};
+            grad.updateColorsOk();
+            Render::GL::g_pHyprOpenGL->renderBorder(proxy, grad, {.round = round, .roundingPower = ROUND_PWR, .borderSize = borderWidth});
+        } else
+            Log::logger->log(Log::ERR, "[hyprexpo] invalid drag_drop_proxy_border_color config: {}", effectiveSpec);
+    };
+
     // Draw borders in order: hover (lowest), then current, then focus (highest priority)
     if (hoveredID != -1 && hoveredID != openedID && hoveredID != kbFocusID)
         drawBorderForID(hoveredID, std::string{*PBCOLHOV}, std::string{*PBGREHOV}, RND_HOV);
@@ -552,6 +585,9 @@ void COverview::fullRender() {
         const int         sourceWidth  = **PDRAGSOURCEBWIDTH >= 0 ? **PDRAGSOURCEBWIDTH : (int)**PBWIDTH;
         drawBorderForID(dragSourceID, sourceBorder, std::string{*PBGREFOC}, RND_FOC, sourceWidth);
     }
+
+    dropIntent = {};
+    dropIntentTargetID = -1;
 
     if (dragWindow && isTileValid(dragSourceID)) {
         const auto windowBox = dragWindow->getWindowMainSurfaceBox();
@@ -573,34 +609,54 @@ void COverview::fullRender() {
             const int maxProxyRound = std::max(0, (int)std::floor(std::min(proxy.w, proxy.h) / 2.0));
             const int autoRound     = std::min(RND_FOC, maxProxyRound);
             const int round         = **PDRAGPROXYROUND >= 0 ? std::min(std::max(0, (int)std::lround((double)**PDRAGPROXYROUND * pMonitor->m_scale)), maxProxyRound) : autoRound;
+
+            if (dragMoved && hoveredID != -1 && hoveredID != dragSourceID && isTileValid(hoveredID)) {
+                const int tx = hoveredID % SIDE_LENGTH;
+                const int ty = hoveredID / SIDE_LENGTH;
+                const Hyprexpo::SRect targetTileLocal{
+                    OUTER + tx * tileRenderSize.x + tx * GAPSIZE,
+                    OUTER + ty * tileRenderSize.y + ty * GAPSIZE,
+                    tileRenderSize.x,
+                    tileRenderSize.y,
+                };
+                dropIntent = Hyprexpo::computeDropIntentGeometry({
+                    .targetValid     = true,
+                    .pointerLocal    = {lastMousePosLocal.x, lastMousePosLocal.y},
+                    .targetTileLocal = targetTileLocal,
+                    .workspaceSize   = {pMonitor->m_size.x, pMonitor->m_size.y},
+                    .windowSize      = {windowBox.w, windowBox.h},
+                    .grabOffset      = {dragGrabOffset.x, dragGrabOffset.y},
+                });
+                dropIntentTargetID = dropIntent.valid ? hoveredID : -1;
+            }
+
+            if (dropIntent.valid) {
+                CBox targetProxy{
+                    dropIntent.targetProxyLocal.x,
+                    dropIntent.targetProxyLocal.y,
+                    dropIntent.targetProxyLocal.w,
+                    dropIntent.targetProxyLocal.h,
+                };
+                targetProxy.scale(pMonitor->m_scale).translate(pos->value());
+                targetProxy.round();
+
+                const int targetMaxRound = std::max(0, (int)std::floor(std::min(targetProxy.w, targetProxy.h) / 2.0));
+                const int targetRound    = **PDRAGPROXYROUND >= 0 ? std::min(std::max(0, (int)std::lround((double)**PDRAGPROXYROUND * pMonitor->m_scale)), targetMaxRound) :
+                                                                   std::min(RND_FOC, targetMaxRound);
+                Render::GL::g_pHyprOpenGL->renderRect(targetProxy, CHyprColor{(uint64_t)**PDRAGPROXYACTCOL}, {.round = targetRound, .roundingPower = ROUND_PWR});
+
+                const int   borderWidth   = **PDRAGPROXYBWIDTH >= 0 ? **PDRAGPROXYBWIDTH : std::max(2, (int)**PBWIDTH + 1);
+                const std::string effectiveSpec = std::string{*PDRAGPROXYBORDER}.empty() ? std::string{*PBCOLFOC} : std::string{*PDRAGPROXYBORDER};
+                drawProxyBorder(targetProxy, targetRound, borderWidth, effectiveSpec, std::string{*PBGREFOC});
+            }
+
             Render::GL::g_pHyprOpenGL->renderRect(proxy, CHyprColor{(uint64_t)(dragMoved ? **PDRAGPROXYACTCOL : **PDRAGPROXYCOL)}, {.round = round, .roundingPower = ROUND_PWR});
 
             const int   borderWidth   = **PDRAGPROXYBWIDTH >= 0 ? **PDRAGPROXYBWIDTH : std::max(2, (int)**PBWIDTH + 1);
             std::string effectiveSpec = std::string{*PDRAGPROXYBORDER}.empty() ? std::string{*PBCOLFOC} : std::string{*PDRAGPROXYBORDER};
             if (effectiveSpec.empty())
                 effectiveSpec = std::string{*PBGREFOC};
-            if (isGradientBorderSpec(effectiveSpec)) {
-                const auto spec = parseGradientSpec(effectiveSpec);
-                if (spec.valid) {
-                    Config::CGradientValueData grad;
-                    grad.m_colors.clear();
-                    grad.m_colors.push_back(spec.c1);
-                    grad.m_colors.push_back(spec.c2);
-                    grad.m_angle = spec.angleDeg * (float)M_PI / 180.f;
-                    grad.updateColorsOk();
-                    if (borderWidth > 0)
-                        Render::GL::g_pHyprOpenGL->renderBorder(proxy, grad, {.round = round, .roundingPower = ROUND_PWR, .borderSize = borderWidth});
-                }
-            } else if (!effectiveSpec.empty()) {
-                Hyprexpo::SColorRGBA parsedColor;
-                if (Hyprexpo::parseSolidColorSpec(effectiveSpec, parsedColor)) {
-                    Config::CGradientValueData grad{CHyprColor{parsedColor.r, parsedColor.g, parsedColor.b, parsedColor.a}};
-                    grad.updateColorsOk();
-                    if (borderWidth > 0)
-                        Render::GL::g_pHyprOpenGL->renderBorder(proxy, grad, {.round = round, .roundingPower = ROUND_PWR, .borderSize = borderWidth});
-                } else
-                    Log::logger->log(Log::ERR, "[hyprexpo] invalid drag_drop_proxy_border_color config: {}", effectiveSpec);
-            }
+            drawProxyBorder(proxy, round, borderWidth, effectiveSpec, std::string{*PBGREFOC});
         }
     }
 }

--- a/docs/configuration/labels-borders.md
+++ b/docs/configuration/labels-borders.md
@@ -21,11 +21,16 @@ Deprecated fallback keys are still recognized for compatibility: `border_grad_cu
 
 ## Drag-Drop Window Styling
 
-Drag-drop window movement uses a translucent proxy under the pointer plus a
-source-workspace border while the move is active. By default those visuals keep
-the existing proxy colors and inherit the focused tile border; set the
-`drag_drop_*` keys when you want the window-moving feedback to match your
-theme.
+Drag-drop window movement uses a translucent proxy under the pointer, a
+source-workspace border, and a positional landing proxy inside the hovered
+target tile while the move is active. By default those visuals keep the existing
+proxy colors and inherit the focused tile border; set the `drag_drop_*` keys
+when you want the window-moving feedback to match your theme.
+
+The target-tile landing proxy is a visual drop-intent preview. It shows where
+the grabbed window would land based on pointer position and grab offset, but the
+current release behavior still uses Hyprland's safe workspace move path. Floating
+positional release and tiled layout-aware insertion are deferred follow-up work.
 
 | key | type | description | default |
 | --- | --- | --- | --- |

--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -63,9 +63,13 @@ plugin {
 ## Drag-Drop Window Styling
 
 These options style the visual feedback shown while dragging a window between
-workspace previews. Empty border color values inherit the focused tile border,
-so the default look stays unchanged until you opt into drag/drop-specific
-styling.
+workspace previews. HyprExpo renders the under-pointer drag proxy and, while the
+pointer is over a valid target workspace, a positional landing proxy inside that
+target tile. Empty border color values inherit the focused tile border, so the
+default look stays unchanged until you opt into drag/drop-specific styling.
+
+The landing proxy is visual-only in this milestone. It previews drop intent; the
+actual release still uses the existing safe workspace move behavior.
 
 | key | type | description | default |
 | --- | --- | --- | --- |

--- a/docs/guides/runtime-smoke.md
+++ b/docs/guides/runtime-smoke.md
@@ -23,8 +23,12 @@ Nested test binds:
 4. Move keyboard focus with `hyprexpo:kb_focus`, then select with `hyprexpo:kb_confirm`.
 5. Select by pointer or touch near the outside edges of the monitor.
 6. Confirm current, hover, focus, label, and border styling render as configured.
-7. Exercise the Lua gesture registration path and complete or cancel a swipe.
-8. Unload or reload the plugin after closing overview and confirm no stale render pass callback crashes the session.
+7. Open two or more windows on one workspace, open overview, press on a visible window preview, drag across the move threshold, and confirm the under-pointer drag proxy appears.
+8. Drag that window preview over another valid workspace tile and confirm a positional landing proxy appears inside the hovered target tile.
+9. Move the pointer within the target tile and between target tiles; confirm the landing proxy tracks the pointer position, preserves the original grab offset, and disappears when hovering the source or an invalid target.
+10. Release on a target workspace and confirm the window still moves through the existing safe workspace move behavior. This release is not yet a positional layout insertion.
+11. Exercise the Lua gesture registration path and complete or cancel a swipe.
+12. Unload or reload the plugin after closing overview and confirm no stale render pass callback crashes the session.
 
 ::: warning
 The public site and docs should not claim full release readiness until this runtime smoke gate has been completed for the intended release artifact.

--- a/scripts/dev-watch.sh
+++ b/scripts/dev-watch.sh
@@ -32,7 +32,7 @@ plugin {
     tile_rounding_current = 14
   }
 }
-bind = , F10, exec, hyprctl dispatch hyprexpo:expo toggle
+bind = , F10, hyprexpo:expo, toggle
 bind = SUPER, Return, exec, kitty
 bind = SUPER, Q, killactive
 bind = SUPER SHIFT, Q, exit
@@ -55,11 +55,11 @@ bind = SUPER SHIFT, 7, movetoworkspace, 7
 bind = SUPER SHIFT, 8, movetoworkspace, 8
 bind = SUPER SHIFT, 9, movetoworkspace, 9
 submap = hyprexpo
-  bind = , left,  exec, hyprctl dispatch hyprexpo:kb_focus left
-  bind = , right, exec, hyprctl dispatch hyprexpo:kb_focus right
-  bind = , up,    exec, hyprctl dispatch hyprexpo:kb_focus up
-  bind = , down,  exec, hyprctl dispatch hyprexpo:kb_focus down
-  bind = , return, exec, hyprctl dispatch hyprexpo:kb_confirm
+  bind = , left, hyprexpo:kb_focus, left
+  bind = , right, hyprexpo:kb_focus, right
+  bind = , up, hyprexpo:kb_focus, up
+  bind = , down, hyprexpo:kb_focus, down
+  bind = , return, hyprexpo:kb_confirm
 submap = reset
 EOF
 }

--- a/scripts/run-nested.sh
+++ b/scripts/run-nested.sh
@@ -77,7 +77,7 @@ plugin {
 }
 
 # toggle with an unmodified function key to avoid host grabs
-bind = , F10, exec, hyprctl dispatch hyprexpo:expo toggle
+bind = , F10, hyprexpo:expo, toggle
 
 # nested-session test controls
 bind = SUPER, Return, exec, kitty
@@ -104,21 +104,21 @@ bind = SUPER SHIFT, 9, movetoworkspace, 9
 
 # submap for keyboard nav (the plugin auto-enters this when open)
 submap = hyprexpo
-  bind = , left,  exec, hyprctl dispatch hyprexpo:kb_focus left
-  bind = , right, exec, hyprctl dispatch hyprexpo:kb_focus right
-  bind = , up,    exec, hyprctl dispatch hyprexpo:kb_focus up
-  bind = , down,  exec, hyprctl dispatch hyprexpo:kb_focus down
-  bind = , return, exec, hyprctl dispatch hyprexpo:kb_confirm
-  bind = , 1, exec, hyprctl dispatch hyprexpo:kb_selectn 1
-  bind = , 2, exec, hyprctl dispatch hyprexpo:kb_selectn 2
-  bind = , 3, exec, hyprctl dispatch hyprexpo:kb_selectn 3
-  bind = , 4, exec, hyprctl dispatch hyprexpo:kb_selectn 4
-  bind = , 5, exec, hyprctl dispatch hyprexpo:kb_selectn 5
-  bind = , 6, exec, hyprctl dispatch hyprexpo:kb_selectn 6
-  bind = , 7, exec, hyprctl dispatch hyprexpo:kb_selectn 7
-  bind = , 8, exec, hyprctl dispatch hyprexpo:kb_selectn 8
-  bind = , 9, exec, hyprctl dispatch hyprexpo:kb_selectn 9
-  bind = , 0, exec, hyprctl dispatch hyprexpo:kb_selectn 0
+  bind = , left, hyprexpo:kb_focus, left
+  bind = , right, hyprexpo:kb_focus, right
+  bind = , up, hyprexpo:kb_focus, up
+  bind = , down, hyprexpo:kb_focus, down
+  bind = , return, hyprexpo:kb_confirm
+  bind = , 1, hyprexpo:kb_selectn, 1
+  bind = , 2, hyprexpo:kb_selectn, 2
+  bind = , 3, hyprexpo:kb_selectn, 3
+  bind = , 4, hyprexpo:kb_selectn, 4
+  bind = , 5, hyprexpo:kb_selectn, 5
+  bind = , 6, hyprexpo:kb_selectn, 6
+  bind = , 7, hyprexpo:kb_selectn, 7
+  bind = , 8, hyprexpo:kb_selectn, 8
+  bind = , 9, hyprexpo:kb_selectn, 9
+  bind = , 0, hyprexpo:kb_selectn, 0
 submap = reset
 EOF
 

--- a/tests/HyprexpoLogicTests.cpp
+++ b/tests/HyprexpoLogicTests.cpp
@@ -20,6 +20,10 @@ bool near(float a, float b) {
     return std::abs(a - b) < 0.001F;
 }
 
+bool near(double a, double b) {
+    return std::abs(a - b) < 0.001;
+}
+
 }
 
 int main() {
@@ -36,6 +40,36 @@ int main() {
     expect(tileIndexFromPoint(299, 299, 300, 300, 3) == 8, "tile index bottom-right inside");
     expect(tileIndexFromPoint(300, 300, 300, 300, 3) == 8, "tile index clamps monitor edge");
     expect(tileIndexFromPoint(10, 10, 0, 300, 3) == -1, "tile index rejects invalid width");
+
+    SDropIntentInput dropInput{
+        .targetValid     = true,
+        .pointerLocal    = {150, 150},
+        .targetTileLocal = {0, 0, 300, 300},
+        .workspaceSize   = {1200, 900},
+        .windowSize      = {300, 180},
+        .grabOffset      = {150, 90},
+    };
+    auto drop = computeDropIntentGeometry(dropInput);
+    expect(drop.valid, "drop intent center is valid");
+    expect(near(drop.targetWorkspacePoint.x, 600) && near(drop.targetWorkspacePoint.y, 450), "drop intent maps pointer to workspace point");
+    expect(near(drop.targetProxyLocal.x, 112.5) && near(drop.targetProxyLocal.y, 120), "drop intent preserves grab offset");
+    expect(near(drop.targetProxyLocal.w, 75) && near(drop.targetProxyLocal.h, 60), "drop intent scales window into target preview");
+
+    dropInput.pointerLocal = {300, 300};
+    drop                   = computeDropIntentGeometry(dropInput);
+    expect(near(drop.targetWorkspacePoint.x, 1200) && near(drop.targetWorkspacePoint.y, 900), "drop intent maps bottom-right edge");
+    expect(near(drop.targetProxyLocal.x, 225) && near(drop.targetProxyLocal.y, 240), "drop intent clamps bottom-right proxy");
+
+    dropInput.pointerLocal = {-20, -20};
+    drop                   = computeDropIntentGeometry(dropInput);
+    expect(near(drop.targetWorkspacePoint.x, 0) && near(drop.targetWorkspacePoint.y, 0), "drop intent clamps outside pointer to workspace edge");
+    expect(near(drop.targetProxyLocal.x, 0) && near(drop.targetProxyLocal.y, 0), "drop intent clamps outside pointer proxy to tile edge");
+
+    dropInput.targetValid = false;
+    expect(!computeDropIntentGeometry(dropInput).valid, "drop intent rejects invalid target");
+    dropInput.targetValid  = true;
+    dropInput.windowSize.w = 0;
+    expect(!computeDropIntentGeometry(dropInput).valid, "drop intent rejects invalid window size");
 
     expect(fallbackTokenForVisibleIndex(0) == "1", "fallback token first workspace");
     expect(fallbackTokenForVisibleIndex(9) == "0", "fallback token tenth workspace");


### PR DESCRIPTION
Found it. Took maybe 6 hours to reproduce and only 10 minutes to fix.

render-state leak during Hyprexpo preview capture.

summary:  

Hyprland was keeping stolen window in transient workspace-move animation/render state. Hyprexpo then opened and captures each workspace preview by temporarily rendering workspaces into framebuffers. Hyprland’s renderer is not strictly “only render windows owned this workspace”; it may render windows that are still considered visible, force-rendered, moving, or animated on the monitor.

Result: the recently moved window gets drawn into many or all non-empty Hyprexpo workspace previews. Sometimes it disappears after the transition state settles; sometimes it persists in the cached preview. The real window is only interactable in one workspace, but stale/incorrect preview pixels make it look replicated everywhere.

There could be one lingering issue:

Current likely remaining bug: `renderWorkspaceWindows()` path includes windows based on monitor rendering, not ownership, so may need a stricter capture-time filter or a different capture strategy.