### PR TITLE
render and damage hooks now fall back to normal Hyprland handling whe…

### DIFF
--- a/Overview.hpp
+++ b/Overview.hpp
@@ -30,6 +30,7 @@ class COverview {
     void onPreRender();
 
     void setClosing(bool closing);
+    bool shouldRenderOverviewForMonitor(const PHLMONITOR& monitor) const;
 
     void resetSwipe();
     void onSwipeUpdate(double delta);

--- a/OverviewRender.cpp
+++ b/OverviewRender.cpp
@@ -72,7 +72,8 @@ void COverview::redrawID(int id, bool forcelowres) {
     const auto PWORKSPACE = image.pWorkspace ? image.pWorkspace : g_pCompositor->getWorkspaceByID(image.workspaceID);
     image.pWorkspace      = PWORKSPACE;
 
-    PHLWORKSPACE openSpecial = pMonitor->m_activeSpecialWorkspace;
+    const auto   restoreWorkspace = pMonitor->m_activeWorkspace;
+    PHLWORKSPACE openSpecial      = pMonitor->m_activeSpecialWorkspace;
     if (openSpecial)
         pMonitor->m_activeSpecialWorkspace.reset();
 
@@ -106,9 +107,14 @@ void COverview::redrawID(int id, bool forcelowres) {
     pMonitor->m_transformedSize = savedTransformedSize;
 
     pMonitor->m_activeSpecialWorkspace = openSpecial;
-    pMonitor->m_activeWorkspace        = startedOn;
-    startedOn->m_visible               = true;
-    g_pDesktopAnimationManager->startAnimation(startedOn, CDesktopAnimationManager::ANIMATION_TYPE_IN, true, true);
+
+    const auto activeWorkspace = restoreWorkspace ? restoreWorkspace : startedOn;
+    pMonitor->m_activeWorkspace = activeWorkspace;
+    if (activeWorkspace) {
+        activeWorkspace->m_visible = true;
+        if (activeWorkspace == startedOn)
+            g_pDesktopAnimationManager->startAnimation(activeWorkspace, CDesktopAnimationManager::ANIMATION_TYPE_IN, true, true);
+    }
 
     blockOverviewRendering = false;
 }
@@ -223,6 +229,16 @@ void COverview::onWorkspaceChange() {
 
 void COverview::render() {
     g_pHyprRenderer->m_renderPass.add(makeUnique<COverviewPassElement>());
+}
+
+bool COverview::shouldRenderOverviewForMonitor(const PHLMONITOR& monitor) const {
+    if (pMonitor != monitor)
+        return false;
+
+    if (closing && pMonitor && pMonitor->m_activeWorkspace != startedOn)
+        return false;
+
+    return true;
 }
 
 void COverview::fullRender() {

--- a/main.cpp
+++ b/main.cpp
@@ -22,7 +22,7 @@ typedef void (*origAddDamageA)(void*, const CBox&);
 typedef void (*origAddDamageB)(void*, const pixman_region32_t*);
 
 static void hkRenderWorkspace(void* thisptr, PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace, timespec* now, const CBox& geometry) {
-    if (!g_pOverview || isRenderingOverview() || g_pOverview->blockOverviewRendering || g_pOverview->pMonitor != pMonitor)
+    if (!g_pOverview || isRenderingOverview() || g_pOverview->blockOverviewRendering || !g_pOverview->shouldRenderOverviewForMonitor(pMonitor))
         ((origRenderWorkspace)(g_pRenderWorkspaceHook->m_original))(thisptr, pMonitor, pWorkspace, now, geometry);
     else
         g_pOverview->render();
@@ -31,7 +31,7 @@ static void hkRenderWorkspace(void* thisptr, PHLMONITOR pMonitor, PHLWORKSPACE p
 static void hkAddDamageA(void* thisptr, const CBox& box) {
     const auto PMONITOR = (CMonitor*)thisptr;
 
-    if (!g_pOverview || g_pOverview->pMonitor != PMONITOR->m_self || g_pOverview->blockDamageReporting) {
+    if (!g_pOverview || !g_pOverview->shouldRenderOverviewForMonitor(PMONITOR->m_self.lock()) || g_pOverview->blockDamageReporting) {
         ((origAddDamageA)g_pAddDamageHookA->m_original)(thisptr, box);
         return;
     }
@@ -42,7 +42,7 @@ static void hkAddDamageA(void* thisptr, const CBox& box) {
 static void hkAddDamageB(void* thisptr, const pixman_region32_t* rg) {
     const auto PMONITOR = (CMonitor*)thisptr;
 
-    if (!g_pOverview || g_pOverview->pMonitor != PMONITOR->m_self || g_pOverview->blockDamageReporting) {
+    if (!g_pOverview || !g_pOverview->shouldRenderOverviewForMonitor(PMONITOR->m_self.lock()) || g_pOverview->blockDamageReporting) {
         ((origAddDamageB)g_pAddDamageHookB->m_original)(thisptr, rg);
         return;
     }


### PR DESCRIPTION
…n an external workspace change happens during Hyprexpo close.