### PR TITLE
Add configurable pinned window behavior

### DIFF
--- a/HyprexpoConfig.hpp
+++ b/HyprexpoConfig.hpp
@@ -15,6 +15,7 @@ inline constexpr unsigned    WORKSPACE_NUMBER_COLOR_DEFAULT  = 0xFFFFFFFF;
 inline constexpr int         GESTURE_DISTANCE_DEFAULT        = 200;
 inline constexpr const char* CANCEL_KEY_DEFAULT              = "escape";
 inline constexpr int         SHOW_CURSOR_DEFAULT             = 1;
+inline constexpr int         SHOW_PINNED_WINDOWS_DEFAULT     = 0;
 inline constexpr int         KEYNAV_ENABLE_DEFAULT           = 1;
 inline constexpr int         KEYNAV_WRAP_H_DEFAULT           = 1;
 inline constexpr int         KEYNAV_WRAP_V_DEFAULT           = 1;

--- a/Overview.cpp
+++ b/Overview.cpp
@@ -123,6 +123,7 @@ static Config::INTEGER intDefault(const std::string& name) {
         {"plugin:hyprexpo:bg_col", HyprexpoConfig::BG_COL_DEFAULT},
         {"plugin:hyprexpo:gesture_distance", HyprexpoConfig::GESTURE_DISTANCE_DEFAULT},
         {"plugin:hyprexpo:show_cursor", HyprexpoConfig::SHOW_CURSOR_DEFAULT},
+        {"plugin:hyprexpo:show_pinned_windows", HyprexpoConfig::SHOW_PINNED_WINDOWS_DEFAULT},
         {"plugin:hyprexpo:max_workspace", HyprexpoConfig::MAX_WORKSPACE_DEFAULT},
         {"plugin:hyprexpo:show_workspace_numbers", HyprexpoConfig::SHOW_WORKSPACE_NUMBERS_DEFAULT},
         {"plugin:hyprexpo:workspace_number_color", HyprexpoConfig::WORKSPACE_NUMBER_COLOR_DEFAULT},
@@ -443,6 +444,49 @@ void normalizeMonitorWorkspaceRenderState(PHLMONITOR monitor) {
         window->alpha(Desktop::View::WINDOW_ALPHA_MOVE_FROM_WORKSPACE)->setValueAndWarp(1.F);
         *window->alpha(Desktop::View::WINDOW_ALPHA_MOVE_FROM_WORKSPACE) = 1.F;
     }
+}
+
+bool showPinnedWindowsInPreview() {
+    static auto* const* PSHOWPINNED = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:show_pinned_windows")->getDataStaticPtr();
+    return **PSHOWPINNED != 0;
+}
+
+std::vector<SPinnedWindowPreviewState> applyPinnedWindowPreviewState(bool showPinnedWindows) {
+    std::vector<SPinnedWindowPreviewState> states;
+    if (showPinnedWindows)
+        return states;
+
+    for (const auto& window : g_pCompositor->m_windows) {
+        if (!window || !window->m_isMapped || !window->m_pinned)
+            continue;
+
+        states.push_back({
+            .window = window,
+            .workspace = window->m_workspace,
+            .pinned = window->m_pinned,
+        });
+
+        window->m_pinned = false;
+        window->m_workspace.reset();
+    }
+
+    return states;
+}
+
+void restorePinnedWindowPreviewState(const std::vector<SPinnedWindowPreviewState>& states) {
+    for (const auto& state : states) {
+        if (!state.window)
+            continue;
+
+        state.window->m_workspace = state.workspace;
+        state.window->m_pinned    = state.pinned;
+    }
+}
+
+CPinnedWindowPreviewGuard::CPinnedWindowPreviewGuard(bool showPinnedWindows) : m_states(applyPinnedWindowPreviewState(showPinnedWindows)) {}
+
+CPinnedWindowPreviewGuard::~CPinnedWindowPreviewGuard() {
+    restorePinnedWindowPreviewState(m_states);
 }
 
 bool windowVisibleOnWorkspace(const PHLWINDOW& window, const PHLWORKSPACE& workspace) {
@@ -769,7 +813,10 @@ COverview::COverview(PHLWORKSPACE startedOn_, bool swipe_) : startedOn(startedOn
             if (PWORKSPACE == startedOn)
                 PMONITOR->m_activeSpecialWorkspace = openSpecial;
 
-            g_pHyprRenderer->renderWorkspace(PMONITOR, PWORKSPACE, Time::steadyNow(), monbox);
+            {
+                CPinnedWindowPreviewGuard pinnedWindowPreviewGuard{showPinnedWindowsInPreview()};
+                g_pHyprRenderer->renderWorkspace(PMONITOR, PWORKSPACE, Time::steadyNow(), monbox);
+            }
 
             restoreWorkspaceWindowGoalState(windowState);
             restoreWorkspacePreviewStates(previewStates);
@@ -778,8 +825,10 @@ COverview::COverview(PHLWORKSPACE startedOn_, bool swipe_) : startedOn(startedOn
 
             if (PWORKSPACE == startedOn)
                 PMONITOR->m_activeSpecialWorkspace.reset();
-        } else
+        } else {
+            CPinnedWindowPreviewGuard pinnedWindowPreviewGuard{showPinnedWindowsInPreview()};
             g_pHyprRenderer->renderWorkspace(PMONITOR, PWORKSPACE, Time::steadyNow(), monbox);
+        }
 
         image.box = {(i % SIDE_LENGTH) * tileRenderSize.x + (i % SIDE_LENGTH) * GAP_WIDTH, (i / SIDE_LENGTH) * tileRenderSize.y + (i / SIDE_LENGTH) * GAP_WIDTH, tileRenderSize.x,
                      tileRenderSize.y};

--- a/OverviewInternal.hpp
+++ b/OverviewInternal.hpp
@@ -30,6 +30,24 @@ struct SWindowPreviewState {
     Vector2D  sizeGoal;
 };
 
+struct SPinnedWindowPreviewState {
+    PHLWINDOW   window;
+    PHLWORKSPACE workspace;
+    bool        pinned = false;
+};
+
+class CPinnedWindowPreviewGuard {
+  public:
+    explicit CPinnedWindowPreviewGuard(bool showPinnedWindows);
+    ~CPinnedWindowPreviewGuard();
+
+    CPinnedWindowPreviewGuard(const CPinnedWindowPreviewGuard&)            = delete;
+    CPinnedWindowPreviewGuard& operator=(const CPinnedWindowPreviewGuard&) = delete;
+
+  private:
+    std::vector<SPinnedWindowPreviewState> m_states;
+};
+
 void clearWithColor(const CHyprColor& color);
 uint32_t framebufferFormatWithAlpha(uint32_t drmFormat);
 bool isTransformRotated(wl_output_transform t);
@@ -50,6 +68,9 @@ std::vector<std::pair<PHLWORKSPACE, SWorkspacePreviewState>> applyExclusiveWorks
 void restoreWorkspacePreviewStates(const std::vector<std::pair<PHLWORKSPACE, SWorkspacePreviewState>>& states);
 void normalizeMonitorWorkspaceRenderState(PHLMONITOR monitor);
 
+bool showPinnedWindowsInPreview();
+std::vector<SPinnedWindowPreviewState> applyPinnedWindowPreviewState(bool showPinnedWindows);
+void restorePinnedWindowPreviewState(const std::vector<SPinnedWindowPreviewState>& states);
 bool windowVisibleOnWorkspace(const PHLWINDOW& window, const PHLWORKSPACE& workspace);
 void settleWorkspaceMoveAnimation(const PHLWINDOW& window);
 void settleWorkspaceMoveAnimations();

--- a/OverviewRender.cpp
+++ b/OverviewRender.cpp
@@ -87,7 +87,10 @@ void COverview::redrawID(int id, bool forcelowres) {
         if (PWORKSPACE == startedOn)
             pMonitor->m_activeSpecialWorkspace = openSpecial;
 
-        g_pHyprRenderer->renderWorkspace(pMonitor.lock(), PWORKSPACE, Time::steadyNow(), monbox);
+        {
+            CPinnedWindowPreviewGuard pinnedWindowPreviewGuard{showPinnedWindowsInPreview()};
+            g_pHyprRenderer->renderWorkspace(pMonitor.lock(), PWORKSPACE, Time::steadyNow(), monbox);
+        }
 
         restoreWorkspaceWindowGoalState(windowState);
         restoreWorkspacePreviewStates(previewStates);
@@ -95,8 +98,10 @@ void COverview::redrawID(int id, bool forcelowres) {
 
         if (PWORKSPACE == startedOn)
             pMonitor->m_activeSpecialWorkspace.reset();
-    } else
+    } else {
+        CPinnedWindowPreviewGuard pinnedWindowPreviewGuard{showPinnedWindowsInPreview()};
         g_pHyprRenderer->renderWorkspace(pMonitor.lock(), PWORKSPACE, Time::steadyNow(), monbox);
+    }
 
     g_pHyprRenderer->m_renderData.blockScreenShader = true;
     g_pHyprRenderer->endRender();

--- a/PluginConfig.cpp
+++ b/PluginConfig.cpp
@@ -30,6 +30,7 @@ void registerHyprexpoConfigValues() {
     addConfigValue(makeShared<Config::Values::CIntValue>("plugin:hyprexpo:gesture_distance", "gesture distance", HyprexpoConfig::GESTURE_DISTANCE_DEFAULT));
     addConfigValue(createCancelKeyConfig());
     addConfigValue(makeShared<Config::Values::CIntValue>("plugin:hyprexpo:show_cursor", "show cursor during overview", HyprexpoConfig::SHOW_CURSOR_DEFAULT));
+    addConfigValue(makeShared<Config::Values::CIntValue>("plugin:hyprexpo:show_pinned_windows", "show pinned windows in previews", HyprexpoConfig::SHOW_PINNED_WINDOWS_DEFAULT));
 
     // keyboard navigation + styling
     addConfigValue(makeShared<Config::Values::CIntValue>("plugin:hyprexpo:keynav_enable", "key navigation enable", HyprexpoConfig::KEYNAV_ENABLE_DEFAULT));

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ plugin {
         gesture_distance = 200
         cancel_key = escape
         show_cursor = 1
+        show_pinned_windows = 0
     }
 }
 ```

--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -40,6 +40,9 @@ plugin {
 | `plugin:hyprexpo:gesture_distance` | int | swipe distance considered complete | `200` |
 | `plugin:hyprexpo:cancel_key` | string | comma-separated key names that close overview without selecting; `none` or `off` disables | `escape` |
 | `plugin:hyprexpo:show_cursor` | bool int | keep the cursor visible while overview is open; set `0` for old hidden-cursor behavior | `1` |
+| `plugin:hyprexpo:show_pinned_windows` | bool int | render pinned/PiP windows in workspace preview thumbnails; default `0` hides them from previews only | `0` |
+
+Pinned windows, including browser Picture-in-Picture windows, stay pinned and visible in normal Hyprland. By default HyprExpo hides them only while capturing workspace preview thumbnails so they do not appear on every tile. Set `show_pinned_windows = 1` to opt in to the old preview behavior.
 
 ## Tile Appearance
 
@@ -196,6 +199,6 @@ Then bind `hyprexpo:kb_select` to those tokens in the overview submap.
 ## Safe Failure Behavior
 
 Invalid `columns`, workspace methods, label tokens, border colors, drag/drop
-border colors, and gradient values are expected to fail safely. The plugin
-should log invalid values or use a fallback instead of crashing Hyprland during
-render.
+border colors, gradient values, and bool-int options are expected to fail
+safely. The plugin should log invalid values or use a fallback instead of
+crashing Hyprland during render.

--- a/docs/guides/runtime-smoke.md
+++ b/docs/guides/runtime-smoke.md
@@ -28,7 +28,11 @@ Nested test binds:
 9. Move the pointer within the target tile and between target tiles; confirm the landing proxy tracks the pointer position, preserves the original grab offset, and disappears when hovering the source or an invalid target.
 10. Release on a target workspace and confirm the window still moves through the existing safe workspace move behavior. This release is not yet a positional layout insertion.
 11. Exercise the Lua gesture registration path and complete or cancel a swipe.
-12. Unload or reload the plugin after closing overview and confirm no stale render pass callback crashes the session.
+12. Open or create a Picture-in-Picture-like pinned window. In the nested session, one practical path is to focus a test window and run `hyprctl dispatch pin` from a terminal.
+13. With the default `plugin:hyprexpo:show_pinned_windows = 0`, open overview and confirm the pinned window is not rendered into every workspace preview tile.
+14. Set `plugin:hyprexpo:show_pinned_windows = 1`, reload or apply the keyword, reopen overview, and confirm pinned windows render in previews again for users who opt in.
+15. Set `plugin:hyprexpo:show_pinned_windows = 0` again, close overview, and confirm the pinned window is still visible and pinned in the normal Hyprland session.
+16. Unload or reload the plugin after closing overview and confirm no stale render pass callback crashes the session.
 
 ::: warning
 The public site and docs should not claim full release readiness until this runtime smoke gate has been completed for the intended release artifact.

--- a/scripts/dev-watch.sh
+++ b/scripts/dev-watch.sh
@@ -30,6 +30,7 @@ plugin {
     tile_rounding = 12
     tile_rounding_focus = 16
     tile_rounding_current = 14
+    show_pinned_windows = 0
   }
 }
 bind = , F10, hyprexpo:expo, toggle

--- a/scripts/run-nested.sh
+++ b/scripts/run-nested.sh
@@ -36,6 +36,7 @@ plugin {
     bg_col = rgb(101010)
     workspace_method = center current
     skip_empty = 0
+    show_pinned_windows = 0
 
     # borders (hypr-style gradient, thicker to showcase)
     border_style = hyprland

--- a/scripts/verify-site-dist.sh
+++ b/scripts/verify-site-dist.sh
@@ -31,6 +31,7 @@ require_grep "github.com/sandwichfarm/hyprexpo" dist/index.html
 require_grep "github.com/user-attachments/assets/861baa26-46b6-4fa8-8d37-65cbb9ecbed4" dist/index.html
 require_grep "drag-drop window movement" dist/index.html
 require_grep "plugin:hyprexpo:show_cursor" dist/docs
+require_grep "plugin:hyprexpo:show_pinned_windows" dist/docs
 require_grep "plugin:hyprexpo:tile_rounding" dist/docs/configuration/options/index.html
 require_grep "plugin:hyprexpo:border_color_current" dist/docs/configuration/options/index.html
 require_grep "plugin:hyprexpo:drag_drop_proxy_color" dist/docs/configuration/options/index.html

--- a/tests/HyprexpoLogicTests.cpp
+++ b/tests/HyprexpoLogicTests.cpp
@@ -1,4 +1,5 @@
 #include "../HyprexpoLogic.hpp"
+#include "../HyprexpoConfig.hpp"
 
 #include <cstdlib>
 #include <iostream>
@@ -35,6 +36,7 @@ int main() {
     expect(clampGridColumns(-1) == 1, "columns clamp lower bound");
     expect(clampGridColumns(3) == 3, "columns keep valid value");
     expect(clampGridColumns(99) == 7, "columns clamp upper bound");
+    expect(HyprexpoConfig::SHOW_PINNED_WINDOWS_DEFAULT == 0, "pinned windows are hidden from previews by default");
 
     expect(tileIndexFromPoint(0, 0, 300, 300, 3) == 0, "tile index top-left");
     expect(tileIndexFromPoint(299, 299, 300, 300, 3) == 8, "tile index bottom-right inside");


### PR DESCRIPTION
Resolves #43.

## Summary
- Add `plugin:hyprexpo:show_pinned_windows`, defaulting to `0`, so pinned/PiP windows are hidden from Hyprexpo workspace preview thumbnails by default.
- Keep an opt-in path with `show_pinned_windows = 1` for users who want the previous pinned-window preview behavior.
- Scope preview suppression to thumbnail capture only, then restore the pinned/window workspace render state immediately after capture.
- Apply the guard to both initial preview capture and targeted redraw capture.
- Update README, configuration reference, runtime smoke guide, nested helper configs, site-dist verification, and logic tests.

## How to test
Automated checks:

```bash
make test
make all
./scripts/build-site.sh
./scripts/verify-site-dist.sh
bash -n scripts/run-nested.sh scripts/dev-watch.sh
git diff --check
```

Runtime smoke:

1. Load the plugin build into Hyprland or start the nested helper with `scripts/run-nested.sh`.
2. Confirm the default config value:

```bash
hyprctl getoption plugin:hyprexpo:show_pinned_windows
```

Expected default is `int: 0` unless the user explicitly configured another value.

3. Create a pinned/PiP-like test window:

```bash
hyprctl dispatch exec 'kitty --title hyprexpo-pinned-smoke'
# focus the new window, then:
hyprctl dispatch togglefloating
hyprctl dispatch pin
```

4. Open Hyprexpo. With `show_pinned_windows = 0`, the pinned window should remain visible and pinned in the normal Hyprland session, but should not be replicated into every workspace preview thumbnail.
5. Opt into the previous behavior and reopen Hyprexpo:

```bash
hyprctl keyword plugin:hyprexpo:show_pinned_windows 1
hyprctl dispatch hyprexpo:expo toggle
```

Pinned windows should render in previews again.

6. Reset the safer default and verify the pinned window is still visible, pinned, and not moved after closing Hyprexpo:

```bash
hyprctl keyword plugin:hyprexpo:show_pinned_windows 0
```