### PR TITLE
docs: remove unsupported gaps_out from quick config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,6 @@ Add the plugin block to your Hyprland config:
 plugin {
     hyprexpo {
         columns = 3
-        gaps_in = 5
-        gaps_out = 0
         bg_col = rgb(111111)
         workspace_method = center current
         gesture_distance = 200
@@ -103,8 +101,6 @@ hl.config({
     plugin = {
         hyprexpo = {
             columns = 3,
-            gaps_in = 5,
-            gaps_out = 0,
             bg_col = "rgb(111111)",
             workspace_method = "center current",
             gesture_distance = 200,

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Add the plugin block to your Hyprland config:
 plugin {
     hyprexpo {
         columns = 3
+		gaps_in = 5
         bg_col = rgb(111111)
         workspace_method = center current
         gesture_distance = 200
@@ -101,6 +102,7 @@ hl.config({
     plugin = {
         hyprexpo = {
             columns = 3,
+            gaps_in = 5
             bg_col = "rgb(111111)",
             workspace_method = "center current",
             gesture_distance = 200,


### PR DESCRIPTION
gaps_in and gap_out causes errors on latest Hyprland build.