### PR TITLE
Preserve preview orientation on rotated monitors

### DIFF
--- a/Overview.cpp
+++ b/Overview.cpp
@@ -24,6 +24,7 @@
 #include <hyprland/src/managers/eventLoop/EventLoopTimer.hpp>
 #include <hyprland/src/managers/input/InputManager.hpp>
 #include <hyprland/src/managers/PointerManager.hpp>
+#include <hyprland/src/helpers/math/Math.hpp>
 #include <hyprland/src/helpers/time/Time.hpp>
 #include <hyprland/src/helpers/varlist/VarList.hpp>
 #include <hyprland/src/helpers/Format.hpp>
@@ -835,6 +836,10 @@ COverview::COverview(PHLWORKSPACE startedOn_, bool swipe_) : startedOn(startedOn
 
         g_pHyprRenderer->m_renderData.blockScreenShader = true;
         g_pHyprRenderer->endRender();
+
+        // Capture normalizes monitor geometry; preserve the real output direction on the texture.
+        if (const auto texture = image.fb->getTexture(); texture)
+            texture->m_transform = Math::wlTransformToHyprutils(Math::invertTransform(savedTransform));
     }
 
     g_pHyprRenderer->m_bBlockSurfaceFeedback = false;

--- a/OverviewRender.cpp
+++ b/OverviewRender.cpp
@@ -9,6 +9,7 @@
 #include <hyprland/src/config/ConfigValue.hpp>
 #include <hyprland/src/config/shared/actions/ConfigActions.hpp>
 #include <hyprland/src/config/shared/complex/ComplexDataTypes.hpp>
+#include <hyprland/src/helpers/math/Math.hpp>
 #include <hyprland/src/managers/animation/DesktopAnimationManager.hpp>
 #include <hyprland/src/render/OpenGL.hpp>
 #include <hyprland/src/render/Renderer.hpp>
@@ -111,6 +112,10 @@ void COverview::redrawID(int id, bool forcelowres) {
     MON->m_transform       = savedTransform;
     MON->m_pixelSize       = savedPixelSize;
     MON->m_transformedSize = savedTransformedSize;
+
+    // Capture normalizes monitor geometry; preserve the real output direction on the texture.
+    if (const auto texture = image.fb->getTexture(); texture)
+        texture->m_transform = Math::wlTransformToHyprutils(Math::invertTransform(savedTransform));
 
     MON->m_activeSpecialWorkspace = openSpecial;
 


### PR DESCRIPTION
## Summary
- Preserve the saved monitor transform on captured workspace preview textures.
- Apply the same transform metadata after initial overview capture and targeted redraw capture.

fixes #51

## Verification
- `make test`
- `make all TARGET=/tmp/hyprexpo-pr51-issue51.so`
- `git diff --check`
- Nested Hyprland transform-1 plugin load and `hyprexpo:expo toggle` smoke

## Notes
- Physical vertical monitor visual confirmation is still needed; the nested smoke confirms the rotated-output load/open path only.