### PR TITLE
Fix Fedora Lua pkg-config builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,27 @@ set(HYPREXPO_SRC
 add_library(hyprexpo SHARED ${HYPREXPO_SRC})
 
 find_package(PkgConfig REQUIRED)
+
+set(HYPREXPO_LUA_PKG_CONFIG "" CACHE STRING "Lua pkg-config module to use; leave empty to try lua5.4 then lua")
+set(HYPREXPO_LUA_PKG_CONFIG_CANDIDATES lua5.4 lua)
+if(HYPREXPO_LUA_PKG_CONFIG)
+    set(HYPREXPO_LUA_PKG_CONFIG_CANDIDATES ${HYPREXPO_LUA_PKG_CONFIG})
+endif()
+
+foreach(lua_pkg IN LISTS HYPREXPO_LUA_PKG_CONFIG_CANDIDATES)
+    pkg_check_modules(HYPREXPO_LUA QUIET IMPORTED_TARGET ${lua_pkg})
+    if(HYPREXPO_LUA_FOUND)
+        set(HYPREXPO_LUA_PKG_CONFIG_RESOLVED ${lua_pkg})
+        break()
+    endif()
+endforeach()
+
+if(NOT HYPREXPO_LUA_FOUND)
+    message(FATAL_ERROR "Could not find Lua through pkg-config; tried: ${HYPREXPO_LUA_PKG_CONFIG_CANDIDATES}")
+endif()
+
+message(STATUS "Using Lua pkg-config module: ${HYPREXPO_LUA_PKG_CONFIG_RESOLVED}")
+
 pkg_check_modules(deps REQUIRED IMPORTED_TARGET
     hyprland
     libdrm
@@ -31,9 +52,8 @@ pkg_check_modules(deps REQUIRED IMPORTED_TARGET
     pixman-1
     wayland-server
     xkbcommon
-    lua5.4
 )
-target_link_libraries(hyprexpo PRIVATE rt PkgConfig::deps)
+target_link_libraries(hyprexpo PRIVATE rt PkgConfig::deps PkgConfig::HYPREXPO_LUA)
 
 enable_testing()
 add_executable(HyprexpoLogicTests

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,11 @@ else
 endif
 
 CXXFLAGS = -shared -fPIC -g -std=c++2b -Wno-c++11-narrowing -Wno-narrowing
-INCLUDES = `pkg-config --cflags pixman-1 libdrm hyprland pangocairo libinput libudev wayland-server xkbcommon lua5.4`
-LIBS = `pkg-config --libs pangocairo xkbcommon lua5.4`
+LUA_PKG_CONFIG ?= $(shell if pkg-config --exists lua5.4; then printf 'lua5.4'; elif pkg-config --exists lua; then printf 'lua'; else printf 'lua5.4'; fi)
+PKG_CONFIG_DEPS = pixman-1 libdrm hyprland pangocairo libinput libudev wayland-server xkbcommon $(LUA_PKG_CONFIG)
+LINK_DEPS = pangocairo xkbcommon $(LUA_PKG_CONFIG)
+INCLUDES = $(shell pkg-config --cflags $(PKG_CONFIG_DEPS))
+LIBS = $(shell pkg-config --libs $(LINK_DEPS))
 
 SRC = main.cpp Dispatchers.cpp PluginConfig.cpp Overview.cpp OverviewInteraction.cpp OverviewRender.cpp ExpoGesture.cpp OverviewPassElement.cpp HyprexpoLogic.cpp
 HEADERS = globals.hpp Dispatchers.hpp PluginConfig.hpp HyprlandConfigCompat.hpp Overview.hpp OverviewInternal.hpp ExpoGesture.hpp OverviewPassElement.hpp HyprexpoConfig.hpp HyprexpoLogic.hpp

--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ Install a C++23 compiler, `pkg-config`, Hyprland development headers, and these 
 hyprland pixman-1 libdrm pangocairo libinput libudev wayland-server xkbcommon lua5.4
 ```
 
+The build prefers the `lua5.4` pkg-config module and falls back to `lua` for
+distributions such as Fedora where `lua-devel` exposes the generic module name.
+
 Build with the Makefile:
 
 ```bash

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -20,6 +20,9 @@ Build dependencies are a C++23 compiler, `pkg-config`, Hyprland development head
 hyprland pixman-1 libdrm pangocairo libinput libudev wayland-server xkbcommon lua5.4
 ```
 
+The build prefers the `lua5.4` pkg-config module and falls back to `lua` for
+distributions such as Fedora where `lua-devel` exposes the generic module name.
+
 Build with the Makefile:
 
 ```bash

--- a/docs/reference/compatibility.md
+++ b/docs/reference/compatibility.md
@@ -8,7 +8,7 @@ Release builds attach `release-provenance.txt` next to `hyprexpo.so`. That file 
 
 - `hyprctl version`
 - `pkg-config --modversion hyprland`
-- `pkg-config --modversion lua5.4`
+- `pkg-config --modversion lua5.4 || pkg-config --modversion lua`
 - compiler version
 - `ldd -r hyprexpo.so`
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -6,7 +6,7 @@ Rebuild HyprExpo against the same Hyprland revision that is running, then reload
 
 ## Plugin Load Fails Because Dependencies Are Missing
 
-Install the build dependencies and rebuild. Current linked runtime dependencies include `lua5.4`, `pangocairo`, and `xkbcommon`.
+Install the build dependencies and rebuild. Current linked runtime dependencies include Lua (`lua5.4` or `lua` through pkg-config), `pangocairo`, and `xkbcommon`.
 
 ## Invalid Config Values
 

--- a/meson.build
+++ b/meson.build
@@ -31,6 +31,10 @@ src = files(
 )
 
 hyprland = dependency('hyprland')
+lua_dep = dependency('lua5.4', required: false)
+if not lua_dep.found()
+  lua_dep = dependency('lua')
+endif
 
 shared_module(meson.project_name(), src,
   dependencies: [
@@ -42,7 +46,7 @@ shared_module(meson.project_name(), src,
     dependency('libudev'),
     dependency('wayland-server'),
     dependency('xkbcommon'),
-    dependency('lua5.4'),
+    lua_dep,
   ],
   install: true,
 )


### PR DESCRIPTION
## Summary
- prefer `lua5.4` but fall back to the generic `lua` pkg-config module in Makefile, CMake, and Meson builds
- document the Fedora `lua-devel` module-name difference in source-build and troubleshooting docs

fixes #48

## Validation
- `make test`
- `make all`
- `PATH=/tmp/hyprexpo-pkg-config-filter:$PATH make TARGET=/tmp/hyprexpo-pr48-auto-lua.so all`
- `cmake -S . -B /tmp/hyprexpo-pr48-cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo`
- `cmake --build /tmp/hyprexpo-pr48-cmake`
- `ctest --test-dir /tmp/hyprexpo-pr48-cmake --output-on-failure`
- `cmake -S . -B /tmp/hyprexpo-pr48-cmake-auto-lua -DCMAKE_BUILD_TYPE=RelWithDebInfo` with `pkg-config` wrapper hiding `lua5.4`
- `cmake --build /tmp/hyprexpo-pr48-cmake-auto-lua`
- `ctest --test-dir /tmp/hyprexpo-pr48-cmake-auto-lua --output-on-failure`
- `meson setup /tmp/hyprexpo-pr48-meson`
- `meson compile -C /tmp/hyprexpo-pr48-meson`
- `meson test -C /tmp/hyprexpo-pr48-meson --print-errorlogs`
- `PATH=/tmp/hyprexpo-pkg-config-filter:$PATH meson setup /tmp/hyprexpo-pr48-meson-auto-lua`
- `PATH=/tmp/hyprexpo-pkg-config-filter:$PATH meson compile -C /tmp/hyprexpo-pr48-meson-auto-lua`
- `PATH=/tmp/hyprexpo-pkg-config-filter:$PATH meson test -C /tmp/hyprexpo-pr48-meson-auto-lua --print-errorlogs`
- `git diff --check`