### PR TITLE
Fix rotated monitor preview orientation

### DIFF
--- a/Overview.cpp
+++ b/Overview.cpp
@@ -24,7 +24,6 @@
 #include <hyprland/src/managers/eventLoop/EventLoopTimer.hpp>
 #include <hyprland/src/managers/input/InputManager.hpp>
 #include <hyprland/src/managers/PointerManager.hpp>
-#include <hyprland/src/helpers/math/Math.hpp>
 #include <hyprland/src/helpers/time/Time.hpp>
 #include <hyprland/src/helpers/varlist/VarList.hpp>
 #include <hyprland/src/helpers/Format.hpp>
@@ -837,9 +836,9 @@ COverview::COverview(PHLWORKSPACE startedOn_, bool swipe_) : startedOn(startedOn
         g_pHyprRenderer->m_renderData.blockScreenShader = true;
         g_pHyprRenderer->endRender();
 
-        // Capture normalizes monitor geometry; preserve the real output direction on the texture.
+        // Capture normalizes rotated monitor geometry; Hyprland's output path adds one more half-turn.
         if (const auto texture = image.fb->getTexture(); texture)
-            texture->m_transform = Math::wlTransformToHyprutils(Math::invertTransform(savedTransform));
+            texture->m_transform = isTransformRotated(savedTransform) ? HYPRUTILS_TRANSFORM_180 : HYPRUTILS_TRANSFORM_NORMAL;
     }
 
     g_pHyprRenderer->m_bBlockSurfaceFeedback = false;

--- a/OverviewRender.cpp
+++ b/OverviewRender.cpp
@@ -9,7 +9,6 @@
 #include <hyprland/src/config/ConfigValue.hpp>
 #include <hyprland/src/config/shared/actions/ConfigActions.hpp>
 #include <hyprland/src/config/shared/complex/ComplexDataTypes.hpp>
-#include <hyprland/src/helpers/math/Math.hpp>
 #include <hyprland/src/managers/animation/DesktopAnimationManager.hpp>
 #include <hyprland/src/render/OpenGL.hpp>
 #include <hyprland/src/render/Renderer.hpp>
@@ -113,9 +112,9 @@ void COverview::redrawID(int id, bool forcelowres) {
     MON->m_pixelSize       = savedPixelSize;
     MON->m_transformedSize = savedTransformedSize;
 
-    // Capture normalizes monitor geometry; preserve the real output direction on the texture.
+    // Capture normalizes rotated monitor geometry; Hyprland's output path adds one more half-turn.
     if (const auto texture = image.fb->getTexture(); texture)
-        texture->m_transform = Math::wlTransformToHyprutils(Math::invertTransform(savedTransform));
+        texture->m_transform = isTransformRotated(savedTransform) ? HYPRUTILS_TRANSFORM_180 : HYPRUTILS_TRANSFORM_NORMAL;
 
     MON->m_activeSpecialWorkspace = openSpecial;
 


### PR DESCRIPTION
## Summary
- Correct preview texture orientation on rotated monitors after initial capture and redraw capture.

Fixes #51

## Verification
- `make test`
- `make all`
- `git diff --check`
- Nested Hyprland transform 0, 1, and 3 visual proof