### PR TITLE
Clear stale drag overlays after cancelled drops

### DIFF
--- a/OverviewInteraction.cpp
+++ b/OverviewInteraction.cpp
@@ -230,6 +230,8 @@ bool COverview::finishWindowDrag() {
     if (!WINDOW || !MOVED)
         return false;
 
+    // Drag proxies are render-only; repaint even when release does not move workspace contents.
+    damage();
     updateHoveredFromMouse();
 
     const int TARGET = hoveredID;


### PR DESCRIPTION
## Summary
- repaint the overview immediately after clearing a moved drag overlay
- prevents same-tile or invalid-target releases from leaving a stale drag proxy until unrelated damage arrives

Fixes #54

## Verification
- git diff --check -- OverviewInteraction.cpp .planning/debug/issue-54-drag-glitches.md
- make test
- make all TARGET=/tmp/hyprexpo-issue54-fixed.so
- nested Hyprland loaded /tmp/hyprexpo-issue54-fixed.so; virtual pointer input exercised the overview drag path