### PR TITLE
Repaint after overview teardown

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ SRC = main.cpp Dispatchers.cpp PluginConfig.cpp Overview.cpp OverviewInteraction
 HEADERS = globals.hpp Dispatchers.hpp PluginConfig.hpp HyprlandConfigCompat.hpp Overview.hpp OverviewInternal.hpp ExpoGesture.hpp OverviewPassElement.hpp HyprexpoConfig.hpp HyprexpoLogic.hpp
 TARGET = hyprexpo.so
 TEST_TARGET = HyprexpoLogicTests
+SOURCE_TEST_TARGET = OverviewSourceTests
 INSTALL_DIR = /var/cache/hyprpm/$(USER)/hyprexpo
 INSTALL_NAME = hyprexpo.so
 
@@ -39,13 +40,17 @@ install: $(TARGET)
 	install -Dm755 $(TARGET) $(INSTALL_DIR)/$(INSTALL_NAME)
 
 clean:
-	rm -f ./$(TARGET) ./$(TEST_TARGET)
+	rm -f ./$(TARGET) ./$(TEST_TARGET) ./$(SOURCE_TEST_TARGET)
 
-test: $(TEST_TARGET)
+test: $(TEST_TARGET) $(SOURCE_TEST_TARGET)
 	./$(TEST_TARGET)
+	./$(SOURCE_TEST_TARGET)
 
 $(TEST_TARGET): HyprexpoLogic.cpp HyprexpoLogic.hpp HyprexpoConfig.hpp tests/HyprexpoLogicTests.cpp
 	$(CXX) -std=c++2b -Wall -Wextra -Werror HyprexpoLogic.cpp tests/HyprexpoLogicTests.cpp -o $@
+
+$(SOURCE_TEST_TARGET): tests/OverviewSourceTests.cpp Overview.cpp
+	$(CXX) -std=c++2b -Wall -Wextra -Werror tests/OverviewSourceTests.cpp -o $@
 
 # --- Release ceremony -----------------------------------------------------
 # 1. make version vX.Y.Z+N   set + commit the VERSION file

--- a/Overview.cpp
+++ b/Overview.cpp
@@ -597,7 +597,19 @@ void restoreActiveWorkspaceAfterPreview(PHLMONITOR monitor, const PHLWORKSPACE& 
 }
 
 void removeOverview(WP<Hyprutils::Animation::CBaseAnimatedVariable> thisptr) {
+    if (!g_pOverview)
+        return;
+
+    const auto MON = g_pOverview->pMonitor.lock();
     g_pOverview.reset();
+
+    if (!MON)
+        return;
+
+    // Force one normal compositor frame after the overview pass is removed.
+    // Idle/empty workspaces may not produce their own damage immediately.
+    g_pHyprRenderer->damageMonitor(MON);
+    g_pCompositor->scheduleFrameForMonitor(MON);
 }
 
 static bool shouldShowCursorDuringOverview() {

--- a/tests/OverviewSourceTests.cpp
+++ b/tests/OverviewSourceTests.cpp
@@ -1,0 +1,75 @@
+#include <fstream>
+#include <iostream>
+#include <string>
+
+namespace {
+
+int failures = 0;
+
+void expect(bool condition, const std::string& label) {
+    if (condition)
+        return;
+
+    ++failures;
+    std::cerr << "FAIL: " << label << '\n';
+}
+
+std::string readFile(const std::string& path) {
+    std::ifstream file(path);
+    if (!file)
+        return {};
+
+    return std::string(std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>());
+}
+
+std::string extractFunction(const std::string& source, const std::string& signature) {
+    const auto start = source.find(signature);
+    if (start == std::string::npos)
+        return {};
+
+    const auto open = source.find('{', start);
+    if (open == std::string::npos)
+        return {};
+
+    int depth = 0;
+    for (size_t i = open; i < source.size(); ++i) {
+        if (source[i] == '{')
+            ++depth;
+        else if (source[i] == '}') {
+            --depth;
+            if (depth == 0)
+                return source.substr(start, i - start + 1);
+        }
+    }
+
+    return {};
+}
+
+}
+
+int main() {
+    const auto source = readFile("Overview.cpp");
+    expect(!source.empty(), "Overview.cpp can be read from repo root");
+
+    const auto function = extractFunction(source, "void removeOverview(");
+    expect(!function.empty(), "removeOverview function exists");
+
+    const auto lockPos     = function.find("const auto MON = g_pOverview->pMonitor.lock();");
+    const auto resetPos    = function.find("g_pOverview.reset();");
+    const auto damagePos   = function.find("g_pHyprRenderer->damageMonitor(MON);");
+    const auto schedulePos = function.find("g_pCompositor->scheduleFrameForMonitor(MON);");
+
+    expect(lockPos != std::string::npos, "removeOverview captures monitor before teardown");
+    expect(resetPos != std::string::npos, "removeOverview destroys active overview");
+    expect(damagePos != std::string::npos, "removeOverview damages monitor after teardown");
+    expect(schedulePos != std::string::npos, "removeOverview schedules a frame after teardown");
+    expect(lockPos < resetPos, "monitor is captured before overview reset");
+    expect(resetPos < damagePos, "monitor damage happens after overview reset");
+    expect(damagePos < schedulePos, "frame scheduling follows monitor damage");
+
+    if (failures != 0)
+        return 1;
+
+    std::cout << "OverviewSourceTests passed\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary
- force a normal monitor repaint after `g_pOverview` is destroyed so idle workspaces clear the final Hyprexpo overlay frame
- keep the #57/#58 committed-close guard intact
- add `OverviewSourceTests` to lock the teardown ordering in `make test`

Resolves #61.

## Verification
- `git diff --check`
- `make test`
- `make all`
- nested Hyprland smoke with isolated runtime dir `/tmp/hx63r`: plugin `hyprexpo` loaded as `v0.55.2+2-dev+f420f8f`; repeated `hyprexpo:expo toggle` dispatches returned `ok`; log scan found no `SIGSEGV`, `CWeakPointer`, or `dataNonNull` signatures

## Notes
- Exact physical touchpad gesture reproduction was not completed locally. The nested smoke exercises the same overview teardown callback path, but reporter/system confirmation is still useful for the original touchpad gesture.