### PR TITLE
Fix: make install permission denied

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,17 +27,43 @@ HEADERS = globals.hpp Dispatchers.hpp PluginConfig.hpp HyprlandConfigCompat.hpp 
 TARGET = hyprexpo.so
 TEST_TARGET = HyprexpoLogicTests
 SOURCE_TEST_TARGET = OverviewSourceTests
-INSTALL_DIR = /var/cache/hyprpm/$(USER)/hyprexpo
+INSTALL_USER ?= $(if $(SUDO_USER),$(SUDO_USER),$(USER))
+INSTALL_DIR ?= /var/cache/hyprpm/$(INSTALL_USER)/hyprexpo
 INSTALL_NAME = hyprexpo.so
+XDG_CACHE_HOME ?= $(HOME)/.cache
+DEV_DIR ?= $(XDG_CACHE_HOME)/hyprexpo
+DEV_TARGET ?= $(DEV_DIR)/$(INSTALL_NAME)
+COMPILE_PLUGIN = $(CXX) $(CXXFLAGS) $(EXTRA_FLAGS) $(VERSION_DEFINE) $(INCLUDES) $(SRC) -o $@ $(LIBS)
 
 all: $(TARGET)
 
 # Rebuild when the version changes so the baked-in value stays correct.
 $(TARGET): $(SRC) $(HEADERS) $(VERSION_FILE)
-	$(CXX) $(CXXFLAGS) $(EXTRA_FLAGS) $(VERSION_DEFINE) $(INCLUDES) $(SRC) -o $@ $(LIBS)
+	$(COMPILE_PLUGIN)
+
+$(DEV_TARGET): $(SRC) $(HEADERS) $(VERSION_FILE)
+	@mkdir -p "$(dir $@)"
+	$(COMPILE_PLUGIN)
+
+dev-build: $(DEV_TARGET)
+
+dev-load: dev-build
+	@so="$$(readlink -f "$(DEV_TARGET)")"; \
+	echo "loading $$so"; \
+	hyprctl plugin load "$$so"
+
+dev-reload: dev-build
+	@so="$$(readlink -f "$(DEV_TARGET)")"; \
+	echo "reloading $$so"; \
+	hyprctl plugin unload "$$so" >/dev/null 2>&1 || true; \
+	hyprctl plugin load "$$so"
+
+dev-nested:
+	./scripts/run-nested.sh
 
 install: $(TARGET)
-	sudo install -Dm755 $(TARGET) $(INSTALL_DIR)/$(INSTALL_NAME)
+	@echo "Installing for $(INSTALL_USER) into $(INSTALL_DIR)/$(INSTALL_NAME)"
+	install -Dm755 $(TARGET) $(INSTALL_DIR)/$(INSTALL_NAME)
 
 clean:
 	rm -f ./$(TARGET) ./$(TEST_TARGET) ./$(SOURCE_TEST_TARGET)
@@ -111,4 +137,4 @@ check-version:
 		|| { echo "::error::VERSION ($$file_ver) does not match tag ($$tag_ver)"; exit 1; }; \
 	echo "version aligned: $$file_ver"
 
-.PHONY: all clean install test version tag publish check-version
+.PHONY: all clean install test dev-build dev-load dev-reload dev-nested version tag publish check-version

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ $(TARGET): $(SRC) $(HEADERS) $(VERSION_FILE)
 	$(CXX) $(CXXFLAGS) $(EXTRA_FLAGS) $(VERSION_DEFINE) $(INCLUDES) $(SRC) -o $@ $(LIBS)
 
 install: $(TARGET)
-	install -Dm755 $(TARGET) $(INSTALL_DIR)/$(INSTALL_NAME)
+	sudo install -Dm755 $(TARGET) $(INSTALL_DIR)/$(INSTALL_NAME)
 
 clean:
 	rm -f ./$(TARGET) ./$(TEST_TARGET)

--- a/README.md
+++ b/README.md
@@ -53,14 +53,42 @@ cd hyprexpo
 make all
 ```
 
-Install the local build over the hyprpm-managed copy:
+For day-to-day development, prefer a disposable nested Hyprland session. This
+matches Hyprland's plugin development guidance: build the plugin, load it by
+absolute path with `hyprctl plugin load`, then unload and load again after
+changes.
+
+```bash
+./scripts/run-nested.sh
+```
+
+If you already have a disposable Hyprland session running, build to a
+user-owned cache path and load or reload that `.so` directly:
+
+```bash
+make dev-load
+make dev-reload
+```
+
+Only replace the hyprpm-managed copy when you intentionally want the installed
+plugin to point at this checkout's build:
 
 ```bash
 make install
 hyprpm reload
 ```
 
-Use `install` or `make install`, not plain `cp`, when replacing a loaded `.so`. Hyprland maps plugin files into the running process, and overwriting that file in place can corrupt the live mapping.
+If your distro or install path stores hyprpm artifacts under a root-owned cache,
+keep privilege at the command line instead of baking `sudo` into the Makefile:
+
+```bash
+sudo make install INSTALL_USER="$USER"
+hyprpm reload
+```
+
+Use `install` or `make install`, not plain `cp`, when replacing a loaded `.so`.
+Hyprland maps plugin files into the running process, and overwriting that file
+in place can corrupt the live mapping.
 
 Other build entry points:
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -45,10 +45,38 @@ cmake --build build
 
 ## Install a Local Build
 
-Install the Makefile build over the hyprpm-managed copy:
+For development, do not replace the hyprpm-managed copy first. Hyprland's
+plugin development docs recommend testing in a nested debug session and loading
+the built plugin by absolute path with `hyprctl plugin load`.
+
+Launch a disposable nested session that builds and loads a user-owned local
+plugin artifact:
+
+```bash
+./scripts/run-nested.sh
+```
+
+If you already have a disposable Hyprland session running, build to
+`${XDG_CACHE_HOME:-$HOME/.cache}/hyprexpo/hyprexpo.so` and load or reload it:
+
+```bash
+make dev-load
+make dev-reload
+```
+
+Only replace the hyprpm-managed copy when you intentionally want the installed
+plugin to point at this checkout's build:
 
 ```bash
 make install
+hyprpm reload
+```
+
+If the hyprpm artifact path is root-owned, keep the privilege at the command
+line and preserve the target user explicitly:
+
+```bash
+sudo make install INSTALL_USER="$USER"
 hyprpm reload
 ```
 
@@ -59,6 +87,8 @@ install -Dm755 hyprexpo.so \
     /var/cache/hyprpm/$USER/hyprexpo/hyprexpo.so
 hyprpm reload
 ```
+
+Use `sudo install ...` only if that destination is intentionally root-owned.
 
 ::: warning
 Use `install`, not plain `cp`, when replacing a loaded `.so`. Hyprland maps the plugin into the running process. Overwriting that file in place can corrupt the live mapping and crash the session.

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,4 +18,4 @@ HyprExpo uses modern `plugin:hyprexpo:*` configuration keys plus Lua helpers und
 
 ## Runtime Boundary
 
-HyprExpo is a shared object loaded by Hyprland. Build it against the Hyprland revision you run, and use `install` or `make install` when replacing a loaded plugin file so Hyprland does not keep a corrupted mapping.
+HyprExpo is a shared object loaded by Hyprland. Build it against the Hyprland revision you run, test local changes in a nested session or with `hyprctl plugin load /absolute/path/to/hyprexpo.so`, and use `install` or `make install` only when replacing an installed plugin file so Hyprland does not keep a corrupted mapping.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -18,7 +18,7 @@ Invalid `workspace_method` or border color values should be logged and fall back
 
 ## Replacing a Loaded Plugin Crashes Hyprland
 
-Use `make install` or `install` instead of overwriting the file with `cp`.
+For development, prefer `./scripts/run-nested.sh` or `make dev-reload` so Hyprland loads a fresh user-owned build by absolute path. If you intentionally replace an installed plugin file, use `make install` or `install` instead of overwriting the file with `cp`.
 
 ## Per-Monitor Placement Does Not Apply
 

--- a/scripts/dev-link.sh
+++ b/scripts/dev-link.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Link a cached local hyprexpo.so into the hyprpm-installed plugin path.
+# Link a cached local hyprexpo.so into a user-writable plugin path.
+# Prefer scripts/run-nested.sh or make dev-reload for normal development.
 #
 # Usage:
 #   ./scripts/dev-link.sh                 # auto-detect installed hyprexpo.so and symlink to cached build
@@ -10,8 +11,8 @@ set -euo pipefail
 #   ./scripts/dev-link.sh -r              # restore original file from .bak and remove symlink
 #
 # Notes:
-# - This script only affects your local user install if hyprpm installed to XDG_DATA_HOME.
-# - If your hyprexpo is system-wide, you may need sudo to replace it.
+# - This script only affects user-writable installs.
+# - Do not run this script with sudo; use make install for intentional system-cache replacement.
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd "$script_dir/.." && pwd)"
@@ -28,7 +29,8 @@ err() { echo "[dev-link] ERROR: $*" >&2; exit 1; }
 
 usage() {
   cat <<'EOF'
-Link a cached local hyprexpo.so into the hyprpm-installed plugin path.
+Link a cached local hyprexpo.so into a user-writable plugin path.
+For normal development, prefer ./scripts/run-nested.sh or make dev-reload.
 
 Usage:
   ./scripts/dev-link.sh                 # auto-detect installed hyprexpo.so and symlink to cached build
@@ -38,9 +40,27 @@ Usage:
 
 Notes:
 - Local builds default to ${XDG_CACHE_HOME:-$HOME/.cache}/hyprexpo/hyprexpo.so.
-- This script only affects your local user install if hyprpm installed to XDG_DATA_HOME.
-- If your hyprexpo is system-wide, you may need sudo to replace it.
+- This script only affects user-writable installs.
+- Do not run this script with sudo; use make install for intentional system-cache replacement.
 EOF
+}
+
+ensure_not_root() {
+  if [[ "${EUID:-$(id -u)}" -eq 0 ]]; then
+    err "Do not run this development linker as root. Use ./scripts/run-nested.sh, make dev-reload, or sudo make install INSTALL_USER=\$USER for intentional system-cache replacement."
+  fi
+}
+
+ensure_writable_target() {
+  local target="$1"
+  local target_dir
+  target_dir="$(dirname "$target")"
+
+  [[ -d "$target_dir" ]] || err "Target directory does not exist: $target_dir"
+  [[ -w "$target_dir" ]] || err "Target directory is not writable: $target_dir. Use ./scripts/run-nested.sh or make dev-reload for development; use sudo make install INSTALL_USER=\$USER only for intentional system-cache replacement."
+  if [[ -e "$target" && ! -w "$target" ]]; then
+    err "Target is not writable: $target. Use ./scripts/run-nested.sh or make dev-reload for development; use sudo make install INSTALL_USER=\$USER only for intentional system-cache replacement."
+  fi
 }
 
 detect_target() {
@@ -95,6 +115,8 @@ while (( "$#" )); do
     *) err "Unknown arg: $1" ;;
   esac
 done
+
+ensure_not_root
 
 if (( do_restore )); then
   if [[ -z "$target_so" ]]; then
@@ -183,6 +205,7 @@ fi
 [[ -n "$target_so" ]] || err "Could not detect hyprexpo.so. Pass -t /path/to/hyprexpo.so"
 
 msg "Target: $target_so"
+ensure_writable_target "$target_so"
 
 local_abs="$(readlink -f "$local_so")"
 target_abs="$(readlink -f "$target_so" 2>/dev/null || true)"


### PR DESCRIPTION
## Summary 
when running `make install`, it requires super user privileges so it can change /var/cache/hyprpm/$USER/hyprexpo/hyprexpo.so 

when running `sudo make install` it runs make as sudo, so it sets $USER to root instead of the actual user.

adding sudo in the Makefile install section fixes the issue, because make itself is not running as sudo, only the install command

## Verification
- `make all` 
- `make install`
- `ls -l /var/cache/hyprpm/$USER/hyprexpo/hyprexpo.so` see the timestamp to check if it was updated 

 