### PR TITLE
Add active workspace overview mode

### DIFF
--- a/Dispatchers.cpp
+++ b/Dispatchers.cpp
@@ -435,7 +435,7 @@ static SDispatchResult onExpoDispatcher(std::string arg) {
 
     if (arg == "toggle") {
         if (g_pOverview)
-            g_pOverview->close();
+            g_pOverview->close(false);
         else {
             const auto PMONITOR = State::monitorState()->query().vec(g_pInputManager->getMouseCoordsInternal()).run();
             if (!PMONITOR)
@@ -455,7 +455,7 @@ static SDispatchResult onExpoDispatcher(std::string arg) {
 
     if (arg == "off" || arg == "close" || arg == "disable") {
         if (g_pOverview)
-            g_pOverview->close();
+            g_pOverview->close(false);
         return {};
     }
 

--- a/HyprexpoConfig.hpp
+++ b/HyprexpoConfig.hpp
@@ -1,6 +1,24 @@
 #pragma once
 
 namespace HyprexpoConfig {
+// PR #605 compatibility defaults kept separate from the richer sandwichfarm
+// runtime options below. These values are registered for later integration and
+// must not replace the newer config surface.
+inline constexpr int         LEGACY_DYNAMIC_GRID_DEFAULT         = 0;
+inline constexpr int         LEGACY_FILL_GAPS_DEFAULT            = 0;
+inline constexpr int         LEGACY_MRU_SORT_DEFAULT             = 0;
+inline constexpr unsigned    LEGACY_ACTIVE_HIGHLIGHT_COL_DEFAULT = 0xFF3584E4;
+inline constexpr int         LEGACY_ACTIVE_HIGHLIGHT_BORDER_DEFAULT = 2;
+inline constexpr unsigned    LEGACY_HOVER_HIGHLIGHT_COL_DEFAULT  = 0x80FFFFFF;
+inline constexpr int         LEGACY_HOVER_HIGHLIGHT_BORDER_DEFAULT = 2;
+inline constexpr const char* LEGACY_LABEL_POS_DEFAULT            = "top_right";
+inline constexpr int         LEGACY_LABEL_SIZE_DEFAULT           = 36;
+inline constexpr unsigned    LEGACY_LABEL_COL_DEFAULT            = 0xFFFFFFFF;
+inline constexpr int         LEGACY_SHOW_WORKSPACE_NAMES_DEFAULT = 0;
+inline constexpr int         LEGACY_ENABLE_KEYBOARD_NAV_DEFAULT  = 1;
+inline constexpr int         LEGACY_ENABLE_DRAG_MOVE_DEFAULT     = 0;
+inline constexpr int         LEGACY_ANIMATE_ENTRY_DEFAULT        = 0;
+
 inline constexpr int         COLUMNS_DEFAULT                 = 3;
 inline constexpr int         COLUMNS_MIN                     = 1;
 inline constexpr int         COLUMNS_MAX                     = 7;

--- a/HyprexpoConfig.hpp
+++ b/HyprexpoConfig.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstddef>
+
 namespace HyprexpoConfig {
 // PR #605 compatibility defaults kept separate from the richer sandwichfarm
 // runtime options below. These values are registered for later integration and
@@ -19,6 +21,7 @@ inline constexpr int         LEGACY_ENABLE_KEYBOARD_NAV_DEFAULT  = 1;
 inline constexpr int         LEGACY_ENABLE_DRAG_MOVE_DEFAULT     = 0;
 inline constexpr int         LEGACY_ANIMATE_ENTRY_DEFAULT        = 0;
 inline constexpr int         WALLPAPER_BG_DEFAULT                = 0;
+inline constexpr std::size_t DYNAMIC_GRID_MAX_TILES              = 64;
 
 inline constexpr int         COLUMNS_DEFAULT                 = 3;
 inline constexpr int         COLUMNS_MIN                     = 1;

--- a/HyprexpoConfig.hpp
+++ b/HyprexpoConfig.hpp
@@ -18,6 +18,7 @@ inline constexpr int         LEGACY_SHOW_WORKSPACE_NAMES_DEFAULT = 0;
 inline constexpr int         LEGACY_ENABLE_KEYBOARD_NAV_DEFAULT  = 1;
 inline constexpr int         LEGACY_ENABLE_DRAG_MOVE_DEFAULT     = 0;
 inline constexpr int         LEGACY_ANIMATE_ENTRY_DEFAULT        = 0;
+inline constexpr int         WALLPAPER_BG_DEFAULT                = 0;
 
 inline constexpr int         COLUMNS_DEFAULT                 = 3;
 inline constexpr int         COLUMNS_MIN                     = 1;

--- a/HyprexpoLogic.cpp
+++ b/HyprexpoLogic.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <charconv>
 #include <cctype>
+#include <cmath>
 
 namespace Hyprexpo {
 
@@ -38,6 +39,84 @@ std::vector<std::string> splitCommaList(const std::string& value) {
     }
 
     return entries;
+}
+
+SGridShape computeDynamicGridShape(int visibleCount) {
+    if (visibleCount <= 0)
+        return {1, 1};
+
+    const int cols = std::max(1, static_cast<int>(std::ceil(std::sqrt(static_cast<double>(visibleCount)))));
+    int       rows = static_cast<int>(std::ceil(static_cast<double>(visibleCount) / cols));
+    if (visibleCount > 1 && rows < 2)
+        rows = 2;
+
+    return {cols, rows};
+}
+
+SSize aspectCorrectTileSize(double screenW, double screenH, int cols, int rows, double gap) {
+    if (screenW <= 0.0 || screenH <= 0.0 || cols <= 0 || rows <= 0)
+        return {};
+
+    const double safeGap = std::max(0.0, gap);
+    const double monAspect = screenW / screenH;
+    const double maxTileW  = std::max(0.0, (screenW - safeGap * (cols - 1)) / cols);
+    const double maxTileH  = std::max(0.0, (screenH - safeGap * (rows - 1)) / rows);
+
+    if (maxTileW <= 0.0 || maxTileH <= 0.0 || monAspect <= 0.0)
+        return {0.0, 0.0};
+
+    const double cellAspect = maxTileW / maxTileH;
+    if (cellAspect > monAspect)
+        return {maxTileH * monAspect, maxTileH};
+
+    return {maxTileW, maxTileW / monAspect};
+}
+
+STileLayout computeTileLayout(int index, int visibleCount, SGridShape shape, SSize total, double gap, bool centerPartialRows) {
+    STileLayout layout;
+
+    if (visibleCount <= 0 || index < 0 || index >= visibleCount)
+        return layout;
+
+    shape.cols = std::max(1, shape.cols);
+    shape.rows = std::max(1, shape.rows);
+
+    const SSize tileSize = aspectCorrectTileSize(total.w, total.h, shape.cols, shape.rows, gap);
+    const int   row      = index / shape.cols;
+    const int   col      = index % shape.cols;
+
+    const int    occupiedRows = std::max(1, static_cast<int>(std::ceil(static_cast<double>(visibleCount) / shape.cols)));
+    const int    lastRow      = occupiedRows - 1;
+    const int    tilesInLastRow = visibleCount % shape.cols == 0 ? shape.cols : visibleCount % shape.cols;
+    const double stepX        = tileSize.w + gap;
+    const double stepY        = tileSize.h + gap;
+    const double gridW        = shape.cols * tileSize.w + (shape.cols - 1) * gap;
+    const double gridH        = occupiedRows * tileSize.h + (occupiedRows - 1) * gap;
+    const double baseX        = (total.w - gridW) / 2.0;
+    const double baseY        = (total.h - gridH) / 2.0;
+
+    double x = baseX + col * stepX;
+    const double y = baseY + row * stepY;
+
+    if (centerPartialRows && row == lastRow && tilesInLastRow < shape.cols) {
+        const double rowW = tilesInLastRow * tileSize.w + (tilesInLastRow - 1) * gap;
+        x                 = (total.w - rowW) / 2.0 + col * stepX;
+    }
+
+    layout.box = {x, y, tileSize.w, tileSize.h};
+    layout.row = row;
+    layout.col = col;
+    return layout;
+}
+
+int tileIndexAtPoint(double x, double y, int visibleCount, SGridShape shape, SSize total, double gap, bool centerPartialRows) {
+    for (int i = 0; i < visibleCount; ++i) {
+        const auto layout = computeTileLayout(i, visibleCount, shape, total, gap, centerPartialRows);
+        if (x >= layout.box.x && x < layout.box.x + layout.box.w && y >= layout.box.y && y < layout.box.y + layout.box.h)
+            return i;
+    }
+
+    return -1;
 }
 
 int clampGridColumns(int columns) {

--- a/HyprexpoLogic.cpp
+++ b/HyprexpoLogic.cpp
@@ -53,6 +53,31 @@ SGridShape computeDynamicGridShape(int visibleCount) {
     return {cols, rows};
 }
 
+std::optional<std::vector<int64_t>> expandDynamicWorkspaceIDs(const std::vector<int64_t>& workspaceIDs, bool fillGaps, std::size_t maxExpandedWorkspaces) {
+    std::vector<int64_t> normalized = workspaceIDs;
+    std::sort(normalized.begin(), normalized.end());
+    normalized.erase(std::unique(normalized.begin(), normalized.end()), normalized.end());
+
+    if (!fillGaps || normalized.empty())
+        return normalized;
+    if (maxExpandedWorkspaces == 0)
+        return std::nullopt;
+
+    const int64_t  minID = normalized.front();
+    const int64_t  maxID = normalized.back();
+    const __int128 expandedCountWide = static_cast<__int128>(maxID) - static_cast<__int128>(minID) + 1;
+    if (expandedCountWide <= 0 || expandedCountWide > static_cast<__int128>(maxExpandedWorkspaces))
+        return std::nullopt;
+
+    const std::size_t expandedCount = static_cast<std::size_t>(expandedCountWide);
+    std::vector<int64_t> expanded;
+    expanded.reserve(expandedCount);
+    for (std::size_t offset = 0; offset < expandedCount; ++offset)
+        expanded.push_back(minID + static_cast<int64_t>(offset));
+
+    return expanded;
+}
+
 SSize aspectCorrectTileSize(double screenW, double screenH, int cols, int rows, double gap) {
     if (screenW <= 0.0 || screenH <= 0.0 || cols <= 0 || rows <= 0)
         return {};
@@ -303,6 +328,30 @@ SGradientSpec parseGradientSpec(const std::string& value) {
 bool isGradientBorderSpec(const std::string& value) {
     const auto first = value.find("rgba(");
     return first != std::string::npos && value.find("rgba(", first + 1) != std::string::npos;
+}
+
+bool shouldShowWorkspaceLabel(bool labelEnabled, const std::string& labelShow, bool isHovered, bool isFocused, bool isCurrent) {
+    if (!labelEnabled)
+        return false;
+
+    const auto mode = lowerString(trimString(labelShow));
+    if (mode == "never")
+        return false;
+    if (mode == "hover")
+        return isHovered;
+    if (mode == "focus")
+        return isFocused;
+    if (mode == "hover+focus")
+        return isHovered || isFocused;
+    if (mode == "current+focus")
+        return isCurrent || isFocused;
+
+    return true;
+}
+
+std::string resolveBorderSpec(const std::string& modernSpec, const std::string& legacySpec) {
+    const auto modern = trimString(modernSpec);
+    return modern.empty() ? trimString(legacySpec) : modern;
 }
 
 static std::vector<std::string> splitWhitespace(const std::string& value) {

--- a/HyprexpoLogic.hpp
+++ b/HyprexpoLogic.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstddef>
+#include <cstdint>
 #include <optional>
 #include <string>
 #include <vector>
@@ -81,6 +83,7 @@ std::string lowerString(std::string value);
 std::vector<std::string> splitCommaList(const std::string& value);
 
 SGridShape               computeDynamicGridShape(int visibleCount);
+std::optional<std::vector<int64_t>> expandDynamicWorkspaceIDs(const std::vector<int64_t>& workspaceIDs, bool fillGaps, std::size_t maxExpandedWorkspaces);
 SSize                    aspectCorrectTileSize(double screenW, double screenH, int cols, int rows, double gap);
 STileLayout              computeTileLayout(int index, int visibleCount, SGridShape shape, SSize total, double gap, bool centerPartialRows);
 int                      tileIndexAtPoint(double x, double y, int visibleCount, SGridShape shape, SSize total, double gap, bool centerPartialRows);
@@ -96,6 +99,8 @@ bool                     parseHexRGBA8(const std::string& value, SColorRGBA& out
 bool                     parseSolidColorSpec(const std::string& value, SColorRGBA& out);
 SGradientSpec            parseGradientSpec(const std::string& value);
 bool                     isGradientBorderSpec(const std::string& value);
+bool                     shouldShowWorkspaceLabel(bool labelEnabled, const std::string& labelShow, bool isHovered, bool isFocused, bool isCurrent);
+std::string              resolveBorderSpec(const std::string& modernSpec, const std::string& legacySpec);
 
 SWorkspaceMethodSpec     parseWorkspaceMethodSpec(const std::string& method);
 SWorkspaceMethodSpec     resolveWorkspaceMethodForMonitor(const std::string& config, const std::string& monitorName);

--- a/HyprexpoLogic.hpp
+++ b/HyprexpoLogic.hpp
@@ -49,25 +49,41 @@ struct SRect {
     double h = 0.0;
 };
 
+struct SGridShape {
+    int cols = 1;
+    int rows = 1;
+};
+
+struct STileLayout {
+    SRect box;
+    int   row = -1;
+    int   col = -1;
+};
+
 struct SDropIntentInput {
-    bool   targetValid        = false;
-    SPoint pointerLocal       = {};
-    SRect  targetTileLocal    = {};
-    SSize  workspaceSize      = {};
-    SSize  windowSize         = {};
-    SPoint grabOffset         = {};
-    double minProxySize       = 24.0;
+    bool   targetValid     = false;
+    SPoint pointerLocal    = {};
+    SRect  targetTileLocal = {};
+    SSize  workspaceSize   = {};
+    SSize  windowSize      = {};
+    SPoint grabOffset      = {};
+    double minProxySize    = 24.0;
 };
 
 struct SDropIntentGeometry {
-    bool   valid                = false;
+    bool   valid               = false;
     SPoint targetWorkspacePoint = {};
     SRect  targetProxyLocal     = {};
 };
 
-std::string              trimString(std::string value);
-std::string              lowerString(std::string value);
+std::string trimString(std::string value);
+std::string lowerString(std::string value);
 std::vector<std::string> splitCommaList(const std::string& value);
+
+SGridShape               computeDynamicGridShape(int visibleCount);
+SSize                    aspectCorrectTileSize(double screenW, double screenH, int cols, int rows, double gap);
+STileLayout              computeTileLayout(int index, int visibleCount, SGridShape shape, SSize total, double gap, bool centerPartialRows);
+int                      tileIndexAtPoint(double x, double y, int visibleCount, SGridShape shape, SSize total, double gap, bool centerPartialRows);
 
 int                      clampGridColumns(int columns);
 int                      tileIndexFromPoint(double x, double y, double width, double height, int sideLength);

--- a/Overview.cpp
+++ b/Overview.cpp
@@ -847,15 +847,13 @@ COverview::COverview(PHLWORKSPACE startedOn_, bool swipe_) : startedOn(startedOn
         if (visibleWorkspaceIDs.empty() && currentWorkspaceID != WORKSPACE_INVALID)
             visibleWorkspaceIDs.push_back(currentWorkspaceID);
 
-        std::sort(visibleWorkspaceIDs.begin(), visibleWorkspaceIDs.end());
-        visibleWorkspaceIDs.erase(std::unique(visibleWorkspaceIDs.begin(), visibleWorkspaceIDs.end()), visibleWorkspaceIDs.end());
-
-        if (**PFILLGAPS && !visibleWorkspaceIDs.empty()) {
-            const int64_t minID = visibleWorkspaceIDs.front();
-            const int64_t maxID = visibleWorkspaceIDs.back();
-            visibleWorkspaceIDs.clear();
-            for (int64_t id = minID; id <= maxID; ++id)
-                visibleWorkspaceIDs.push_back(id);
+        const auto expandedWorkspaceIDs =
+            Hyprexpo::expandDynamicWorkspaceIDs(visibleWorkspaceIDs, **PFILLGAPS, HyprexpoConfig::DYNAMIC_GRID_MAX_TILES);
+        if (expandedWorkspaceIDs)
+            visibleWorkspaceIDs = *expandedWorkspaceIDs;
+        else {
+            visibleWorkspaceIDs = *Hyprexpo::expandDynamicWorkspaceIDs(visibleWorkspaceIDs, false, HyprexpoConfig::DYNAMIC_GRID_MAX_TILES);
+            Log::logger->log(Log::ERR, "[hyprexpo] fill_gaps range exceeds {} tiles; using sparse workspace IDs", HyprexpoConfig::DYNAMIC_GRID_MAX_TILES);
         }
 
         if (**PMRUSORT) {

--- a/Overview.cpp
+++ b/Overview.cpp
@@ -732,6 +732,7 @@ COverview::COverview(PHLWORKSPACE startedOn_, bool swipe_) : startedOn(startedOn
     static auto* const* PMRUSORT  = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:mru_sort")->getDataStaticPtr();
     static auto* const* PSHNAMES  = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:show_workspace_names")->getDataStaticPtr();
     static auto* const* PANIMATE  = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:animate_entry")->getDataStaticPtr();
+    static auto* const* PWALLBG   = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:wallpaper_bg")->getDataStaticPtr();
 
     createdAt            = std::chrono::steady_clock::now();
     SIDE_LENGTH          = Hyprexpo::clampGridColumns(**PCOLUMNS);
@@ -741,6 +742,7 @@ COverview::COverview(PHLWORKSPACE startedOn_, bool swipe_) : startedOn(startedOn
     showWorkspaceNumbers = **PSHOWNUM;
     showWorkspaceNames   = **PSHNAMES;
     animateEntry         = **PANIMATE;
+    wallpaperBg          = **PWALLBG;
     dynamicGrid          = **PDYNAMIC;
 
     // Get workspace method for this specific monitor

--- a/Overview.cpp
+++ b/Overview.cpp
@@ -654,6 +654,57 @@ static std::pair<bool, int> getWorkspaceMethodForMonitor(PHLMONITOR monitor) {
     return {methodCenter, methodStartID};
 }
 
+Hyprexpo::SGridShape COverview::currentGridShape() const {
+    if (dynamicGrid)
+        return gridShape;
+
+    return {SIDE_LENGTH, SIDE_LENGTH};
+}
+
+double COverview::currentOuterInset() const {
+    const auto MON = pMonitor.lock();
+    if (!MON)
+        return 0.0;
+
+    static auto* const* PGAPSO = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:gaps_out")->getDataStaticPtr();
+    const double        percent = closing ? (1.0 - size->getPercent()) : size->getPercent();
+    return std::max<Hyprlang::INT>(0, **PGAPSO) * percent;
+}
+
+Hyprexpo::STileLayout COverview::tileLayoutForIndex(int id, const Vector2D& totalSize, double gap, double outerInset, bool centerPartialRows) const {
+    const auto shape = currentGridShape();
+    const Hyprexpo::SSize total{std::max(0.0, totalSize.x - outerInset * 2.0), std::max(0.0, totalSize.y - outerInset * 2.0)};
+    auto                  layout = Hyprexpo::computeTileLayout(id, (int)images.size(), shape, total, gap, centerPartialRows);
+    layout.box.x += outerInset;
+    layout.box.y += outerInset;
+    return layout;
+}
+
+CBox COverview::tileBoxForIndex(int id, const Vector2D& totalSize, double gap, double outerInset, bool centerPartialRows) const {
+    const auto layout = tileLayoutForIndex(id, totalSize, gap, outerInset, centerPartialRows);
+    return {layout.box.x, layout.box.y, layout.box.w, layout.box.h};
+}
+
+int COverview::tileIndexAtPoint(const Vector2D& point, const Vector2D& totalSize, double gap, double outerInset, bool centerPartialRows) const {
+    const auto shape = currentGridShape();
+    const Hyprexpo::SSize total{std::max(0.0, totalSize.x - outerInset * 2.0), std::max(0.0, totalSize.y - outerInset * 2.0)};
+    return Hyprexpo::tileIndexAtPoint(point.x - outerInset, point.y - outerInset, (int)images.size(), shape, total, gap, centerPartialRows);
+}
+
+Vector2D COverview::tilePosForID(int id, const Vector2D& totalSize, double gap, double outerInset, bool centerPartialRows) const {
+    const auto box = tileBoxForIndex(id, totalSize, gap, outerInset, centerPartialRows);
+    return {box.x, box.y};
+}
+
+Vector2D COverview::zoomSizeForCurrentGrid(const Vector2D& monitorSize) const {
+    const auto shape = currentGridShape();
+    const auto tileSize = Hyprexpo::aspectCorrectTileSize(monitorSize.x, monitorSize.y, shape.cols, shape.rows, 0.0);
+    if (tileSize.w <= 0.0 || tileSize.h <= 0.0)
+        return monitorSize;
+
+    return {monitorSize.x * monitorSize.x / tileSize.w, monitorSize.y * monitorSize.y / tileSize.h};
+}
+
 COverview::~COverview() {
     Render::GL::g_pHyprOpenGL->makeEGLCurrent();
     images.clear(); // otherwise we get a vram leak
@@ -670,17 +721,27 @@ COverview::COverview(PHLWORKSPACE startedOn_, bool swipe_) : startedOn(startedOn
     const auto PMONITOR = State::monitorState()->query().vec(g_pInputManager->getMouseCoordsInternal()).run();
     pMonitor            = PMONITOR;
 
-    static auto* const* PCOLUMNS = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:columns")->getDataStaticPtr();
-    static auto* const* PGAPS    = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:gaps_in")->getDataStaticPtr();
-    static auto* const* PCOL     = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:bg_col")->getDataStaticPtr();
-    static auto* const* PSKIP    = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:skip_empty")->getDataStaticPtr();
-    static auto* const* PMAXWS   = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:max_workspace")->getDataStaticPtr();
-    static auto* const* PSHOWNUM = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:show_workspace_numbers")->getDataStaticPtr();
+    static auto* const* PCOLUMNS  = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:columns")->getDataStaticPtr();
+    static auto* const* PGAPS     = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:gaps_in")->getDataStaticPtr();
+    static auto* const* PCOL      = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:bg_col")->getDataStaticPtr();
+    static auto* const* PSKIP     = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:skip_empty")->getDataStaticPtr();
+    static auto* const* PMAXWS    = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:max_workspace")->getDataStaticPtr();
+    static auto* const* PSHOWNUM  = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:show_workspace_numbers")->getDataStaticPtr();
+    static auto* const* PDYNAMIC  = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:dynamic_grid")->getDataStaticPtr();
+    static auto* const* PFILLGAPS = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:fill_gaps")->getDataStaticPtr();
+    static auto* const* PMRUSORT  = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:mru_sort")->getDataStaticPtr();
+    static auto* const* PSHNAMES  = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:show_workspace_names")->getDataStaticPtr();
+    static auto* const* PANIMATE  = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:animate_entry")->getDataStaticPtr();
 
+    createdAt            = std::chrono::steady_clock::now();
     SIDE_LENGTH          = Hyprexpo::clampGridColumns(**PCOLUMNS);
+    gridShape            = {SIDE_LENGTH, SIDE_LENGTH};
     GAP_WIDTH            = std::max<Hyprlang::INT>(0, **PGAPS);
     BG_COLOR             = **PCOL;
     showWorkspaceNumbers = **PSHOWNUM;
+    showWorkspaceNames   = **PSHNAMES;
+    animateEntry         = **PANIMATE;
+    dynamicGrid          = **PDYNAMIC;
 
     // Get workspace method for this specific monitor
     auto [methodCenter, methodStartID] = getWorkspaceMethodForMonitor(pMonitor.lock());
@@ -727,7 +788,7 @@ COverview::COverview(PHLWORKSPACE startedOn_, bool swipe_) : startedOn(startedOn
         // Scan through workspaces higher than methodStartID. If using "m"
         // (skip_empty), stop when we wrap, leaving the rest of the workspace
         // ID's set to WORKSPACE_INVALID
-        for (size_t i = 0; i < (size_t)(SIDE_LENGTH * SIDE_LENGTH); ++i) {
+        for (size_t i = 0; i < images.size(); ++i) {
             auto& image = images[i];
             if ((int64_t)i - backtracked < 0) {
                 currentID = getWorkspaceIDNameFromString(selector + std::to_string((int64_t)i - backtracked)).id;
@@ -769,10 +830,51 @@ COverview::COverview(PHLWORKSPACE startedOn_, bool swipe_) : startedOn(startedOn
         pMonitor->m_activeWorkspace = startedOn;
     }
 
+    if (dynamicGrid) {
+        std::vector<int64_t> visibleWorkspaceIDs;
+        const auto MON = pMonitor.lock();
+        const int64_t currentWorkspaceID = startedOn ? startedOn->m_id : (MON ? MON->activeWorkspaceID() : WORKSPACE_INVALID);
+
+        for (const auto& workspace : State::workspaceState()->workspacesCopy()) {
+            if (!workspace || workspace->m_isSpecialWorkspace || workspace->m_monitor != MON || workspace->getWindowCount() <= 0)
+                continue;
+
+            visibleWorkspaceIDs.push_back(workspace->m_id);
+        }
+
+        if (visibleWorkspaceIDs.empty() && currentWorkspaceID != WORKSPACE_INVALID)
+            visibleWorkspaceIDs.push_back(currentWorkspaceID);
+
+        std::sort(visibleWorkspaceIDs.begin(), visibleWorkspaceIDs.end());
+        visibleWorkspaceIDs.erase(std::unique(visibleWorkspaceIDs.begin(), visibleWorkspaceIDs.end()), visibleWorkspaceIDs.end());
+
+        if (**PFILLGAPS && !visibleWorkspaceIDs.empty()) {
+            const int64_t minID = visibleWorkspaceIDs.front();
+            const int64_t maxID = visibleWorkspaceIDs.back();
+            visibleWorkspaceIDs.clear();
+            for (int64_t id = minID; id <= maxID; ++id)
+                visibleWorkspaceIDs.push_back(id);
+        }
+
+        if (**PMRUSORT) {
+            const auto it = std::find(visibleWorkspaceIDs.begin(), visibleWorkspaceIDs.end(), currentWorkspaceID);
+            if (it != visibleWorkspaceIDs.end() && it != visibleWorkspaceIDs.begin()) {
+                const auto current = *it;
+                visibleWorkspaceIDs.erase(it);
+                visibleWorkspaceIDs.insert(visibleWorkspaceIDs.begin(), current);
+            }
+        }
+
+        gridShape = Hyprexpo::computeDynamicGridShape((int)visibleWorkspaceIDs.size());
+        SIDE_LENGTH = gridShape.cols;
+        images.resize(visibleWorkspaceIDs.size());
+        for (size_t i = 0; i < visibleWorkspaceIDs.size(); ++i)
+            images[i].workspaceID = visibleWorkspaceIDs[i];
+    }
+
     Render::GL::g_pHyprOpenGL->makeEGLCurrent();
 
-    Vector2D tileSize       = pMonitor->m_size / SIDE_LENGTH;
-    Vector2D tileRenderSize = (pMonitor->m_size - Vector2D{GAP_WIDTH * pMonitor->m_scale, GAP_WIDTH * pMonitor->m_scale} * (SIDE_LENGTH - 1)) / SIDE_LENGTH;
+    Vector2D tileSize = pMonitor->m_size / SIDE_LENGTH;
     CBox     monbox{0, 0, tileSize.x * 2, tileSize.y * 2};
 
     if (!ENABLE_LOWRES)
@@ -809,7 +911,7 @@ COverview::COverview(PHLWORKSPACE startedOn_, bool swipe_) : startedOn(startedOn
 
     startedOn->m_visible = false;
 
-    for (size_t i = 0; i < (size_t)(SIDE_LENGTH * SIDE_LENGTH); ++i) {
+    for (size_t i = 0; i < images.size(); ++i) {
         COverview::SWorkspaceImage& image = images[i];
         ensureFramebuffer(image, monbox, framebufferFormatWithAlpha(PMONITOR->m_output->state->state().drmFormat));
 
@@ -855,8 +957,7 @@ COverview::COverview(PHLWORKSPACE startedOn_, bool swipe_) : startedOn(startedOn
             g_pHyprRenderer->renderWorkspace(PMONITOR, PWORKSPACE, Time::steadyNow(), monbox);
         }
 
-        image.box = {(i % SIDE_LENGTH) * tileRenderSize.x + (i % SIDE_LENGTH) * GAP_WIDTH, (i / SIDE_LENGTH) * tileRenderSize.y + (i / SIDE_LENGTH) * GAP_WIDTH, tileRenderSize.x,
-                     tileRenderSize.y};
+        image.box = tileBoxForIndex((int)i, pMonitor->m_size, GAP_WIDTH, 0.0, true);
 
         g_pHyprRenderer->m_renderData.blockScreenShader = true;
         g_pHyprRenderer->endRender();
@@ -881,10 +982,9 @@ COverview::COverview(PHLWORKSPACE startedOn_, bool swipe_) : startedOn(startedOn
     // zoom on the current workspace.
     // const auto& TILE = images[std::clamp(currentid, 0, SIDE_LENGTH * SIDE_LENGTH)];
 
-    Animation::mgr()->createAnimation(pMonitor->m_size * pMonitor->m_size / tileSize, size, Config::animationTree()->getAnimationPropertyConfig("windowsMove"), AVARDAMAGE_NONE);
-    Animation::mgr()->createAnimation((-((pMonitor->m_size / (double)SIDE_LENGTH) * Vector2D{currentid % SIDE_LENGTH, currentid / SIDE_LENGTH}) * pMonitor->m_scale) *
-                                             (pMonitor->m_size / tileSize),
-                                         pos, Config::animationTree()->getAnimationPropertyConfig("windowsMove"), AVARDAMAGE_NONE);
+    const auto initSize = zoomSizeForCurrentGrid(pMonitor->m_size);
+    Animation::mgr()->createAnimation(initSize, size, Config::animationTree()->getAnimationPropertyConfig("windowsMove"), AVARDAMAGE_NONE);
+    Animation::mgr()->createAnimation(-(tilePosForID(currentid, initSize, 0.0) * pMonitor->m_scale), pos, Config::animationTree()->getAnimationPropertyConfig("windowsMove"), AVARDAMAGE_NONE);
 
     size->setUpdateCallback(damageMonitor);
     pos->setUpdateCallback(damageMonitor);

--- a/Overview.hpp
+++ b/Overview.hpp
@@ -162,6 +162,7 @@ class COverview {
     bool                         showWorkspaceNumbers = false;
     bool                         showWorkspaceNames = false;
     bool                         animateEntry = false;
+    bool                         wallpaperBg = false;
     std::chrono::steady_clock::time_point createdAt;
 
     friend class COverviewPassElement;

--- a/Overview.hpp
+++ b/Overview.hpp
@@ -10,6 +10,7 @@
 #include <hyprland/src/helpers/AnimatedVariable.hpp>
 #include <hyprland/src/helpers/signal/Signal.hpp>
 #include <hyprland/src/managers/eventLoop/EventLoopTimer.hpp>
+#include <chrono>
 #include <string>
 #include <vector>
 
@@ -85,6 +86,13 @@ class COverview {
     void       redrawAll(bool forcelowres = false);
     void       onWorkspaceChange();
     void       fullRender();
+    Hyprexpo::SGridShape currentGridShape() const;
+    double     currentOuterInset() const;
+    Hyprexpo::STileLayout tileLayoutForIndex(int id, const Vector2D& totalSize, double gap, double outerInset = 0.0, bool centerPartialRows = true) const;
+    CBox       tileBoxForIndex(int id, const Vector2D& totalSize, double gap, double outerInset = 0.0, bool centerPartialRows = true) const;
+    int        tileIndexAtPoint(const Vector2D& point, const Vector2D& totalSize, double gap, double outerInset = 0.0, bool centerPartialRows = true) const;
+    Vector2D   tilePosForID(int id, const Vector2D& totalSize, double gap, double outerInset = 0.0, bool centerPartialRows = true) const;
+    Vector2D   zoomSizeForCurrentGrid(const Vector2D& monitorSize) const;
     void       updateHoveredFromMouse();
     void       ensureKbFocusInitialized();
     bool       isTileValid(int id) const;
@@ -104,6 +112,8 @@ class COverview {
     void       resetSubmapIfNeeded();
 
     int        SIDE_LENGTH = 3;
+    bool       dynamicGrid = false;
+    Hyprexpo::SGridShape gridShape{3, 3};
     int        GAP_WIDTH   = 5;
     CHyprColor BG_COLOR    = CHyprColor{0.1, 0.1, 0.1, 1.0};
 
@@ -150,6 +160,9 @@ class COverview {
     bool                         swipe             = false;
     bool                         swipeWasCommenced = false;
     bool                         showWorkspaceNumbers = false;
+    bool                         showWorkspaceNames = false;
+    bool                         animateEntry = false;
+    std::chrono::steady_clock::time_point createdAt;
 
     friend class COverviewPassElement;
 };

--- a/OverviewInteraction.cpp
+++ b/OverviewInteraction.cpp
@@ -20,7 +20,7 @@ void COverview::selectHoveredWorkspace() {
         return;
 
     updateHoveredFromMouse();
-    closeOnID = std::clamp(hoveredID, 0, SIDE_LENGTH * SIDE_LENGTH - 1);
+    closeOnID = hoveredID >= 0 && hoveredID < (int)images.size() ? hoveredID : -1;
 }
 
 int64_t COverview::selectedWorkspaceID() const {
@@ -71,7 +71,7 @@ void COverview::updateHoveredFromMouse() {
     if (!MON)
         return;
 
-    const int newHoveredID = Hyprexpo::tileIndexFromPoint(lastMousePosLocal.x, lastMousePosLocal.y, MON->m_size.x, MON->m_size.y, SIDE_LENGTH);
+    const int newHoveredID = tileIndexAtPoint(lastMousePosLocal, size->value(), GAP_WIDTH, currentOuterInset(), true);
     if (newHoveredID == hoveredID)
         return;
 
@@ -131,13 +131,12 @@ Vector2D COverview::tilePointToWorkspacePoint(int id, const Vector2D& localPoint
     if (!MON)
         return {};
 
-    const Vector2D tileSize = MON->m_size / SIDE_LENGTH;
-    const Vector2D tilePos  = tileSize * Vector2D{id % SIDE_LENGTH, id / SIDE_LENGTH};
-    const Vector2D inTile   = localPoint - tilePos;
+    const auto tileBox = tileBoxForIndex(id, size->value(), GAP_WIDTH, currentOuterInset(), true);
+    const Vector2D inTile = localPoint - Vector2D{tileBox.x, tileBox.y};
 
     return MON->m_position + Vector2D{
-        std::clamp(inTile.x / tileSize.x, 0.0, 1.0) * MON->m_size.x,
-        std::clamp(inTile.y / tileSize.y, 0.0, 1.0) * MON->m_size.y,
+        std::clamp(inTile.x / std::max(1.0, tileBox.w), 0.0, 1.0) * MON->m_size.x,
+        std::clamp(inTile.y / std::max(1.0, tileBox.h), 0.0, 1.0) * MON->m_size.y,
     };
 }
 
@@ -436,8 +435,9 @@ void COverview::moveFocus(int dx, int dy) {
     if (kbFocusID == -1)
         return;
 
-    int x = kbFocusID % SIDE_LENGTH;
-    int y = kbFocusID / SIDE_LENGTH;
+    const auto shape = currentGridShape();
+    int x = kbFocusID % shape.cols;
+    int y = kbFocusID / shape.cols;
 
     static auto* const* PWRAPH = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:keynav_wrap_h")->getDataStaticPtr();
     static auto* const* PWRAPV = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:keynav_wrap_v")->getDataStaticPtr();
@@ -447,7 +447,7 @@ void COverview::moveFocus(int dx, int dy) {
         int                 step     = dx > 0 ? 1 : -1;
         if (**PREADING) {
             // reading-order scan: proceed linearly across the grid (row-major)
-            const int total = SIDE_LENGTH * SIDE_LENGTH;
+            const int total = (int)images.size();
             int       idx   = kbFocusID;
             for (int tries = 0; tries < total; ++tries) {
                 idx += step;
@@ -466,15 +466,15 @@ void COverview::moveFocus(int dx, int dy) {
         } else {
             // in-row scan with optional horizontal wrap
             int nx = x;
-            for (int tries = 0; tries < SIDE_LENGTH; ++tries) {
+            for (int tries = 0; tries < shape.cols; ++tries) {
                 nx += step;
-                if (nx < 0 || nx >= SIDE_LENGTH) {
+                if (nx < 0 || nx >= shape.cols) {
                     if (**PWRAPH)
-                        nx = (nx + SIDE_LENGTH) % SIDE_LENGTH;
+                        nx = (nx + shape.cols) % shape.cols;
                     else
                         break;
                 }
-                const int nid = nx + y * SIDE_LENGTH;
+                const int nid = nx + y * shape.cols;
                 if (isTileValid(nid)) {
                     kbFocusID = nid;
                     return;
@@ -486,15 +486,15 @@ void COverview::moveFocus(int dx, int dy) {
     if (dy != 0) {
         int step = dy > 0 ? 1 : -1;
         int ny   = y;
-        for (int tries = 0; tries < SIDE_LENGTH; ++tries) {
+        for (int tries = 0; tries < shape.rows; ++tries) {
             ny += step;
-            if (ny < 0 || ny >= SIDE_LENGTH) {
+            if (ny < 0 || ny >= shape.rows) {
                 if (**PWRAPV)
-                    ny = (ny + SIDE_LENGTH) % SIDE_LENGTH;
+                    ny = (ny + shape.rows) % shape.rows;
                 else
                     break;
             }
-            const int nid = x + ny * SIDE_LENGTH;
+            const int nid = x + ny * shape.cols;
             if (isTileValid(nid)) {
                 kbFocusID = nid;
                 return;
@@ -603,11 +603,8 @@ void COverview::onSwipeUpdate(double delta) {
     const float         PERC               = closing ? std::clamp(delta / distance, 0.0, 1.0) : 1.0 - std::clamp(delta / distance, 0.0, 1.0);
     const auto          WORKSPACE_FOCUS_ID = closing && closeOnID != -1 ? closeOnID : openedID;
 
-    Vector2D            tileSize = (MON->m_size / SIDE_LENGTH);
-
-    const auto          SIZEMAX = MON->m_size * MON->m_size / tileSize;
-    const auto          POSMAX  = (-((MON->m_size / (double)SIDE_LENGTH) * Vector2D{WORKSPACE_FOCUS_ID % SIDE_LENGTH, WORKSPACE_FOCUS_ID / SIDE_LENGTH}) * MON->m_scale) *
-        (MON->m_size / tileSize);
+    const auto          SIZEMAX = zoomSizeForCurrentGrid(MON->m_size);
+    const auto          POSMAX  = -(tilePosForID(WORKSPACE_FOCUS_ID, SIZEMAX, 0.0) * MON->m_scale);
 
     const auto SIZEMIN = MON->m_size;
     const auto POSMIN  = Vector2D{0, 0};
@@ -633,8 +630,13 @@ void COverview::onSwipeEnd() {
     }
 
     const auto SIZEMIN = MON->m_size;
-    const auto SIZEMAX = MON->m_size * MON->m_size / (MON->m_size / SIDE_LENGTH);
-    const auto PERC    = (size->value() - SIZEMIN).x / (SIZEMAX - SIZEMIN).x;
+    const auto SIZEMAX = zoomSizeForCurrentGrid(MON->m_size);
+    const auto span    = SIZEMAX - SIZEMIN;
+    if (std::abs(span.x) <= 1e-6) {
+        close();
+        return;
+    }
+    const auto PERC    = (size->value() - SIZEMIN).x / span.x;
     if (PERC > 0.5) {
         close();
         return;

--- a/OverviewRender.cpp
+++ b/OverviewRender.cpp
@@ -381,11 +381,8 @@ void COverview::fullRender() {
     static auto const*  PLABELPOS   = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:label_position")->getDataStaticPtr();
     static auto const*  PLABELPOSL  = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:label_pos")->getDataStaticPtr();
     static auto* const* PLABELSIZEL = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:label_size")->getDataStaticPtr();
-    static auto* const* PLABELCOLL  = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:label_col")->getDataStaticPtr();
     static auto* const* PACTCOL     = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:active_highlight_col")->getDataStaticPtr();
-    static auto* const* PACTBORDER  = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:active_highlight_border")->getDataStaticPtr();
     static auto* const* PHOVCOL     = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:hover_highlight_col")->getDataStaticPtr();
-    static auto* const* PHOVBORDER  = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:hover_highlight_border")->getDataStaticPtr();
     static auto const*  PLABELMODE  = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:label_text_mode")->getDataStaticPtr();
     static auto const*  PTOKENMAP   = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:label_token_map")->getDataStaticPtr();
     static auto* const* PLABELOX    = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:label_offset_x")->getDataStaticPtr();
@@ -535,7 +532,7 @@ void COverview::fullRender() {
             return;
 
         const int BWIDTH = std::max(1, borderWidthOverride > 0 ? borderWidthOverride : (int)**PBWIDTH);
-        std::string effectiveSpec = borderSpec.empty() ? deprecatedGradSpec : borderSpec;
+        const std::string effectiveSpec = Hyprexpo::resolveBorderSpec(borderSpec, deprecatedGradSpec);
 
         if (isGradientBorderSpec(effectiveSpec)) {
             const auto spec = parseGradientSpec(effectiveSpec);
@@ -591,74 +588,15 @@ void COverview::fullRender() {
         Render::GL::g_pHyprOpenGL->renderBorder(proxy, grad, {.round = round, .roundingPower = ROUND_PWR, .borderSize = borderWidth});
     };
 
-    auto drawSolidBorderForID = [&](int id, const CHyprColor& color, int roundScaled, int borderWidth) {
-        if (!isTileValid(id) || id < 0 || id >= (int)tileBoxes.size())
-            return;
-        if (borderWidth <= 0)
-            return;
-
-        const CBox& box = tileBoxes[id];
-        if (box.w <= 0.0 || box.h <= 0.0)
-            return;
-
-        Render::GL::g_pHyprOpenGL->renderBorder(box, color, {.round = roundScaled, .roundingPower = ROUND_PWR, .borderSize = borderWidth});
-    };
-
     std::vector<std::string> selectionTokens;
     if (!std::string{*PSELECTMAP}.empty())
         selectionTokens = splitCommaList(std::string{*PSELECTMAP});
 
-    if (dynamicGrid) {
-        const std::string legacyAnchor = normalizeAnchor(std::string{*PLABELPOSL});
-        // PR #605 treated label_size as the badge size and rendered text at
-        // half that size; preserve that legacy meaning on the richer renderer.
-        const int         legacyFont   = std::max(8, (int)**PLABELSIZEL / 2);
-        const CHyprColor  legacyColor{(uint64_t)**PLABELCOLL};
-
-        int tokenCounter = 0;
-        for (size_t id = 0; id < images.size(); ++id) {
-            const auto& image = images[id];
-            if (image.workspaceID == WORKSPACE_INVALID)
-                continue;
-
-            const auto& tile = tileBoxes[id];
-            if (tile.w <= 0.0 || tile.h <= 0.0)
-                continue;
-
-            const std::string label = showWorkspaceNames ? resolveWorkspaceName(id) : std::to_string(image.workspaceID);
-            if (!label.empty())
-                renderLabel(images[id].labelTexDefault, images[id].labelSizeDefault, label, legacyColor, 1.0f, tile, legacyAnchor, **PLABELOX, **PLABELOY, legacyFont);
-
-            if (**PSELECTEN && tokenCounter < (int)selectionTokens.size() && !selectionTokens[tokenCounter].empty())
-                renderLabel(images[id].selectionLabelTex, images[id].selectionLabelSize, selectionTokens[tokenCounter], CHyprColor{(uint64_t)**PSELECTCOL}, 1.0f, tile,
-                            std::string{*PSELECTPOS}, **PSELECTOX, **PSELECTOY, **PLABELSIZE);
-
-            ++tokenCounter;
-        }
-    } else if (**PLABELEN || **PSELECTEN || showWorkspaceNumbers) {
+    if (**PLABELEN || **PSELECTEN || showWorkspaceNumbers) {
         const int labelHoveredID = closing ? -1 : hoveredID;
-
-        auto shouldShow = [&](int id) -> bool {
-            if (showWorkspaceNumbers)
-                return true;
-            if (std::string{*PLABELSHOW} == "never")
-                return false;
-            if (std::string{*PLABELSHOW} == "always")
-                return true;
-            const bool isHover = id == labelHoveredID;
-            const bool isFocus = id == kbFocusID;
-            const bool isCurr  = id == openedID;
-            const std::string mode{*PLABELSHOW};
-            if (mode == "hover")
-                return isHover;
-            if (mode == "focus")
-                return isFocus;
-            if (mode == "hover+focus")
-                return isHover || isFocus;
-            if (mode == "current+focus")
-                return isCurr || isFocus;
-            return true;
-        };
+        const std::string modernAnchor = Hyprexpo::trimString(std::string{*PLABELPOS});
+        const std::string labelAnchor  = normalizeAnchor(modernAnchor.empty() ? std::string{*PLABELPOSL} : modernAnchor);
+        const int labelFontSize = **PLABELSIZE > 0 ? **PLABELSIZE : std::max(8, (int)**PLABELSIZEL / 2);
 
         auto resolveState = [&](int id) -> int {
             if (id == kbFocusID)
@@ -682,10 +620,14 @@ void COverview::fullRender() {
             if (image.workspaceID == WORKSPACE_INVALID || tile.w <= 0.0 || tile.h <= 0.0)
                 continue;
 
-            if ((**PLABELEN || showWorkspaceNumbers) && shouldShow((int)id)) {
+            const bool labelEnabled = **PLABELEN || showWorkspaceNumbers;
+            const std::string labelShow = showWorkspaceNumbers ? "always" : std::string{*PLABELSHOW};
+            if (Hyprexpo::shouldShowWorkspaceLabel(labelEnabled, labelShow, (int)id == labelHoveredID, (int)id == kbFocusID, (int)id == openedID)) {
                 std::string label;
                 const std::string mode = showWorkspaceNumbers ? std::string{"id"} : std::string{*PLABELMODE};
-                if (mode == "token") {
+                if (dynamicGrid && showWorkspaceNames) {
+                    label = resolveWorkspaceName(id);
+                } else if (mode == "token") {
                     if (tokenCounter < (int)labelTokens.size() && !labelTokens[tokenCounter].empty())
                         label = labelTokens[tokenCounter];
                     else
@@ -699,20 +641,20 @@ void COverview::fullRender() {
                 const int st = resolveState((int)id);
                 if (!label.empty()) {
                     if (showWorkspaceNumbers)
-                        renderLabel(images[id].labelTexDefault, images[id].labelSizeDefault, label, CHyprColor{(uint64_t)**PWSNUMCOL}, 1.0f, tile, std::string{*PLABELPOS}, **PLABELOX, **PLABELOY,
-                                    **PLABELSIZE);
+                        renderLabel(images[id].labelTexDefault, images[id].labelSizeDefault, label, CHyprColor{(uint64_t)**PWSNUMCOL}, 1.0f, tile, labelAnchor, **PLABELOX, **PLABELOY,
+                                    labelFontSize);
                     else if (st == 1)
-                        renderLabel(images[id].labelTexHover, images[id].labelSizeHover, label, CHyprColor{(uint64_t)**PLCOLHOV}, **PLSCALEH, tile, std::string{*PLABELPOS}, **PLABELOX,
-                                    **PLABELOY, **PLABELSIZE);
+                        renderLabel(images[id].labelTexHover, images[id].labelSizeHover, label, CHyprColor{(uint64_t)**PLCOLHOV}, **PLSCALEH, tile, labelAnchor, **PLABELOX,
+                                    **PLABELOY, labelFontSize);
                     else if (st == 2)
-                        renderLabel(images[id].labelTexFocus, images[id].labelSizeFocus, label, CHyprColor{(uint64_t)**PLCOLFOC}, **PLSCALEF, tile, std::string{*PLABELPOS}, **PLABELOX,
-                                    **PLABELOY, **PLABELSIZE);
+                        renderLabel(images[id].labelTexFocus, images[id].labelSizeFocus, label, CHyprColor{(uint64_t)**PLCOLFOC}, **PLSCALEF, tile, labelAnchor, **PLABELOX,
+                                    **PLABELOY, labelFontSize);
                     else if (st == 3)
-                        renderLabel(images[id].labelTexCurrent, images[id].labelSizeCurrent, label, CHyprColor{(uint64_t)**PLCOLCUR}, 1.0f, tile, std::string{*PLABELPOS}, **PLABELOX,
-                                    **PLABELOY, **PLABELSIZE);
+                        renderLabel(images[id].labelTexCurrent, images[id].labelSizeCurrent, label, CHyprColor{(uint64_t)**PLCOLCUR}, 1.0f, tile, labelAnchor, **PLABELOX,
+                                    **PLABELOY, labelFontSize);
                     else
-                        renderLabel(images[id].labelTexDefault, images[id].labelSizeDefault, label, CHyprColor{(uint64_t)**PLCOLDEF}, 1.0f, tile, std::string{*PLABELPOS}, **PLABELOX,
-                                    **PLABELOY, **PLABELSIZE);
+                        renderLabel(images[id].labelTexDefault, images[id].labelSizeDefault, label, CHyprColor{(uint64_t)**PLCOLDEF}, 1.0f, tile, labelAnchor, **PLABELOX,
+                                    **PLABELOY, labelFontSize);
                 }
             }
 
@@ -728,26 +670,24 @@ void COverview::fullRender() {
     const int RND_FOC = FOCUS_ROUND_SCALED;
     const int RND_HOV = HOVER_ROUND_SCALED;
 
-    if (dynamicGrid) {
-        if (hoveredID != -1 && hoveredID != openedID && hoveredID != kbFocusID) {
-            const int hoverWidth = **PHOVBORDER;
-            if (hoverWidth > 0)
-                drawSolidBorderForID(hoveredID, CHyprColor{(uint64_t)**PHOVCOL}, RND_HOV, std::max(1, (int)std::lround(hoverWidth * MON->m_scale)));
-        }
+    auto legacyColorSpec = [](uint64_t color) {
+        constexpr char HEX[] = "0123456789abcdef";
+        std::string    spec  = "0x00000000";
+        for (int index = 0; index < 8; ++index)
+            spec[9 - index] = HEX[(color >> (index * 4)) & 0xF];
+        return spec;
+    };
 
-        const int activeWidth = **PACTBORDER;
-        if (activeWidth > 0)
-            drawSolidBorderForID(openedID, CHyprColor{(uint64_t)**PACTCOL}, RND_CUR, std::max(1, (int)std::lround(activeWidth * MON->m_scale)));
+    const std::string currentLegacySpec = dynamicGrid ? legacyColorSpec((uint64_t)**PACTCOL) : std::string{};
+    const std::string hoverLegacySpec   = dynamicGrid ? legacyColorSpec((uint64_t)**PHOVCOL) : std::string{};
+    const std::string currentFallback   = Hyprexpo::resolveBorderSpec(std::string{*PBGRCUR}, currentLegacySpec);
+    const std::string hoverFallback     = Hyprexpo::resolveBorderSpec(std::string{*PBGREHOV}, hoverLegacySpec);
 
-        if (kbFocusID != -1)
-            drawBorderForID(kbFocusID, std::string{*PBCOLFOC}, std::string{*PBGREFOC}, RND_FOC);
-    } else {
-        if (hoveredID != -1 && hoveredID != openedID && hoveredID != kbFocusID)
-            drawBorderForID(hoveredID, std::string{*PBCOLHOV}, std::string{*PBGREHOV}, RND_HOV);
-        drawBorderForID(openedID, std::string{*PBCOLCUR}, std::string{*PBGRCUR}, RND_CUR);
-        if (kbFocusID != -1)
-            drawBorderForID(kbFocusID, std::string{*PBCOLFOC}, std::string{*PBGREFOC}, RND_FOC);
-    }
+    if (hoveredID != -1 && hoveredID != openedID && hoveredID != kbFocusID)
+        drawBorderForID(hoveredID, std::string{*PBCOLHOV}, hoverFallback, RND_HOV);
+    drawBorderForID(openedID, std::string{*PBCOLCUR}, currentFallback, RND_CUR);
+    if (kbFocusID != -1)
+        drawBorderForID(kbFocusID, std::string{*PBCOLFOC}, std::string{*PBGREFOC}, RND_FOC);
 
     if (dragMoved && dragSourceID != -1) {
         const std::string sourceBorder = std::string{*PDRAGSOURCEBORDER}.empty() ? std::string{*PBCOLFOC} : std::string{*PDRAGSOURCEBORDER};

--- a/OverviewRender.cpp
+++ b/OverviewRender.cpp
@@ -36,11 +36,14 @@ void COverview::redrawID(int id, bool forcelowres) {
     Render::GL::g_pHyprOpenGL->makeEGLCurrent();
     settleWorkspaceMoveAnimations();
 
-    id = std::clamp(id, 0, SIDE_LENGTH * SIDE_LENGTH - 1);
+    if (images.empty()) {
+        blockOverviewRendering = false;
+        return;
+    }
 
-    Vector2D tileSize       = MON->m_size / SIDE_LENGTH;
-    Vector2D tileRenderSize = (MON->m_size - Vector2D{GAP_WIDTH, GAP_WIDTH} * (SIDE_LENGTH - 1)) / SIDE_LENGTH;
-    CBox     monbox{0, 0, tileSize.x * 2, tileSize.y * 2};
+    id = std::clamp(id, 0, (int)images.size() - 1);
+
+    CBox monbox{0, 0, MON->m_pixelSize.x, MON->m_pixelSize.y};
 
     if (!forcelowres && (size->value() != MON->m_size || closing))
         monbox = {{0, 0}, MON->m_pixelSize};
@@ -146,7 +149,7 @@ void COverview::redrawAll(bool forcelowres) {
     if (!MON)
         return;
 
-    for (size_t i = 0; i < (size_t)(SIDE_LENGTH * SIDE_LENGTH); ++i) {
+    for (size_t i = 0; i < images.size(); ++i) {
         redrawID(i, forcelowres);
     }
 }
@@ -170,15 +173,9 @@ void COverview::onDamageReported() {
 
     Vector2D SIZE = size->value();
 
-    Vector2D tileSize       = (SIZE / SIDE_LENGTH);
-    const auto GAPSIZE      = (closing ? (1.0 - size->getPercent()) : size->getPercent()) * GAP_WIDTH;
-    static auto* const* PGAPSO = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:gaps_out")->getDataStaticPtr();
-    const float OUTER       = std::max<Hyprlang::INT>(0, **PGAPSO) * (closing ? (1.0 - size->getPercent()) : size->getPercent());
-    Vector2D tileRenderSize = (SIZE - Vector2D{GAPSIZE, GAPSIZE} * (SIDE_LENGTH - 1) - Vector2D{OUTER * 2, OUTER * 2}) / SIDE_LENGTH;
-    // const auto& TILE           = images[std::clamp(openedID, 0, SIDE_LENGTH * SIDE_LENGTH)];
-    CBox texbox = CBox{OUTER + (openedID % SIDE_LENGTH) * tileRenderSize.x + (openedID % SIDE_LENGTH) * GAPSIZE,
-                       OUTER + (openedID / SIDE_LENGTH) * tileRenderSize.y + (openedID / SIDE_LENGTH) * GAPSIZE, tileRenderSize.x, tileRenderSize.y}
-                      .translate(MON->m_position);
+    const auto GAPSIZE = (closing ? (1.0 - size->getPercent()) : size->getPercent()) * GAP_WIDTH;
+    const auto OUTER = currentOuterInset();
+    CBox texbox = tileBoxForIndex(openedID, SIZE, GAPSIZE, OUTER, true).translate(MON->m_position);
 
     damage();
 
@@ -205,15 +202,19 @@ void COverview::close(bool switchToSelection) {
 
     resetSubmapIfNeeded();
 
+    if (images.empty()) {
+        g_pOverview.reset();
+        return;
+    }
+
     const int   ID = closeOnID == -1 ? openedID : closeOnID;
 
-    const int   SAFEID = std::clamp(ID, 0, SIDE_LENGTH * SIDE_LENGTH - 1);
+    const int   SAFEID = std::clamp(ID, 0, (int)images.size() - 1);
     const auto& TILE   = images[SAFEID];
 
-    Vector2D    tileSize = (MON->m_size / SIDE_LENGTH);
-
-    *size = MON->m_size * MON->m_size / tileSize;
-    *pos  = (-((MON->m_size / (double)SIDE_LENGTH) * Vector2D{SAFEID % SIDE_LENGTH, SAFEID / SIDE_LENGTH}) * MON->m_scale) * (MON->m_size / tileSize);
+    const auto targetSize = zoomSizeForCurrentGrid(MON->m_size);
+    *size = targetSize;
+    *pos  = -(tilePosForID(SAFEID, targetSize, 0.0) * MON->m_scale);
 
     closing = true;
 
@@ -267,7 +268,7 @@ void COverview::onWorkspaceChange() {
     else
         startedOn = MON->m_activeWorkspace;
 
-    for (size_t i = 0; i < (size_t)(SIDE_LENGTH * SIDE_LENGTH); ++i) {
+    for (size_t i = 0; i < images.size(); ++i) {
         if (images[i].workspaceID != MON->activeWorkspaceID())
             continue;
 
@@ -297,12 +298,11 @@ bool COverview::shouldRenderOverviewForMonitor(const PHLMONITOR& monitor) const 
     return true;
 }
 
+
 void COverview::fullRender() {
     const auto MON = pMonitor.lock();
     if (!MON)
         return;
-
-    const auto GAPSIZE = (closing ? (1.0 - size->getPercent()) : size->getPercent()) * GAP_WIDTH;
 
     if (MON->m_activeWorkspace != startedOn && !closing) {
         // likely user changed.
@@ -311,38 +311,39 @@ void COverview::fullRender() {
 
     Vector2D SIZE = size->value();
 
-    static auto* const* PGAPSO = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:gaps_out")->getDataStaticPtr();
-    const float OUTER = std::max<Hyprlang::INT>(0, **PGAPSO) * (closing ? (1.0 - size->getPercent()) : size->getPercent());
-
-    Vector2D tileSize       = (SIZE / SIDE_LENGTH);
-    Vector2D tileRenderSize = (SIZE - Vector2D{GAPSIZE, GAPSIZE} * (SIDE_LENGTH - 1) - Vector2D{OUTER * 2, OUTER * 2}) / SIDE_LENGTH;
+    const auto GAPSIZE = (closing ? (1.0 - size->getPercent()) : size->getPercent()) * GAP_WIDTH;
+    const auto OUTER   = currentOuterInset();
+    const auto SHAPE   = currentGridShape();
 
     clearWithColor(BG_COLOR.stripA());
 
-    static auto* const* PTILEROUND = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:tile_rounding")->getDataStaticPtr();
-    static auto* const* PTOUNDPWR  = (Hyprlang::FLOAT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:tile_rounding_power")->getDataStaticPtr();
+    static auto* const* PTILEROUND  = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:tile_rounding")->getDataStaticPtr();
+    static auto* const* PTOUNDPWR   = (Hyprlang::FLOAT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:tile_rounding_power")->getDataStaticPtr();
     static auto* const* PTILEROUNDF = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:tile_rounding_focus")->getDataStaticPtr();
     static auto* const* PTILEROUNDC = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:tile_rounding_current")->getDataStaticPtr();
     static auto* const* PTILEROUNDH = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:tile_rounding_hover")->getDataStaticPtr();
 
-    const int BASE_ROUND_SCALED   = std::max(0, (int)std::lround((double)**PTILEROUND * MON->m_scale));
-    const int FOCUS_ROUND_SCALED  = **PTILEROUNDF >= 0 ? std::max(0, (int)std::lround((double)**PTILEROUNDF * MON->m_scale)) : BASE_ROUND_SCALED;
-    const int CURRENT_ROUND_SCALED= **PTILEROUNDC >= 0 ? std::max(0, (int)std::lround((double)**PTILEROUNDC * MON->m_scale)) : BASE_ROUND_SCALED;
-    const int HOVER_ROUND_SCALED  = **PTILEROUNDH >= 0 ? std::max(0, (int)std::lround((double)**PTILEROUNDH * MON->m_scale)) : BASE_ROUND_SCALED;
-    const float ROUND_PWR         = **PTOUNDPWR;
-
-    // (shadows moved to feature/shadows branch)
+    const int   BASE_ROUND_SCALED    = std::max(0, (int)std::lround((double)**PTILEROUND * MON->m_scale));
+    const int   FOCUS_ROUND_SCALED   = **PTILEROUNDF >= 0 ? std::max(0, (int)std::lround((double)**PTILEROUNDF * MON->m_scale)) : BASE_ROUND_SCALED;
+    const int   CURRENT_ROUND_SCALED = **PTILEROUNDC >= 0 ? std::max(0, (int)std::lround((double)**PTILEROUNDC * MON->m_scale)) : BASE_ROUND_SCALED;
+    const int   HOVER_ROUND_SCALED   = **PTILEROUNDH >= 0 ? std::max(0, (int)std::lround((double)**PTILEROUNDH * MON->m_scale)) : BASE_ROUND_SCALED;
+    const float ROUND_PWR            = **PTOUNDPWR;
 
     std::vector<CBox> tileBoxes(images.size());
+    const bool        entryAnimationActive = animateEntry && !closing;
+    bool              entryAnimationPending = false;
+    const double      entryElapsed = entryAnimationActive ? std::chrono::duration<double>(std::chrono::steady_clock::now() - createdAt).count() : 0.0;
 
-    for (size_t y = 0; y < (size_t)SIDE_LENGTH; ++y) {
-        for (size_t x = 0; x < (size_t)SIDE_LENGTH; ++x) {
-            const int id = x + y * SIDE_LENGTH;
-            CBox      texbox{OUTER + x * tileRenderSize.x + x * GAPSIZE, OUTER + y * tileRenderSize.y + y * GAPSIZE, tileRenderSize.x, tileRenderSize.y};
+    for (size_t y = 0; y < (size_t)SHAPE.rows; ++y) {
+        for (size_t x = 0; x < (size_t)SHAPE.cols; ++x) {
+            const int id = x + y * SHAPE.cols;
+            if (id < 0 || id >= (int)images.size())
+                continue;
+            CBox texbox = tileBoxForIndex(id, SIZE, GAPSIZE, OUTER, true);
             texbox.scale(MON->m_scale).translate(pos->value());
             texbox.round();
             tileBoxes[id] = texbox;
-            // per-tile rounding override for focus/current/hover (priority: focus > current > hover)
+
             int tileRound = BASE_ROUND_SCALED;
             if ((int)id == kbFocusID)
                 tileRound = FOCUS_ROUND_SCALED;
@@ -351,252 +352,186 @@ void COverview::fullRender() {
             else if ((int)id == hoveredID)
                 tileRound = HOVER_ROUND_SCALED;
 
-            // clamp rounding to tile size
             const int maxCornerPx = std::max(0, (int)std::floor(std::min(texbox.w, texbox.h) / 2.0));
             tileRound = std::min(tileRound, maxCornerPx);
 
-            // no shadow in this branch
+            float alpha = 1.0f;
+            if (entryAnimationActive) {
+                const double delay = (double)id * 0.05;
+                const double raw   = std::clamp((entryElapsed - delay) / 0.2, 0.0, 1.0);
+                alpha              = (float)(raw * raw * (3.0 - 2.0 * raw));
+                if (raw < 1.0)
+                    entryAnimationPending = true;
+            }
 
             CRegion damage{0, 0, INT16_MAX, INT16_MAX};
-            Render::GL::g_pHyprOpenGL->renderTextureInternal(images[id].fb->getTexture(), texbox, {.damage = &damage, .a = 1.0, .round = tileRound, .roundingPower = ROUND_PWR});
+            Render::GL::g_pHyprOpenGL->renderTextureInternal(images[id].fb->getTexture(), texbox, {.damage = &damage, .a = alpha, .round = tileRound, .roundingPower = ROUND_PWR});
         }
     }
 
-    // overlays: numbers and borders
-    static auto* const* PLABELEN   = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:label_enable")->getDataStaticPtr();
-    static auto* const* PLABELSIZE = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:label_font_size")->getDataStaticPtr();
-    static auto  const* PLABELPOS  = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:label_position")->getDataStaticPtr();
-    static auto  const* PLABELMODE = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:label_text_mode")->getDataStaticPtr();
-    static auto  const* PTOKENMAP  = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:label_token_map")->getDataStaticPtr();
-    static auto* const* PLABELOX   = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:label_offset_x")->getDataStaticPtr();
-    static auto* const* PLABELOY   = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:label_offset_y")->getDataStaticPtr();
-    static auto  const* PLABELSHOW = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:label_show")->getDataStaticPtr();
-    static auto* const* PLCOLDEF   = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:label_color_default")->getDataStaticPtr();
-    static auto* const* PLCOLHOV   = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:label_color_hover")->getDataStaticPtr();
-    static auto* const* PLCOLFOC   = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:label_color_focus")->getDataStaticPtr();
-    static auto* const* PLCOLCUR   = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:label_color_current")->getDataStaticPtr();
-    static auto* const* PWSNUMCOL  = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:workspace_number_color")->getDataStaticPtr();
-    static auto* const* PLSCALEH   = (Hyprlang::FLOAT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:label_scale_hover")->getDataStaticPtr();
-    static auto* const* PLSCALEF   = (Hyprlang::FLOAT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:label_scale_focus")->getDataStaticPtr();
-    static auto* const* PLBGEN     = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:label_bg_enable")->getDataStaticPtr();
-    static auto* const* PLBGCOL    = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:label_bg_color")->getDataStaticPtr();
-    static auto* const* PLBGROUND  = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:label_bg_rounding")->getDataStaticPtr();
-    static auto  const* PLBGSHAPE  = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:label_bg_shape")->getDataStaticPtr();
-    static auto* const* PLBGPAD    = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:label_padding")->getDataStaticPtr();
+    // overlays: labels and borders
+    static auto* const* PLABELEN    = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:label_enable")->getDataStaticPtr();
+    static auto* const* PLABELSIZE  = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:label_font_size")->getDataStaticPtr();
+    static auto const*  PLABELPOS   = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:label_position")->getDataStaticPtr();
+    static auto const*  PLABELPOSL  = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:label_pos")->getDataStaticPtr();
+    static auto* const* PLABELSIZEL = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:label_size")->getDataStaticPtr();
+    static auto* const* PLABELCOLL  = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:label_col")->getDataStaticPtr();
+    static auto* const* PACTCOL     = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:active_highlight_col")->getDataStaticPtr();
+    static auto* const* PACTBORDER  = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:active_highlight_border")->getDataStaticPtr();
+    static auto* const* PHOVCOL     = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:hover_highlight_col")->getDataStaticPtr();
+    static auto* const* PHOVBORDER  = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:hover_highlight_border")->getDataStaticPtr();
+    static auto const*  PLABELMODE  = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:label_text_mode")->getDataStaticPtr();
+    static auto const*  PTOKENMAP   = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:label_token_map")->getDataStaticPtr();
+    static auto* const* PLABELOX    = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:label_offset_x")->getDataStaticPtr();
+    static auto* const* PLABELOY    = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:label_offset_y")->getDataStaticPtr();
+    static auto const*  PLABELSHOW  = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:label_show")->getDataStaticPtr();
+    static auto* const* PLCOLDEF    = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:label_color_default")->getDataStaticPtr();
+    static auto* const* PLCOLHOV    = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:label_color_hover")->getDataStaticPtr();
+    static auto* const* PLCOLFOC    = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:label_color_focus")->getDataStaticPtr();
+    static auto* const* PLCOLCUR    = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:label_color_current")->getDataStaticPtr();
+    static auto* const* PWSNUMCOL   = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:workspace_number_color")->getDataStaticPtr();
+    static auto* const* PLSCALEH    = (Hyprlang::FLOAT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:label_scale_hover")->getDataStaticPtr();
+    static auto* const* PLSCALEF    = (Hyprlang::FLOAT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:label_scale_focus")->getDataStaticPtr();
+    static auto* const* PLBGEN      = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:label_bg_enable")->getDataStaticPtr();
+    static auto* const* PLBGCOL     = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:label_bg_color")->getDataStaticPtr();
+    static auto* const* PLBGROUND   = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:label_bg_rounding")->getDataStaticPtr();
+    static auto const*  PLBGSHAPE   = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:label_bg_shape")->getDataStaticPtr();
+    static auto* const* PLBGPAD     = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:label_padding")->getDataStaticPtr();
 
-    static auto* const* PBWIDTH      = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:border_width")->getDataStaticPtr();
-    static auto  const* PBCOLCUR     = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:border_color_current")->getDataStaticPtr();
-    static auto  const* PBCOLFOC     = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:border_color_focus")->getDataStaticPtr();
-    static auto  const* PBCOLHOV     = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:border_color_hover")->getDataStaticPtr();
-    // Deprecated configs for backwards compatibility
-    static auto  const* PBGRCUR      = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:border_grad_current")->getDataStaticPtr();
-    static auto  const* PBGREFOC     = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:border_grad_focus")->getDataStaticPtr();
-    static auto  const* PBGREHOV     = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:border_grad_hover")->getDataStaticPtr();
+    static auto* const* PBWIDTH     = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:border_width")->getDataStaticPtr();
+    static auto const*  PBCOLCUR    = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:border_color_current")->getDataStaticPtr();
+    static auto const*  PBCOLFOC    = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:border_color_focus")->getDataStaticPtr();
+    static auto const*  PBCOLHOV    = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:border_color_hover")->getDataStaticPtr();
+    static auto const*  PBGRCUR     = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:border_grad_current")->getDataStaticPtr();
+    static auto const*  PBGREFOC    = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:border_grad_focus")->getDataStaticPtr();
+    static auto const*  PBGREHOV    = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:border_grad_hover")->getDataStaticPtr();
 
-    static auto* const* PDRAGPROXYCOL     = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:drag_drop_proxy_color")->getDataStaticPtr();
-    static auto* const* PDRAGPROXYACTCOL  = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:drag_drop_proxy_active_color")->getDataStaticPtr();
-    static auto  const* PDRAGPROXYBORDER  = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:drag_drop_proxy_border_color")->getDataStaticPtr();
-    static auto* const* PDRAGPROXYBWIDTH  = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:drag_drop_proxy_border_width")->getDataStaticPtr();
-    static auto* const* PDRAGPROXYROUND   = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:drag_drop_proxy_rounding")->getDataStaticPtr();
-    static auto  const* PDRAGSOURCEBORDER = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:drag_drop_source_border_color")->getDataStaticPtr();
+    static auto* const* PDRAGPROXYCOL    = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:drag_drop_proxy_color")->getDataStaticPtr();
+    static auto* const* PDRAGPROXYACTCOL = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:drag_drop_proxy_active_color")->getDataStaticPtr();
+    static auto const*  PDRAGPROXYBORDER = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:drag_drop_proxy_border_color")->getDataStaticPtr();
+    static auto* const* PDRAGPROXYBWIDTH = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:drag_drop_proxy_border_width")->getDataStaticPtr();
+    static auto* const* PDRAGPROXYROUND  = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:drag_drop_proxy_rounding")->getDataStaticPtr();
+    static auto const*  PDRAGSOURCEBORDER = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:drag_drop_source_border_color")->getDataStaticPtr();
     static auto* const* PDRAGSOURCEBWIDTH = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:drag_drop_source_border_width")->getDataStaticPtr();
 
     static auto* const* PSELECTEN   = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:selection_label_enable")->getDataStaticPtr();
-    static auto  const* PSELECTMAP  = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:selection_label_token_map")->getDataStaticPtr();
-    static auto  const* PSELECTPOS  = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:selection_label_position")->getDataStaticPtr();
+    static auto const*  PSELECTMAP  = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:selection_label_token_map")->getDataStaticPtr();
+    static auto const*  PSELECTPOS  = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:selection_label_position")->getDataStaticPtr();
     static auto* const* PSELECTOX   = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:selection_label_offset_x")->getDataStaticPtr();
     static auto* const* PSELECTOY   = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:selection_label_offset_y")->getDataStaticPtr();
     static auto* const* PSELECTCOL  = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:selection_label_color")->getDataStaticPtr();
 
-    // draw labels
-    if (**PLABELEN || **PSELECTEN || showWorkspaceNumbers) {
-        // use the tracked hoveredID (cleared during closing)
-        const int labelHoveredID = closing ? -1 : hoveredID;
+    auto normalizeAnchor = [](std::string anchor) {
+        std::replace(anchor.begin(), anchor.end(), '_', '-');
+        return anchor;
+    };
 
-        auto shouldShow = [&](int id) -> bool {
-            if (showWorkspaceNumbers)
-                return true;
-            if (std::string{*PLABELSHOW} == "never")
-                return false;
-            if (std::string{*PLABELSHOW} == "always")
-                return true;
-            const bool isHover  = id == labelHoveredID;
-            const bool isFocus  = id == kbFocusID;
-            const bool isCurr   = id == openedID;
-            const std::string mode{*PLABELSHOW};
-            if (mode == "hover")
-                return isHover;
-            if (mode == "focus")
-                return isFocus;
-            if (mode == "hover+focus")
-                return isHover || isFocus;
-            if (mode == "current+focus")
-                return isCurr || isFocus;
-            return true;
-        };
+    auto resolveWorkspaceName = [&](size_t id) -> std::string {
+        if (id >= images.size())
+            return {};
 
-        auto resolveState = [&](int id) -> int {
-            // precedence: focus > current > hover > default
-            if (id == kbFocusID)
-                return 2; // focus
-            if (id == openedID)
-                return 3; // current
-            if (id == labelHoveredID)
-                return 1; // hover
-            return 0;     // default
-        };
+        const auto& image = images[id];
+        if (image.pWorkspace && !image.pWorkspace->m_name.empty())
+            return image.pWorkspace->m_name;
 
-        auto placeBox = [&](const CBox& tile, const Vector2D& size, const std::string& anchor, int offsetX, int offsetY) -> CBox {
-            double x = tile.x, y = tile.y;
-            if (anchor == "top-left") {
-                x += offsetX; y += offsetY;
-            } else if (anchor == "top-right") {
-                x += tile.w - size.x - offsetX; y += offsetY;
-            } else if (anchor == "bottom-left") {
-                x += offsetX; y += tile.h - size.y - offsetY;
-            } else if (anchor == "bottom-right") {
-                x += tile.w - size.x - offsetX; y += tile.h - size.y - offsetY;
-            } else { // center
-                x += (tile.w - size.x) / 2.0; y += (tile.h - size.y) / 2.0;
+        for (const auto& workspace : State::workspaceState()->workspacesCopy()) {
+            if (!workspace || workspace->m_id != image.workspaceID)
+                continue;
+
+            if (!workspace->m_name.empty())
+                return workspace->m_name;
+            break;
+        }
+
+        return std::to_string(image.workspaceID);
+    };
+
+    auto renderLabel = [&](SP<Render::ITexture>& tex, Vector2D& sz, const std::string& label, const CHyprColor& col, float scaleMul, const CBox& tile, const std::string& anchor,
+                           int offsetX, int offsetY, int fontSize) {
+        if (label.empty())
+            return;
+
+        const int baseF = std::max(8, fontSize);
+        if (!tex || tex->m_texID == 0) {
+            const int fsz = std::max(8, (int)std::round(baseF * scaleMul));
+            Vector2D  buf{std::max(32, fsz * std::max(2, (int)label.size())), std::max(24, fsz + 8)};
+            sz  = buf;
+            tex = renderNumberTexture(label, col, buf, MON->m_scale, fsz);
+        }
+
+        if (!tex || tex->m_texID == 0)
+            return;
+
+        static auto* const* PLPIXELSNAP = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:label_pixel_snap")->getDataStaticPtr();
+
+        auto placeBox = [&](const CBox& tileBox, const Vector2D& size, const std::string& anchorName, int offsetX2, int offsetY2) -> CBox {
+            double x = tileBox.x, y = tileBox.y;
+            if (anchorName == "top-left") {
+                x += offsetX2;
+                y += offsetY2;
+            } else if (anchorName == "top-right") {
+                x += tileBox.w - size.x - offsetX2;
+                y += offsetY2;
+            } else if (anchorName == "bottom-left") {
+                x += offsetX2;
+                y += tileBox.h - size.y - offsetY2;
+            } else if (anchorName == "bottom-right") {
+                x += tileBox.w - size.x - offsetX2;
+                y += tileBox.h - size.y - offsetY2;
+            } else {
+                x += (tileBox.w - size.x) / 2.0;
+                y += (tileBox.h - size.y) / 2.0;
             }
             return CBox{x, y, (double)size.x, (double)size.y};
         };
 
-        auto renderLabel = [&](SP<Render::ITexture>& tex, Vector2D& sz, const std::string& label, const CHyprColor& col, float scaleMul, const CBox& tile, const std::string& anchor,
-                               int offsetX, int offsetY) {
-            if (label.empty())
-                return;
-
-            const int baseF = std::max(8, (int)**PLABELSIZE);
-            if (!tex || tex->m_texID == 0) {
-                const int fsz = std::max(8, (int)std::round(baseF * scaleMul));
-                Vector2D  buf{std::max(32, fsz * 2), std::max(24, fsz + 8)};
-                sz  = buf;
-                tex = renderNumberTexture(label, col, buf, MON->m_scale, fsz);
+        auto drawWithBG = [&]() {
+            const int pad = **PLBGPAD;
+            Vector2D  bgSize = {sz.x + pad * 2, sz.y + pad * 2};
+            const std::string shape{*PLBGSHAPE};
+            int roundPx = **PLBGROUND;
+            if (shape == "circle" || shape == "square") {
+                const double side = std::max(bgSize.x, bgSize.y);
+                bgSize            = {side, side};
+                roundPx           = (shape == "circle") ? std::lround(side / 2.0) : 0;
             }
-
-            if (!tex || tex->m_texID == 0)
-                return;
-
-            static auto* const* PLPIXELSNAP = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:label_pixel_snap")->getDataStaticPtr();
-
-            auto drawWithBG = [&]() {
-                const int pad = **PLBGPAD;
-                Vector2D  bgSize = {sz.x + pad * 2, sz.y + pad * 2};
-                const std::string shape{*PLBGSHAPE};
-                int roundPx = **PLBGROUND;
-                if (shape == "circle" || shape == "square") {
-                    const double side = std::max(bgSize.x, bgSize.y);
-                    bgSize            = {side, side};
-                    roundPx           = (shape == "circle") ? std::lround(side / 2.0) : 0;
-                }
-                CBox bg = placeBox(tile, bgSize, anchor, offsetX, offsetY);
-                CBox lb{bg.x + (bg.w - sz.x) / 2.0, bg.y + (bg.h - sz.y) / 2.0, (double)sz.x, (double)sz.y};
-                if (**PLPIXELSNAP) {
-                    bg.round();
-                    lb.round();
-                }
-                Render::GL::g_pHyprOpenGL->renderRect(bg, CHyprColor{(uint64_t)**PLBGCOL}, {.round = roundPx});
-                Render::GL::g_pHyprOpenGL->renderTexture(tex, lb, {.a = 1.0});
-            };
-
-            auto drawNoBG = [&]() {
-                CBox lb = placeBox(tile, sz, anchor, offsetX, offsetY);
-                if (**PLPIXELSNAP)
-                    lb.round();
-                Render::GL::g_pHyprOpenGL->renderTexture(tex, lb, {.a = 1.0});
-            };
-
-            if (**PLBGEN)
-                drawWithBG();
-            else
-                drawNoBG();
+            CBox bg = placeBox(tile, bgSize, anchor, offsetX, offsetY);
+            CBox lb{bg.x + (bg.w - sz.x) / 2.0, bg.y + (bg.h - sz.y) / 2.0, (double)sz.x, (double)sz.y};
+            if (**PLPIXELSNAP) {
+                bg.round();
+                lb.round();
+            }
+            Render::GL::g_pHyprOpenGL->renderRect(bg, CHyprColor{(uint64_t)**PLBGCOL}, {.round = roundPx});
+            Render::GL::g_pHyprOpenGL->renderTexture(tex, lb, {.a = 1.0});
         };
 
-        std::vector<std::string> labelTokens;
-        if (!std::string{*PTOKENMAP}.empty())
-            labelTokens = splitCommaList(std::string{*PTOKENMAP});
+        auto drawNoBG = [&]() {
+            CBox lb = placeBox(tile, sz, anchor, offsetX, offsetY);
+            if (**PLPIXELSNAP)
+                lb.round();
+            Render::GL::g_pHyprOpenGL->renderTexture(tex, lb, {.a = 1.0});
+        };
 
-        std::vector<std::string> selectionTokens;
-        if (!std::string{*PSELECTMAP}.empty())
-            selectionTokens = splitCommaList(std::string{*PSELECTMAP});
+        if (**PLBGEN)
+            drawWithBG();
+        else
+            drawNoBG();
+    };
 
-        int tokenCounter = 0;
-        for (size_t y = 0; y < (size_t)SIDE_LENGTH; ++y) {
-            for (size_t x = 0; x < (size_t)SIDE_LENGTH; ++x) {
-                const int id = x + y * SIDE_LENGTH;
-                if (images[id].workspaceID == WORKSPACE_INVALID)
-                    continue;
-
-                // compute tile box again for label placement
-                CBox tile{OUTER + x * tileRenderSize.x + x * GAPSIZE, OUTER + y * tileRenderSize.y + y * GAPSIZE, tileRenderSize.x, tileRenderSize.y};
-                tile.scale(MON->m_scale).translate(pos->value());
-                tile.round();
-
-                if ((**PLABELEN || showWorkspaceNumbers) && shouldShow(id)) {
-                    std::string label;
-                    const std::string mode = showWorkspaceNumbers ? std::string{"id"} : std::string{*PLABELMODE};
-                    if (mode == "token") {
-                        if (tokenCounter < (int)labelTokens.size() && !labelTokens[tokenCounter].empty())
-                            label = labelTokens[tokenCounter];
-                        else
-                            label = fallbackTokenForVisibleIndex(tokenCounter);
-                    } else if (mode == "index") {
-                        label = std::to_string(tokenCounter + 1);
-                    } else {
-                        label = std::to_string(images[id].workspaceID);
-                    }
-
-                    const int st = resolveState(id);
-                    if (!label.empty()) {
-                        if (showWorkspaceNumbers)
-                            renderLabel(images[id].labelTexDefault, images[id].labelSizeDefault, label, CHyprColor{(uint64_t)**PWSNUMCOL}, 1.0f, tile, std::string{*PLABELPOS}, **PLABELOX, **PLABELOY);
-                        else if (st == 1)
-                            renderLabel(images[id].labelTexHover, images[id].labelSizeHover, label, CHyprColor{(uint64_t)**PLCOLHOV}, **PLSCALEH, tile, std::string{*PLABELPOS}, **PLABELOX, **PLABELOY);
-                        else if (st == 2)
-                            renderLabel(images[id].labelTexFocus, images[id].labelSizeFocus, label, CHyprColor{(uint64_t)**PLCOLFOC}, **PLSCALEF, tile, std::string{*PLABELPOS}, **PLABELOX, **PLABELOY);
-                        else if (st == 3)
-                            renderLabel(images[id].labelTexCurrent, images[id].labelSizeCurrent, label, CHyprColor{(uint64_t)**PLCOLCUR}, 1.0f, tile, std::string{*PLABELPOS}, **PLABELOX, **PLABELOY);
-                        else
-                            renderLabel(images[id].labelTexDefault, images[id].labelSizeDefault, label, CHyprColor{(uint64_t)**PLCOLDEF}, 1.0f, tile, std::string{*PLABELPOS}, **PLABELOX, **PLABELOY);
-                    }
-                }
-
-                if (**PSELECTEN && tokenCounter < (int)selectionTokens.size() && !selectionTokens[tokenCounter].empty())
-                    renderLabel(images[id].selectionLabelTex, images[id].selectionLabelSize, selectionTokens[tokenCounter], CHyprColor{(uint64_t)**PSELECTCOL}, 1.0f, tile,
-                                std::string{*PSELECTPOS}, **PSELECTOX, **PSELECTOY);
-
-                tokenCounter++;
-            }
-        }
-    }
-
-    // draw borders for hover, current and focus (priority order: focus > current > hover)
-
-    // pass rounding based on state
-    const int RND_CUR = CURRENT_ROUND_SCALED;
-    const int RND_FOC = FOCUS_ROUND_SCALED;
-    const int RND_HOV = HOVER_ROUND_SCALED;
-
-    // Helper to parse border config (supports rgb/hex/gradient, with deprecated fallback)
     auto drawBorderForID = [&](int id, const std::string& borderSpec, const std::string& deprecatedGradSpec, int roundScaled, int borderWidthOverride = -1) {
-        if (id < 0)
+        if (!isTileValid(id) || id < 0 || id >= (int)tileBoxes.size())
             return;
         if (borderWidthOverride == 0)
             return;
-        const int ix = id % SIDE_LENGTH;
-        const int iy = id / SIDE_LENGTH;
-        CBox       box{OUTER + ix * tileRenderSize.x + ix * GAPSIZE, OUTER + iy * tileRenderSize.y + iy * GAPSIZE, tileRenderSize.x, tileRenderSize.y};
-        box.scale(MON->m_scale).translate(pos->value());
-        box.round();
-        const int BWIDTH = std::max(1, borderWidthOverride > 0 ? borderWidthOverride : (int)**PBWIDTH);
 
-        // Determine which spec to use (prefer new format, fallback to deprecated)
+        const CBox& box = tileBoxes[id];
+        if (box.w <= 0.0 || box.h <= 0.0)
+            return;
+
+        const int BWIDTH = std::max(1, borderWidthOverride > 0 ? borderWidthOverride : (int)**PBWIDTH);
         std::string effectiveSpec = borderSpec.empty() ? deprecatedGradSpec : borderSpec;
 
-        // Auto-detect format: gradient vs solid color
         if (isGradientBorderSpec(effectiveSpec)) {
-            // Render as gradient border (hyprland style)
             const auto spec = parseGradientSpec(effectiveSpec);
             if (spec.valid) {
                 Config::CGradientValueData grad;
@@ -622,7 +557,7 @@ void COverview::fullRender() {
         if (borderWidth <= 0)
             return;
 
-        std::string effectiveSpec = borderSpec.empty() ? fallbackSpec : borderSpec;
+        const std::string effectiveSpec = borderSpec.empty() ? fallbackSpec : borderSpec;
         if (effectiveSpec.empty())
             return;
 
@@ -632,47 +567,199 @@ void COverview::fullRender() {
                 return;
 
             Config::CGradientValueData grad;
-            grad.m_colors.clear();
-            grad.m_colors.push_back(spec.c1);
-            grad.m_colors.push_back(spec.c2);
-            grad.m_angle = spec.angleDeg * (float)M_PI / 180.f;
+            grad.m_colors = {spec.c1, spec.c2};
+            grad.m_angle  = spec.angleDeg * (float)M_PI / 180.f;
             grad.updateColorsOk();
             Render::GL::g_pHyprOpenGL->renderBorder(proxy, grad, {.round = round, .roundingPower = ROUND_PWR, .borderSize = borderWidth});
             return;
         }
 
         Hyprexpo::SColorRGBA parsedColor;
-        if (Hyprexpo::parseSolidColorSpec(effectiveSpec, parsedColor)) {
-            Config::CGradientValueData grad{CHyprColor{parsedColor.r, parsedColor.g, parsedColor.b, parsedColor.a}};
-            grad.updateColorsOk();
-            Render::GL::g_pHyprOpenGL->renderBorder(proxy, grad, {.round = round, .roundingPower = ROUND_PWR, .borderSize = borderWidth});
-        } else
+        if (!Hyprexpo::parseSolidColorSpec(effectiveSpec, parsedColor)) {
             Log::logger->log(Log::ERR, "[hyprexpo] invalid drag_drop_proxy_border_color config: {}", effectiveSpec);
+            return;
+        }
+
+        Config::CGradientValueData grad{CHyprColor{parsedColor.r, parsedColor.g, parsedColor.b, parsedColor.a}};
+        grad.updateColorsOk();
+        Render::GL::g_pHyprOpenGL->renderBorder(proxy, grad, {.round = round, .roundingPower = ROUND_PWR, .borderSize = borderWidth});
     };
 
-    // Draw borders in order: hover (lowest), then current, then focus (highest priority)
-    if (hoveredID != -1 && hoveredID != openedID && hoveredID != kbFocusID)
-        drawBorderForID(hoveredID, std::string{*PBCOLHOV}, std::string{*PBGREHOV}, RND_HOV);
-    drawBorderForID(openedID, std::string{*PBCOLCUR}, std::string{*PBGRCUR}, RND_CUR);
-    if (kbFocusID != -1)
-        drawBorderForID(kbFocusID, std::string{*PBCOLFOC}, std::string{*PBGREFOC}, RND_FOC);
+    auto drawSolidBorderForID = [&](int id, const CHyprColor& color, int roundScaled, int borderWidth) {
+        if (!isTileValid(id) || id < 0 || id >= (int)tileBoxes.size())
+            return;
+        if (borderWidth <= 0)
+            return;
+
+        const CBox& box = tileBoxes[id];
+        if (box.w <= 0.0 || box.h <= 0.0)
+            return;
+
+        Render::GL::g_pHyprOpenGL->renderBorder(box, color, {.round = roundScaled, .roundingPower = ROUND_PWR, .borderSize = borderWidth});
+    };
+
+    std::vector<std::string> selectionTokens;
+    if (!std::string{*PSELECTMAP}.empty())
+        selectionTokens = splitCommaList(std::string{*PSELECTMAP});
+
+    if (dynamicGrid) {
+        const std::string legacyAnchor = normalizeAnchor(std::string{*PLABELPOSL});
+        // PR #605 treated label_size as the badge size and rendered text at
+        // half that size; preserve that legacy meaning on the richer renderer.
+        const int         legacyFont   = std::max(8, (int)**PLABELSIZEL / 2);
+        const CHyprColor  legacyColor{(uint64_t)**PLABELCOLL};
+
+        int tokenCounter = 0;
+        for (size_t id = 0; id < images.size(); ++id) {
+            const auto& image = images[id];
+            if (image.workspaceID == WORKSPACE_INVALID)
+                continue;
+
+            const auto& tile = tileBoxes[id];
+            if (tile.w <= 0.0 || tile.h <= 0.0)
+                continue;
+
+            const std::string label = showWorkspaceNames ? resolveWorkspaceName(id) : std::to_string(image.workspaceID);
+            if (!label.empty())
+                renderLabel(images[id].labelTexDefault, images[id].labelSizeDefault, label, legacyColor, 1.0f, tile, legacyAnchor, **PLABELOX, **PLABELOY, legacyFont);
+
+            if (**PSELECTEN && tokenCounter < (int)selectionTokens.size() && !selectionTokens[tokenCounter].empty())
+                renderLabel(images[id].selectionLabelTex, images[id].selectionLabelSize, selectionTokens[tokenCounter], CHyprColor{(uint64_t)**PSELECTCOL}, 1.0f, tile,
+                            std::string{*PSELECTPOS}, **PSELECTOX, **PSELECTOY, **PLABELSIZE);
+
+            ++tokenCounter;
+        }
+    } else if (**PLABELEN || **PSELECTEN || showWorkspaceNumbers) {
+        const int labelHoveredID = closing ? -1 : hoveredID;
+
+        auto shouldShow = [&](int id) -> bool {
+            if (showWorkspaceNumbers)
+                return true;
+            if (std::string{*PLABELSHOW} == "never")
+                return false;
+            if (std::string{*PLABELSHOW} == "always")
+                return true;
+            const bool isHover = id == labelHoveredID;
+            const bool isFocus = id == kbFocusID;
+            const bool isCurr  = id == openedID;
+            const std::string mode{*PLABELSHOW};
+            if (mode == "hover")
+                return isHover;
+            if (mode == "focus")
+                return isFocus;
+            if (mode == "hover+focus")
+                return isHover || isFocus;
+            if (mode == "current+focus")
+                return isCurr || isFocus;
+            return true;
+        };
+
+        auto resolveState = [&](int id) -> int {
+            if (id == kbFocusID)
+                return 2;
+            if (id == openedID)
+                return 3;
+            if (id == labelHoveredID)
+                return 1;
+            return 0;
+        };
+
+        std::vector<std::string> labelTokens;
+        if (!std::string{*PTOKENMAP}.empty())
+            labelTokens = splitCommaList(std::string{*PTOKENMAP});
+
+        int tokenCounter = 0;
+        for (size_t id = 0; id < images.size(); ++id) {
+            const auto& image = images[id];
+            const auto& tile  = tileBoxes[id];
+
+            if (image.workspaceID == WORKSPACE_INVALID || tile.w <= 0.0 || tile.h <= 0.0)
+                continue;
+
+            if ((**PLABELEN || showWorkspaceNumbers) && shouldShow((int)id)) {
+                std::string label;
+                const std::string mode = showWorkspaceNumbers ? std::string{"id"} : std::string{*PLABELMODE};
+                if (mode == "token") {
+                    if (tokenCounter < (int)labelTokens.size() && !labelTokens[tokenCounter].empty())
+                        label = labelTokens[tokenCounter];
+                    else
+                        label = fallbackTokenForVisibleIndex(tokenCounter);
+                } else if (mode == "index") {
+                    label = std::to_string(tokenCounter + 1);
+                } else {
+                    label = std::to_string(images[id].workspaceID);
+                }
+
+                const int st = resolveState((int)id);
+                if (!label.empty()) {
+                    if (showWorkspaceNumbers)
+                        renderLabel(images[id].labelTexDefault, images[id].labelSizeDefault, label, CHyprColor{(uint64_t)**PWSNUMCOL}, 1.0f, tile, std::string{*PLABELPOS}, **PLABELOX, **PLABELOY,
+                                    **PLABELSIZE);
+                    else if (st == 1)
+                        renderLabel(images[id].labelTexHover, images[id].labelSizeHover, label, CHyprColor{(uint64_t)**PLCOLHOV}, **PLSCALEH, tile, std::string{*PLABELPOS}, **PLABELOX,
+                                    **PLABELOY, **PLABELSIZE);
+                    else if (st == 2)
+                        renderLabel(images[id].labelTexFocus, images[id].labelSizeFocus, label, CHyprColor{(uint64_t)**PLCOLFOC}, **PLSCALEF, tile, std::string{*PLABELPOS}, **PLABELOX,
+                                    **PLABELOY, **PLABELSIZE);
+                    else if (st == 3)
+                        renderLabel(images[id].labelTexCurrent, images[id].labelSizeCurrent, label, CHyprColor{(uint64_t)**PLCOLCUR}, 1.0f, tile, std::string{*PLABELPOS}, **PLABELOX,
+                                    **PLABELOY, **PLABELSIZE);
+                    else
+                        renderLabel(images[id].labelTexDefault, images[id].labelSizeDefault, label, CHyprColor{(uint64_t)**PLCOLDEF}, 1.0f, tile, std::string{*PLABELPOS}, **PLABELOX,
+                                    **PLABELOY, **PLABELSIZE);
+                }
+            }
+
+            if (**PSELECTEN && tokenCounter < (int)selectionTokens.size() && !selectionTokens[tokenCounter].empty())
+                renderLabel(images[id].selectionLabelTex, images[id].selectionLabelSize, selectionTokens[tokenCounter], CHyprColor{(uint64_t)**PSELECTCOL}, 1.0f, tile,
+                            std::string{*PSELECTPOS}, **PSELECTOX, **PSELECTOY, **PLABELSIZE);
+
+            ++tokenCounter;
+        }
+    }
+
+    const int RND_CUR = CURRENT_ROUND_SCALED;
+    const int RND_FOC = FOCUS_ROUND_SCALED;
+    const int RND_HOV = HOVER_ROUND_SCALED;
+
+    if (dynamicGrid) {
+        if (hoveredID != -1 && hoveredID != openedID && hoveredID != kbFocusID) {
+            const int hoverWidth = **PHOVBORDER;
+            if (hoverWidth > 0)
+                drawSolidBorderForID(hoveredID, CHyprColor{(uint64_t)**PHOVCOL}, RND_HOV, std::max(1, (int)std::lround(hoverWidth * MON->m_scale)));
+        }
+
+        const int activeWidth = **PACTBORDER;
+        if (activeWidth > 0)
+            drawSolidBorderForID(openedID, CHyprColor{(uint64_t)**PACTCOL}, RND_CUR, std::max(1, (int)std::lround(activeWidth * MON->m_scale)));
+
+        if (kbFocusID != -1)
+            drawBorderForID(kbFocusID, std::string{*PBCOLFOC}, std::string{*PBGREFOC}, RND_FOC);
+    } else {
+        if (hoveredID != -1 && hoveredID != openedID && hoveredID != kbFocusID)
+            drawBorderForID(hoveredID, std::string{*PBCOLHOV}, std::string{*PBGREHOV}, RND_HOV);
+        drawBorderForID(openedID, std::string{*PBCOLCUR}, std::string{*PBGRCUR}, RND_CUR);
+        if (kbFocusID != -1)
+            drawBorderForID(kbFocusID, std::string{*PBCOLFOC}, std::string{*PBGREFOC}, RND_FOC);
+    }
+
     if (dragMoved && dragSourceID != -1) {
         const std::string sourceBorder = std::string{*PDRAGSOURCEBORDER}.empty() ? std::string{*PBCOLFOC} : std::string{*PDRAGSOURCEBORDER};
         const int         sourceWidth  = **PDRAGSOURCEBWIDTH >= 0 ? **PDRAGSOURCEBWIDTH : (int)**PBWIDTH;
         drawBorderForID(dragSourceID, sourceBorder, std::string{*PBGREFOC}, RND_FOC, sourceWidth);
     }
 
-    dropIntent = {};
+    dropIntent         = {};
     dropIntentTargetID = -1;
 
     if (dragWindow && isTileValid(dragSourceID)) {
         const auto windowBox = dragWindow->getWindowMainSurfaceBox();
         if (windowBox.w > 0 && windowBox.h > 0) {
-            const CBox&  sourceBox = tileBoxes[dragSourceID];
-            const double scaleX    = sourceBox.w / MON->m_size.x;
-            const double scaleY    = sourceBox.h / MON->m_size.y;
-            const double minW      = std::min(sourceBox.w, 24.0 * MON->m_scale);
-            const double minH      = std::min(sourceBox.h, 24.0 * MON->m_scale);
+            const CBox& sourceBox = tileBoxes[dragSourceID];
+            const double scaleX   = sourceBox.w / MON->m_size.x;
+            const double scaleY   = sourceBox.h / MON->m_size.y;
+            const double minW     = std::min(sourceBox.w, 24.0 * MON->m_scale);
+            const double minH     = std::min(sourceBox.h, 24.0 * MON->m_scale);
 
             CBox proxy{
                 lastMousePosLocal.x * MON->m_scale - dragGrabOffset.x * scaleX,
@@ -684,17 +771,11 @@ void COverview::fullRender() {
 
             const int maxProxyRound = std::max(0, (int)std::floor(std::min(proxy.w, proxy.h) / 2.0));
             const int autoRound     = std::min(RND_FOC, maxProxyRound);
-            const int round         = **PDRAGPROXYROUND >= 0 ? std::min(std::max(0, (int)std::lround((double)**PDRAGPROXYROUND * MON->m_scale)), maxProxyRound) : autoRound;
+            const int round        = **PDRAGPROXYROUND >= 0 ? std::min(std::max(0, (int)std::lround((double)**PDRAGPROXYROUND * MON->m_scale)), maxProxyRound) : autoRound;
 
             if (dragMoved && hoveredID != -1 && hoveredID != dragSourceID && isTileValid(hoveredID)) {
-                const int tx = hoveredID % SIDE_LENGTH;
-                const int ty = hoveredID / SIDE_LENGTH;
-                const Hyprexpo::SRect targetTileLocal{
-                    OUTER + tx * tileRenderSize.x + tx * GAPSIZE,
-                    OUTER + ty * tileRenderSize.y + ty * GAPSIZE,
-                    tileRenderSize.x,
-                    tileRenderSize.y,
-                };
+                const auto targetTileBox = tileBoxForIndex(hoveredID, SIZE, GAPSIZE, OUTER, true);
+                const Hyprexpo::SRect targetTileLocal{targetTileBox.x, targetTileBox.y, targetTileBox.w, targetTileBox.h};
                 dropIntent = Hyprexpo::computeDropIntentGeometry({
                     .targetValid     = true,
                     .pointerLocal    = {lastMousePosLocal.x, lastMousePosLocal.y},
@@ -717,8 +798,7 @@ void COverview::fullRender() {
                 targetProxy.round();
 
                 const int targetMaxRound = std::max(0, (int)std::floor(std::min(targetProxy.w, targetProxy.h) / 2.0));
-                const int targetRound    = **PDRAGPROXYROUND >= 0 ? std::min(std::max(0, (int)std::lround((double)**PDRAGPROXYROUND * MON->m_scale)), targetMaxRound) :
-                                                                   std::min(RND_FOC, targetMaxRound);
+                const int targetRound    = **PDRAGPROXYROUND >= 0 ? std::min(std::max(0, (int)std::lround((double)**PDRAGPROXYROUND * MON->m_scale)), targetMaxRound) : std::min(RND_FOC, targetMaxRound);
                 Render::GL::g_pHyprOpenGL->renderRect(targetProxy, CHyprColor{(uint64_t)**PDRAGPROXYACTCOL}, {.round = targetRound, .roundingPower = ROUND_PWR});
 
                 const int   borderWidth   = **PDRAGPROXYBWIDTH >= 0 ? **PDRAGPROXYBWIDTH : std::max(2, (int)**PBWIDTH + 1);
@@ -735,4 +815,7 @@ void COverview::fullRender() {
             drawProxyBorder(proxy, round, borderWidth, effectiveSpec, std::string{*PBGREFOC});
         }
     }
+
+    if (entryAnimationPending)
+        damage();
 }

--- a/OverviewRender.cpp
+++ b/OverviewRender.cpp
@@ -316,6 +316,12 @@ void COverview::fullRender() {
     const auto SHAPE   = currentGridShape();
 
     clearWithColor(BG_COLOR.stripA());
+    if (wallpaperBg && MON->m_background) {
+        CRegion backgroundDamage{0, 0, INT16_MAX, INT16_MAX};
+        CBox    backgroundBox{{0, 0}, MON->m_transformedSize};
+        Render::GL::g_pHyprOpenGL->renderTextureInternal(MON->m_background, backgroundBox, {.damage = &backgroundDamage, .a = 1.0f});
+        Render::GL::g_pHyprOpenGL->renderRect(backgroundBox, CHyprColor{0x00000066}, {});
+    }
 
     static auto* const* PTILEROUND  = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:tile_rounding")->getDataStaticPtr();
     static auto* const* PTOUNDPWR   = (Hyprlang::FLOAT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:tile_rounding_power")->getDataStaticPtr();

--- a/PluginConfig.cpp
+++ b/PluginConfig.cpp
@@ -15,6 +15,24 @@ static void addConfigValue(SP<Config::Values::IValue> value) {
 }
 
 void registerHyprexpoConfigValues() {
+    // PR #605 compatibility keys: registered separately from the richer
+    // sandwichfarm config surface so later integration can consume them
+    // without changing existing option names or defaults.
+    addConfigValue(makeShared<Config::Values::CIntValue>("plugin:hyprexpo:dynamic_grid", "legacy dynamic grid toggle", HyprexpoConfig::LEGACY_DYNAMIC_GRID_DEFAULT));
+    addConfigValue(makeShared<Config::Values::CIntValue>("plugin:hyprexpo:fill_gaps", "legacy gap filling toggle", HyprexpoConfig::LEGACY_FILL_GAPS_DEFAULT));
+    addConfigValue(makeShared<Config::Values::CIntValue>("plugin:hyprexpo:mru_sort", "legacy mru sorting toggle", HyprexpoConfig::LEGACY_MRU_SORT_DEFAULT));
+    addConfigValue(makeShared<Config::Values::CColorValue>("plugin:hyprexpo:active_highlight_col", "legacy active tile highlight color", HyprexpoConfig::LEGACY_ACTIVE_HIGHLIGHT_COL_DEFAULT));
+    addConfigValue(makeShared<Config::Values::CIntValue>("plugin:hyprexpo:active_highlight_border", "legacy active tile highlight border", HyprexpoConfig::LEGACY_ACTIVE_HIGHLIGHT_BORDER_DEFAULT));
+    addConfigValue(makeShared<Config::Values::CColorValue>("plugin:hyprexpo:hover_highlight_col", "legacy hovered tile highlight color", HyprexpoConfig::LEGACY_HOVER_HIGHLIGHT_COL_DEFAULT));
+    addConfigValue(makeShared<Config::Values::CIntValue>("plugin:hyprexpo:hover_highlight_border", "legacy hovered tile highlight border", HyprexpoConfig::LEGACY_HOVER_HIGHLIGHT_BORDER_DEFAULT));
+    addConfigValue(makeShared<Config::Values::CStringValue>("plugin:hyprexpo:label_pos", "legacy label anchor", HyprexpoConfig::LEGACY_LABEL_POS_DEFAULT));
+    addConfigValue(makeShared<Config::Values::CIntValue>("plugin:hyprexpo:label_size", "legacy label font size", HyprexpoConfig::LEGACY_LABEL_SIZE_DEFAULT));
+    addConfigValue(makeShared<Config::Values::CColorValue>("plugin:hyprexpo:label_col", "legacy label color", HyprexpoConfig::LEGACY_LABEL_COL_DEFAULT));
+    addConfigValue(makeShared<Config::Values::CIntValue>("plugin:hyprexpo:show_workspace_names", "legacy workspace-name label toggle", HyprexpoConfig::LEGACY_SHOW_WORKSPACE_NAMES_DEFAULT));
+    addConfigValue(makeShared<Config::Values::CIntValue>("plugin:hyprexpo:enable_keyboard_nav", "legacy keyboard navigation toggle", HyprexpoConfig::LEGACY_ENABLE_KEYBOARD_NAV_DEFAULT));
+    addConfigValue(makeShared<Config::Values::CIntValue>("plugin:hyprexpo:enable_drag_move", "legacy drag-move toggle", HyprexpoConfig::LEGACY_ENABLE_DRAG_MOVE_DEFAULT));
+    addConfigValue(makeShared<Config::Values::CIntValue>("plugin:hyprexpo:animate_entry", "legacy entry animation toggle", HyprexpoConfig::LEGACY_ANIMATE_ENTRY_DEFAULT));
+
     addConfigValue(makeShared<Config::Values::CIntValue>("plugin:hyprexpo:columns", "columns", HyprexpoConfig::COLUMNS_DEFAULT));
     addConfigValue(makeShared<Config::Values::CIntValue>("plugin:hyprexpo:gaps_in", "inner gaps", HyprexpoConfig::GAPS_IN_DEFAULT));
     addConfigValue(makeShared<Config::Values::CColorValue>("plugin:hyprexpo:bg_col", "background color", HyprexpoConfig::BG_COL_DEFAULT));

--- a/PluginConfig.cpp
+++ b/PluginConfig.cpp
@@ -32,6 +32,7 @@ void registerHyprexpoConfigValues() {
     addConfigValue(makeShared<Config::Values::CIntValue>("plugin:hyprexpo:enable_keyboard_nav", "legacy keyboard navigation toggle", HyprexpoConfig::LEGACY_ENABLE_KEYBOARD_NAV_DEFAULT));
     addConfigValue(makeShared<Config::Values::CIntValue>("plugin:hyprexpo:enable_drag_move", "legacy drag-move toggle", HyprexpoConfig::LEGACY_ENABLE_DRAG_MOVE_DEFAULT));
     addConfigValue(makeShared<Config::Values::CIntValue>("plugin:hyprexpo:animate_entry", "legacy entry animation toggle", HyprexpoConfig::LEGACY_ANIMATE_ENTRY_DEFAULT));
+    addConfigValue(makeShared<Config::Values::CIntValue>("plugin:hyprexpo:wallpaper_bg", "draw the monitor wallpaper behind overview tiles", HyprexpoConfig::WALLPAPER_BG_DEFAULT));
 
     addConfigValue(makeShared<Config::Values::CIntValue>("plugin:hyprexpo:columns", "columns", HyprexpoConfig::COLUMNS_DEFAULT));
     addConfigValue(makeShared<Config::Values::CIntValue>("plugin:hyprexpo:gaps_in", "inner gaps", HyprexpoConfig::GAPS_IN_DEFAULT));

--- a/README.md
+++ b/README.md
@@ -207,6 +207,26 @@ hl.define_submap("hyprexpo", function()
 end)
 ```
 
+## Active workspace grid
+
+For a more dynamic workspace grid with labels and wallpaper background:
+
+```
+plugin {
+    hyprexpo {
+        dynamic_grid = 1
+        fill_gaps = 0
+        mru_sort = 0
+        show_workspace_names = 1
+        label_pos = top_right
+        label_size = 48
+        wallpaper_bg = 1
+    }
+}
+```
+
+For more options, see the [configuration options](https://hyprexpo.lol/docs/configuration/options/).
+
 ## Next Steps
 
 - [Installation details](https://hyprexpo.lol/docs/getting-started/installation/)

--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -48,6 +48,30 @@ hl.config({
 `hl.plugin.hyprexpo` is the Lua helper namespace for dispatchers and gestures;
 it is not the configuration block.
 
+## PR #605 Compatibility Keys
+
+These keys are registered for the active-overview port and are intentionally
+separate from the richer sandwichfarm config surface. They are kept for later
+integration and should not replace the newer keys below.
+
+| key | type | legacy meaning | newer sandwichfarm counterpart |
+| --- | --- | --- | --- |
+| `plugin:hyprexpo:dynamic_grid` | int | dynamic workspace enumeration toggle | no direct equivalent yet |
+| `plugin:hyprexpo:fill_gaps` | int | expand min..max workspace IDs when dynamic | no direct equivalent yet |
+| `plugin:hyprexpo:mru_sort` | int | put the current workspace first | no direct equivalent yet |
+| `plugin:hyprexpo:active_highlight_col` | color | active tile highlight color | `border_color_current` |
+| `plugin:hyprexpo:active_highlight_border` | int | active tile highlight width | `border_width` |
+| `plugin:hyprexpo:hover_highlight_col` | color | hovered tile highlight color | `border_color_hover` |
+| `plugin:hyprexpo:hover_highlight_border` | int | hovered tile highlight width | `border_width` |
+| `plugin:hyprexpo:label_pos` | string | legacy underscore anchor such as `top_right` | `label_position` (`top-right`) |
+| `plugin:hyprexpo:label_size` | int | legacy label font size | `label_font_size` |
+| `plugin:hyprexpo:label_col` | color | legacy label tint | `label_color` / `label_color_default` |
+| `plugin:hyprexpo:show_workspace_names` | int | legacy name/number toggle | `show_workspace_numbers` and `label_text_mode` |
+| `plugin:hyprexpo:enable_keyboard_nav` | int | legacy keyboard-navigation toggle | `keynav_enable` |
+| `plugin:hyprexpo:enable_drag_move` | int | legacy drag-move toggle | no direct equivalent yet |
+| `plugin:hyprexpo:animate_entry` | int | legacy open animation toggle | no direct equivalent yet |
+
+
 ## Layout and Behavior
 
 | key | type | description | default |

--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -56,7 +56,7 @@ integration and should not replace the newer keys below.
 
 | key | type | legacy meaning | newer sandwichfarm counterpart |
 | --- | --- | --- | --- |
-| `plugin:hyprexpo:dynamic_grid` | int | dynamic workspace enumeration toggle | no direct equivalent yet |
+| `plugin:hyprexpo:dynamic_grid` | int | opt-in dynamic workspace enumeration (default: off) | no direct equivalent yet |
 | `plugin:hyprexpo:fill_gaps` | int | expand min..max workspace IDs when dynamic | no direct equivalent yet |
 | `plugin:hyprexpo:mru_sort` | int | put the current workspace first | no direct equivalent yet |
 | `plugin:hyprexpo:active_highlight_col` | color | active tile highlight color | `border_color_current` |
@@ -64,7 +64,7 @@ integration and should not replace the newer keys below.
 | `plugin:hyprexpo:hover_highlight_col` | color | hovered tile highlight color | `border_color_hover` |
 | `plugin:hyprexpo:hover_highlight_border` | int | hovered tile highlight width | `border_width` |
 | `plugin:hyprexpo:label_pos` | string | legacy underscore anchor such as `top_right` | `label_position` (`top-right`) |
-| `plugin:hyprexpo:label_size` | int | legacy label font size | `label_font_size` |
+| `plugin:hyprexpo:label_size` | int | legacy badge size; text renders at roughly half this size | `label_font_size` |
 | `plugin:hyprexpo:label_col` | color | legacy label tint | `label_color` / `label_color_default` |
 | `plugin:hyprexpo:show_workspace_names` | int | legacy name/number toggle | `show_workspace_numbers` and `label_text_mode` |
 | `plugin:hyprexpo:enable_keyboard_nav` | int | legacy keyboard-navigation toggle | `keynav_enable` |
@@ -72,6 +72,22 @@ integration and should not replace the newer keys below.
 | `plugin:hyprexpo:animate_entry` | int | legacy open animation toggle | no direct equivalent yet |
 | `plugin:hyprexpo:wallpaper_bg` | int | draw the monitor wallpaper behind the overview tiles | optional active-overview extension |
 
+Enable the active-workspace layout explicitly; all compatibility options default
+to the existing fixed-grid behavior:
+
+```ini
+plugin {
+    hyprexpo {
+        dynamic_grid = 1
+        fill_gaps = 0
+        mru_sort = 0
+        show_workspace_names = 1
+        label_pos = top_right
+        label_size = 48
+        wallpaper_bg = 1
+    }
+}
+```
 
 ## Layout and Behavior
 

--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -70,6 +70,7 @@ integration and should not replace the newer keys below.
 | `plugin:hyprexpo:enable_keyboard_nav` | int | legacy keyboard-navigation toggle | `keynav_enable` |
 | `plugin:hyprexpo:enable_drag_move` | int | legacy drag-move toggle | no direct equivalent yet |
 | `plugin:hyprexpo:animate_entry` | int | legacy open animation toggle | no direct equivalent yet |
+| `plugin:hyprexpo:wallpaper_bg` | int | draw the monitor wallpaper behind the overview tiles | optional active-overview extension |
 
 
 ## Layout and Behavior

--- a/docs/guides/runtime-smoke.md
+++ b/docs/guides/runtime-smoke.md
@@ -40,6 +40,9 @@ Nested test binds:
 20. Toggle `wallpaper_bg` and reopen the overview. Confirm the wallpaper changes only the background and does not move or resize tiles.
 21. Toggle `mru_sort` and confirm the current workspace moves to the first tile only when enabled. Toggle `fill_gaps` with non-contiguous workspace IDs and confirm missing IDs are added only when enabled.
 22. With only one active workspace, complete and cancel a swipe. Confirm the overview exits cleanly without a crash or invalid animation state.
+23. With `dynamic_grid = 1`, leave the current workspace empty and open a window on a neighboring workspace. Open and close with `hyprexpo:expo, toggle`; confirm the current workspace does not change.
+24. With `dynamic_grid = 1` and `fill_gaps = 1`, create distant workspace IDs (for example 1 and 5000). Open the overview; confirm it rejects gap expansion, remains responsive, and shows only the sparse workspaces.
+25. With `dynamic_grid = 1`, set `label_enable = 0`, then `label_show = never`, and set modern `border_color_current` / `border_color_hover` values. Confirm labels stay hidden and the modern border colors win over legacy highlight values.
 
 ::: warning
 The public site and docs should not claim full release readiness until this runtime smoke gate has been completed for the intended release artifact.

--- a/docs/guides/runtime-smoke.md
+++ b/docs/guides/runtime-smoke.md
@@ -34,6 +34,13 @@ Nested test binds:
 15. Set `plugin:hyprexpo:show_pinned_windows = 0` again, close overview, and confirm the pinned window is still visible and pinned in the normal Hyprland session.
 16. Unload or reload the plugin after closing overview and confirm no stale render pass callback crashes the session.
 
+17. Enable `dynamic_grid = 1`, then test with 1, 2, 3, and 5 non-empty, non-special workspaces. Confirm the overview contains exactly those workspaces without padded empty tiles.
+18. Confirm every preview preserves the monitor aspect ratio. For 3 and 5 workspaces, confirm the partial final row is independently centered.
+19. Set `label_pos = top_right`, choose a visible `label_size`, and toggle `show_workspace_names`. Confirm every label remains inside its corresponding tile.
+20. Toggle `wallpaper_bg` and reopen the overview. Confirm the wallpaper changes only the background and does not move or resize tiles.
+21. Toggle `mru_sort` and confirm the current workspace moves to the first tile only when enabled. Toggle `fill_gaps` with non-contiguous workspace IDs and confirm missing IDs are added only when enabled.
+22. With only one active workspace, complete and cancel a swipe. Confirm the overview exits cleanly without a crash or invalid animation state.
+
 ::: warning
 The public site and docs should not claim full release readiness until this runtime smoke gate has been completed for the intended release artifact.
 :::

--- a/tests/HyprexpoLogicTests.cpp
+++ b/tests/HyprexpoLogicTests.cpp
@@ -1,9 +1,12 @@
 #include "../HyprexpoLogic.hpp"
 #include "../HyprexpoConfig.hpp"
 
+#include <algorithm>
+#include <cmath>
 #include <cstdlib>
 #include <iostream>
 #include <string>
+#include <vector>
 
 namespace {
 
@@ -17,12 +20,132 @@ void expect(bool condition, const std::string& label) {
     std::cerr << "FAIL: " << label << '\n';
 }
 
-bool near(float a, float b) {
-    return std::abs(a - b) < 0.001F;
+bool near(double a, double b, double eps = 0.001) {
+    return std::abs(a - b) < eps;
 }
 
-bool near(double a, double b) {
-    return std::abs(a - b) < 0.001;
+Hyprexpo::SSize makeSize(double w, double h) {
+    return {w, h};
+}
+
+std::vector<Hyprexpo::STileLayout> layoutsFor(int count, const Hyprexpo::SGridShape& shape, const Hyprexpo::SSize& total, double gap, bool centerPartialRows) {
+    std::vector<Hyprexpo::STileLayout> layouts;
+    for (int i = 0; i < count; ++i)
+        layouts.push_back(Hyprexpo::computeTileLayout(i, count, shape, total, gap, centerPartialRows));
+    return layouts;
+}
+
+void checkGeometryForMonitor(const Hyprexpo::SSize& total) {
+    constexpr double gap = 24.0;
+
+    for (int count = 1; count <= 10; ++count) {
+        const auto shape = Hyprexpo::computeDynamicGridShape(count);
+        const int  expectedCols = std::max(1, static_cast<int>(std::ceil(std::sqrt(static_cast<double>(count)))));
+        int        expectedRows = static_cast<int>(std::ceil(static_cast<double>(count) / expectedCols));
+        if (count > 1 && expectedRows < 2)
+            expectedRows = 2;
+
+        expect(shape.cols == expectedCols, "dynamic cols for count " + std::to_string(count));
+        expect(shape.rows == expectedRows, "dynamic rows for count " + std::to_string(count));
+
+        const auto tile = Hyprexpo::aspectCorrectTileSize(total.w, total.h, shape.cols, shape.rows, gap);
+        const double monitorAspect = total.w / total.h;
+        expect(near(tile.w / tile.h, monitorAspect), "tile aspect matches monitor aspect for count " + std::to_string(count));
+
+        const double maxTileW = std::max(0.0, (total.w - gap * (shape.cols - 1)) / shape.cols);
+        const double maxTileH = std::max(0.0, (total.h - gap * (shape.rows - 1)) / shape.rows);
+        expect(tile.w <= maxTileW + 0.001 && tile.h <= maxTileH + 0.001, "tile fits within cell for count " + std::to_string(count));
+
+        const auto layouts = layoutsFor(count, shape, total, gap, true);
+        const int occupiedRows = std::max(1, static_cast<int>(std::ceil(static_cast<double>(count) / shape.cols)));
+        const double gridW = shape.cols * tile.w + (shape.cols - 1) * gap;
+        const double gridH = occupiedRows * tile.h + (occupiedRows - 1) * gap;
+        const double baseX = (total.w - gridW) / 2.0;
+        const double baseY = (total.h - gridH) / 2.0;
+
+        double minX = layouts.front().box.x;
+        double minY = layouts.front().box.y;
+        double maxX = layouts.front().box.x + layouts.front().box.w;
+        double maxY = layouts.front().box.y + layouts.front().box.h;
+        for (const auto& layout : layouts) {
+            minX = std::min(minX, layout.box.x);
+            minY = std::min(minY, layout.box.y);
+            maxX = std::max(maxX, layout.box.x + layout.box.w);
+            maxY = std::max(maxY, layout.box.y + layout.box.h);
+        }
+
+        expect(near(minX, baseX), "grid centered horizontally for count " + std::to_string(count));
+        expect(near(minY, baseY), "grid centered vertically for count " + std::to_string(count));
+        expect(near(maxX - minX, gridW), "grid width consistent for count " + std::to_string(count));
+        expect(near(maxY - minY, gridH), "grid height consistent for count " + std::to_string(count));
+
+        for (int row = 0; row < occupiedRows; ++row) {
+            std::vector<const Hyprexpo::STileLayout*> rowTiles;
+            for (const auto& layout : layouts) {
+                if (layout.row == row)
+                    rowTiles.push_back(&layout);
+            }
+            std::sort(rowTiles.begin(), rowTiles.end(), [](const auto* a, const auto* b) { return a->col < b->col; });
+
+            for (size_t i = 1; i < rowTiles.size(); ++i) {
+                const auto& left = *rowTiles[i - 1];
+                const auto& right = *rowTiles[i];
+                expect(near(right.box.x - (left.box.x + left.box.w), gap), "uniform horizontal gap for count " + std::to_string(count));
+            }
+        }
+
+        for (int row = 1; row < occupiedRows; ++row) {
+            for (int col = 0; col < shape.cols; ++col) {
+                const int upperIndex = row * shape.cols + col;
+                const int lowerIndex = (row - 1) * shape.cols + col;
+                if (upperIndex >= count || lowerIndex >= count)
+                    continue;
+
+                const auto& upper = layouts[lowerIndex];
+                const auto& lower = layouts[upperIndex];
+                expect(near(lower.box.y - (upper.box.y + upper.box.h), gap), "uniform vertical gap for count " + std::to_string(count));
+            }
+        }
+
+        for (int i = 0; i < count; ++i) {
+            const auto& box = layouts[i].box;
+            const double centerX = box.x + box.w / 2.0;
+            const double centerY = box.y + box.h / 2.0;
+            expect(Hyprexpo::tileIndexAtPoint(centerX, centerY, count, shape, total, gap, true) == i, "hit test returns tile center for count " + std::to_string(count));
+        }
+
+        if (shape.cols > 1) {
+            const auto& left = layouts[0].box;
+            const double gapX = left.x + left.w + gap / 2.0;
+            const double gapY = left.y + left.h / 2.0;
+            expect(Hyprexpo::tileIndexAtPoint(gapX, gapY, count, shape, total, gap, true) == -1, "hit test rejects tile gap for count " + std::to_string(count));
+        }
+
+        const int lastRowCount = count % shape.cols == 0 ? shape.cols : count % shape.cols;
+        if (lastRowCount < shape.cols && count > shape.cols) {
+            const int lastRow = occupiedRows - 1;
+            std::vector<const Hyprexpo::STileLayout*> rowTiles;
+            for (const auto& layout : layouts) {
+                if (layout.row == lastRow)
+                    rowTiles.push_back(&layout);
+            }
+            std::sort(rowTiles.begin(), rowTiles.end(), [](const auto* a, const auto* b) { return a->col < b->col; });
+
+            const double rowMinX = rowTiles.front()->box.x;
+            const double rowMaxX = rowTiles.back()->box.x + rowTiles.back()->box.w;
+            expect(near((rowMinX - minX), (maxX - rowMaxX)), "partial row is centered for count " + std::to_string(count));
+
+            const double emptyX = rowMinX - gap / 2.0;
+            const double emptyY = rowTiles.front()->box.y + rowTiles.front()->box.h / 2.0;
+            expect(Hyprexpo::tileIndexAtPoint(emptyX, emptyY, count, shape, total, gap, true) == -1, "hit test rejects centered empty region for count " + std::to_string(count));
+        }
+
+        if (count == 2) {
+            expect(shape.rows == 2, "count 2 keeps two-row grid shape");
+            expect(near(layouts[0].box.y, layouts[1].box.y), "count 2 stays on one occupied row");
+            expect(near(layouts[0].box.y, (total.h - tile.h) / 2.0), "count 2 row is vertically centered");
+        }
+    }
 }
 
 }
@@ -38,10 +161,10 @@ int main() {
     expect(clampGridColumns(99) == 7, "columns clamp upper bound");
     expect(HyprexpoConfig::SHOW_PINNED_WINDOWS_DEFAULT == 0, "pinned windows are hidden from previews by default");
 
-    expect(tileIndexFromPoint(0, 0, 300, 300, 3) == 0, "tile index top-left");
-    expect(tileIndexFromPoint(299, 299, 300, 300, 3) == 8, "tile index bottom-right inside");
-    expect(tileIndexFromPoint(300, 300, 300, 300, 3) == 8, "tile index clamps monitor edge");
-    expect(tileIndexFromPoint(10, 10, 0, 300, 3) == -1, "tile index rejects invalid width");
+    expect(tileIndexFromPoint(0, 0, 300, 300, 3) == 0, "legacy tile index top-left");
+    expect(tileIndexFromPoint(299, 299, 300, 300, 3) == 8, "legacy tile index bottom-right inside");
+    expect(tileIndexFromPoint(300, 300, 300, 300, 3) == 8, "legacy tile index clamps monitor edge");
+    expect(tileIndexFromPoint(10, 10, 0, 300, 3) == -1, "legacy tile index rejects invalid width");
 
     SDropIntentInput dropInput{
         .targetValid     = true,
@@ -69,7 +192,7 @@ int main() {
 
     dropInput.targetValid = false;
     expect(!computeDropIntentGeometry(dropInput).valid, "drop intent rejects invalid target");
-    dropInput.targetValid  = true;
+    dropInput.targetValid   = true;
     dropInput.windowSize.w = 0;
     expect(!computeDropIntentGeometry(dropInput).valid, "drop intent rejects invalid window size");
 
@@ -81,16 +204,16 @@ int main() {
 
     SColorRGBA color;
     expect(parseHexRGBA8("33ccffee", color), "parse rgba hex");
-    expect(near(color.r, 0x33 / 255.F) && near(color.a, 0xee / 255.F), "rgba channels are in rrggbbaa order");
+    expect(near(color.r, 0x33 / 255.0) && near(color.a, 0xee / 255.0), "rgba channels are in rrggbbaa order");
     expect(parseSolidColorSpec("rgb(66ccff)", color), "parse rgb solid color");
-    expect(near(color.r, 0x66 / 255.F) && near(color.a, 1.F), "rgb solid color is opaque");
+    expect(near(color.r, 0x66 / 255.0) && near(color.a, 1.0), "rgb solid color is opaque");
     expect(parseSolidColorSpec("0x8066ccff", color), "parse argb solid color");
-    expect(near(color.a, 0x80 / 255.F) && near(color.r, 0x66 / 255.F), "argb solid channel order");
+    expect(near(color.a, 0x80 / 255.0) && near(color.r, 0x66 / 255.0), "argb solid channel order");
     expect(!parseSolidColorSpec("rgb(nothex)", color), "invalid rgb solid rejected");
 
     const auto gradient = parseGradientSpec("rgba(33ccffee) rgba(00ff99ee) 45deg");
     expect(gradient.valid, "gradient parses two rgba colors");
-    expect(near(gradient.angleDeg, 45.F), "gradient angle parses");
+    expect(near(gradient.angleDeg, 45.0), "gradient angle parses");
     expect(!parseGradientSpec("rgba(33ccffee) nope 45deg").valid, "invalid gradient rejected");
     expect(isGradientBorderSpec("rgba(33ccffee) rgba(00ff99ee) 45deg"), "gradient border detected");
 
@@ -103,6 +226,10 @@ int main() {
     expect(method.valid && method.mode == EWorkspaceMethodMode::Center && method.workspace == "9", "per-monitor method wins");
     method = resolveWorkspaceMethodForMonitor("DP-1 first 1, center current", "eDP-1");
     expect(method.valid && method.mode == EWorkspaceMethodMode::Center && method.workspace == "current", "global fallback method applies");
+
+    checkGeometryForMonitor(makeSize(1600, 900));
+    checkGeometryForMonitor(makeSize(900, 1600));
+    checkGeometryForMonitor(makeSize(2560, 1080));
 
     if (failures != 0)
         return 1;

--- a/tests/HyprexpoLogicTests.cpp
+++ b/tests/HyprexpoLogicTests.cpp
@@ -5,6 +5,7 @@
 #include <cmath>
 #include <cstdlib>
 #include <iostream>
+#include <limits>
 #include <string>
 #include <vector>
 
@@ -160,6 +161,27 @@ int main() {
     expect(clampGridColumns(3) == 3, "columns keep valid value");
     expect(clampGridColumns(99) == 7, "columns clamp upper bound");
     expect(HyprexpoConfig::SHOW_PINNED_WINDOWS_DEFAULT == 0, "pinned windows are hidden from previews by default");
+
+    const auto boundedGapFill = expandDynamicWorkspaceIDs({2, 4}, true, 64);
+    expect(boundedGapFill.has_value(), "bounded fill_gaps range is accepted");
+    expect(boundedGapFill == std::optional<std::vector<int64_t>>{{2, 3, 4}}, "bounded fill_gaps range expands missing IDs");
+
+    const auto distantGapFill = expandDynamicWorkspaceIDs({1, 5000}, true, 64);
+    expect(!distantGapFill.has_value(), "distant fill_gaps range is rejected before allocation");
+
+    const auto extremeGapFill = expandDynamicWorkspaceIDs({std::numeric_limits<int64_t>::min(), std::numeric_limits<int64_t>::max()}, true, 64);
+    expect(!extremeGapFill.has_value(), "fill_gaps span check cannot overflow");
+
+    const auto sparseWithoutFill = expandDynamicWorkspaceIDs({1, 5000}, false, 64);
+    expect(sparseWithoutFill == std::optional<std::vector<int64_t>>{{1, 5000}}, "disabled fill_gaps preserves sparse workspace IDs");
+
+    expect(!shouldShowWorkspaceLabel(false, "always", true, true, true), "modern label_enable disables labels in dynamic mode");
+    expect(!shouldShowWorkspaceLabel(true, "never", true, true, true), "modern label_show never hides labels in dynamic mode");
+    expect(shouldShowWorkspaceLabel(true, "hover", true, false, false), "modern label_show hover displays the hovered label");
+    expect(!shouldShowWorkspaceLabel(true, "hover", false, true, true), "modern label_show hover does not fall through to focus or current");
+
+    expect(resolveBorderSpec("rgb(010203)", "0xffaabbcc") == "rgb(010203)", "modern border spec takes precedence over legacy color");
+    expect(resolveBorderSpec("", "0xffaabbcc") == "0xffaabbcc", "legacy border color is used only when the modern spec is empty");
 
     expect(tileIndexFromPoint(0, 0, 300, 300, 3) == 0, "legacy tile index top-left");
     expect(tileIndexFromPoint(299, 299, 300, 300, 3) == 8, "legacy tile index bottom-right inside");

--- a/tests/OverviewSourceTests.cpp
+++ b/tests/OverviewSourceTests.cpp
@@ -75,6 +75,39 @@ int main() {
     expect(mainSource.find("_ZN8CMonitor9addDamageERKN9Hyprutils4Math4CBoxE") == std::string::npos,
            "damage hook no longer uses the pre-0.56 monitor symbol");
 
+    const auto dispatchersSource = readFile("Dispatchers.cpp");
+    expect(!dispatchersSource.empty(), "Dispatchers.cpp can be read from repo root");
+    const auto expoDispatcher = extractFunction(dispatchersSource, "static SDispatchResult onExpoDispatcher(std::string arg) {");
+    expect(!expoDispatcher.empty(), "expo dispatcher function exists");
+
+    const auto toggleStart = expoDispatcher.find("if (arg == \"toggle\")");
+    const auto cancelStart = expoDispatcher.find("if (arg == \"cancel\")", toggleStart);
+    const auto toggleBlock = toggleStart == std::string::npos || cancelStart == std::string::npos ? std::string{} : expoDispatcher.substr(toggleStart, cancelStart - toggleStart);
+    expect(toggleBlock.find("g_pOverview->close(false);") != std::string::npos, "plain toggle close does not select a fallback workspace");
+
+    const auto offStart = expoDispatcher.find("if (arg == \"off\" || arg == \"close\" || arg == \"disable\")");
+    const auto offEnd   = expoDispatcher.find("\n    if (g_pOverview)\n        return {};", offStart);
+    const auto offBlock = offStart == std::string::npos || offEnd == std::string::npos ? std::string{} : expoDispatcher.substr(offStart, offEnd - offStart);
+    expect(offBlock.find("g_pOverview->close(false);") != std::string::npos, "plain off and close commands do not select a fallback workspace");
+
+    const auto overviewConstructor = extractFunction(source, "COverview::COverview(");
+    expect(!overviewConstructor.empty(), "overview constructor exists");
+    const auto gapExpansionPos = overviewConstructor.find("Hyprexpo::expandDynamicWorkspaceIDs(");
+    const auto dynamicResizePos = overviewConstructor.find("images.resize(visibleWorkspaceIDs.size())");
+    expect(gapExpansionPos != std::string::npos, "dynamic workspace enumeration uses the bounded expansion helper");
+    expect(dynamicResizePos != std::string::npos && gapExpansionPos < dynamicResizePos, "dynamic expansion is bounded before image allocation");
+    expect(overviewConstructor.find("for (int64_t id = minID; id <= maxID; ++id)") == std::string::npos,
+           "dynamic workspace enumeration has no unbounded min-to-max fill loop");
+
+    const auto renderSource = readFile("OverviewRender.cpp");
+    expect(!renderSource.empty(), "OverviewRender.cpp can be read from repo root");
+    const auto fullRender = extractFunction(renderSource, "void COverview::fullRender(");
+    expect(!fullRender.empty(), "overview fullRender function exists");
+    expect(fullRender.find("Hyprexpo::shouldShowWorkspaceLabel(") != std::string::npos,
+           "runtime label rendering uses modern label_enable and label_show policy in every grid mode");
+    expect(fullRender.find("Hyprexpo::resolveBorderSpec(") != std::string::npos,
+           "runtime border rendering uses modern-first border resolution with legacy fallback");
+
     if (failures != 0)
         return 1;
 


### PR DESCRIPTION
## Summary

- add an opt-in dynamic overview containing active, non-special workspaces
- preserve monitor aspect ratio and center incomplete final rows
- use one canonical tile layout for rendering, labels, borders, damage, input, drag/drop, keyboard navigation, swipe, and open/close animation
- restore the labels, highlights, ordering, and entry-animation options from hyprwm/hyprland-plugins#605
- add an optional wallpaper-backed overview background

## Background

This ports the active-overview work from hyprwm/hyprland-plugins#605 onto the Hyprland 0.56-compatible Hyprexpo implementation.

Rather than copying the old rendering and input hooks, the port keeps this fork's current Hyprland 0.56 APIs and richer keyboard, label, border, gesture, and drag/drop behavior. The geometry is centralized in pure helpers so every visual and interactive path uses the same tile boxes.

## Behavior

With `dynamic_grid = 1`, Hyprexpo:

- collects non-empty, non-special workspaces on the overview monitor
- optionally fills missing numeric IDs with `fill_gaps`
- optionally places the current workspace first with `mru_sort`
- chooses an adaptive grid shape from the visible workspace count
- keeps every preview at the monitor aspect ratio
- centers the occupied grid and independently centers a partial final row
- creates no padded invalid tiles

Compatibility options from PR #605 are registered separately from the existing configuration surface. Existing fixed-grid behavior remains the default.

`wallpaper_bg` is an independent, default-off rendering option and does not participate in layout calculations.

## Validation

- clean Meson build against Hyprland 0.56.0 (`36b2e0c`)
- repository-standard `make test` and `make -B all` pass
- `HyprexpoLogicTests` pass
  - workspace counts 1–10
  - landscape, portrait, and ultrawide monitors
  - aspect ratio, bounds, gaps, centering, partial rows, and hit-testing
- `OverviewSourceTests` pass
- nested Hyprland smoke test passes with 1–5 real non-empty workspaces
  - open, keyboard focus, and cancel exercised for every count
  - zero `hyprctl configerrors`
  - N=3 and N=5 visually verified for centered partial rows
  - labels, active/focus borders, and wallpaper background visually verified
- one-workspace swipe completion guards the zero-size animation span
- docs/site workflow commands pass (`./scripts/build-site.sh` and `./scripts/verify-site-dist.sh`)
- `git diff --check` passes
- no missing shared-library dependencies

## Compatibility

All new behavior is opt-in:

- `dynamic_grid = 0` by default
- `wallpaper_bg = 0` by default
- existing fixed-grid options and behavior are preserved

The implementation retains the original PR #605 option names for users migrating from that work while documenting their relationship to this fork's newer label, border, and keyboard options.
