### PR TITLE
fix: use Config::Actions::setSubmap after m_dispatchers removal

### DIFF
--- a/OverviewInteraction.cpp
+++ b/OverviewInteraction.cpp
@@ -9,6 +9,7 @@
 #include <hyprland/src/pointer/cursor/CursorShapeOverrideController.hpp>
 #include <hyprland/src/managers/eventLoop/EventLoopManager.hpp>
 #include <hyprland/src/state/WorkspaceState.hpp>
+#include <hyprland/src/config/shared/actions/ConfigActions.hpp>
 #include <algorithm>
 #include <chrono>
 #include <cmath>
@@ -652,14 +653,14 @@ void COverview::enterSubmapIfEnabled() {
     static auto* const* PKEYNAV = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:keynav_enable")->getDataStaticPtr();
     if (**PKEYNAV && !submapActive) {
         // switch to a dedicated submap for hyprexpo navigation
-        g_pKeybindManager->m_dispatchers["submap"]("hyprexpo");
+        (void)Config::Actions::setSubmap("hyprexpo");
         submapActive = true;
     }
 }
 
 void COverview::resetSubmapIfNeeded() {
     if (submapActive) {
-        g_pKeybindManager->m_dispatchers["submap"]("reset");
+        (void)Config::Actions::setSubmap("reset");
         submapActive = false;
     }
 }


### PR DESCRIPTION
## What

Fixes the build failure reported in #71.

Hyprland commit [a9902ea6](https://github.com/hyprwm/Hyprland/commit/a9902ea65f461af868497c4e74fed798ade0b1b0) removed `CKeybindManager::m_dispatchers`, which breaks `OverviewInteraction.cpp`:

```
OverviewInteraction.cpp:655:28: error: 'class CKeybindManager' has no member named 'm_dispatchers'
  655 |         g_pKeybindManager->m_dispatchers["submap"]("hyprexpo");
OverviewInteraction.cpp:662:28: error: 'class CKeybindManager' has no member named 'm_dispatchers'
  662 |         g_pKeybindManager->m_dispatchers["submap"]("reset");
```

## How

The dispatchers map was replaced by the `Config::Actions` API. The `"submap"` dispatcher is now [`Config::Actions::setSubmap(const std::string&)`](https://github.com/hyprwm/Hyprland/blob/main/src/config/shared/actions/ConfigActions.hpp#L90).

This PR switches the two call sites in `enterSubmapIfEnabled()` / `resetSubmapIfNeeded()` to use it:

```cpp
- g_pKeybindManager->m_dispatchers["submap"]("hyprexpo");
+ (void)Config::Actions::setSubmap("hyprexpo");
...
- g_pKeybindManager->m_dispatchers["submap"]("reset");
+ (void)Config::Actions::setSubmap("reset");
```

The `(void)` discards the now-`[[nodiscard]]` `ActionResult` to keep the original fire-and-forget behavior.

## Cross-version compatibility

`Config::Actions::setSubmap` exists in **both** Hyprland 0.56.0 (the plugin's currently-pinned version, which still had `m_dispatchers`) and the newer main branch that removed it. The `"reset"` semantics are identical in both (`submap == "reset" || submap.empty()` clears the current submap), so a single change works across both versions — no preprocessor guards needed.

## Verification

- `make` builds cleanly with no warnings (against Hyprland 0.56.0)
- `meson`/ninja build passes
- `make test` — `HyprexpoLogicTests` and `OverviewSourceTests` pass
- No remaining `m_dispatchers` references in the repo

Fixes #71.