### PR TITLE
fix: allow border_width = 0 to disable tile borders

### DIFF
--- a/OverviewRender.cpp
+++ b/OverviewRender.cpp
@@ -531,9 +531,6 @@ void COverview::fullRender() {
         if (box.w <= 0.0 || box.h <= 0.0)
             return;
 
-        // border_width = 0 means "no border". This used to be clamped up to 1px, so there was no
-        // way to turn tile borders off from the config at all -- the override path already honoured
-        // 0 above, but the config value itself could not.
         const int BWIDTH = borderWidthOverride > 0 ? borderWidthOverride : (int)**PBWIDTH;
         if (BWIDTH <= 0)
             return;

--- a/OverviewRender.cpp
+++ b/OverviewRender.cpp
@@ -531,7 +531,13 @@ void COverview::fullRender() {
         if (box.w <= 0.0 || box.h <= 0.0)
             return;
 
-        const int BWIDTH = std::max(1, borderWidthOverride > 0 ? borderWidthOverride : (int)**PBWIDTH);
+        // border_width = 0 means "no border". This used to be clamped up to 1px, so there was no
+        // way to turn tile borders off from the config at all -- the override path already honoured
+        // 0 above, but the config value itself could not.
+        const int BWIDTH = borderWidthOverride > 0 ? borderWidthOverride : (int)**PBWIDTH;
+        if (BWIDTH <= 0)
+            return;
+
         const std::string effectiveSpec = Hyprexpo::resolveBorderSpec(borderSpec, deprecatedGradSpec);
 
         if (isGradientBorderSpec(effectiveSpec)) {


### PR DESCRIPTION
`plugin:hyprexpo:border_width = 0` still draws a 1px border, because the width is clamped with `std::max(1, ...)`. There is no other way to switch tile borders off, so a borderless overview is not expressible in the config.

The drag/drop width override immediately above already treats `0` as "don't draw" — this makes the config value consistent with it. Any value `<= 0` now skips the draw.

Default (`2`) unchanged.

**Testing:** `make test` passes; built against Hyprland 0.56.0 and confirmed borders disappear at `0` and are unchanged at the default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0193anMErsSpgd8dC3pTBhce
