### PR TITLE
Prevent number-key crashes under Lua config

### DIFF
--- a/Dispatchers.cpp
+++ b/Dispatchers.cpp
@@ -36,6 +36,7 @@ static bool g_unloading                   = false;
 static bool g_gestureRegistrationDisabled = false;
 static bool renderingOverview             = false;
 static SP<Config::Values::CStringValue> g_pCancelKeyConfig;
+static SP<Config::Values::CStringValue> g_pNumberKeyModeConfig;
 
 static SDispatchResult onExpoDispatcher(std::string arg);
 static SDispatchResult onKbFocusDispatcher(std::string arg);
@@ -257,8 +258,7 @@ bool shouldSelectWorkspaceFromKey(const IKeyboard::SKeyEvent& event) {
     if (arg.empty())
         return false;
 
-    static auto const* PNUMBERKEYMODE = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:number_key_mode")->getDataStaticPtr();
-    const auto         mode           = Hyprexpo::numberKeyModeFromString(std::string{*PNUMBERKEYMODE});
+    const auto mode = Hyprexpo::numberKeyModeFromString(g_pNumberKeyModeConfig ? g_pNumberKeyModeConfig->value() : HyprexpoConfig::NUMBER_KEY_MODE_DEFAULT);
 
     if (mode == Hyprexpo::ENumberKeyMode::Passthrough)
         return false;
@@ -660,9 +660,16 @@ SP<Config::Values::CStringValue> createCancelKeyConfig() {
     return g_pCancelKeyConfig;
 }
 
+SP<Config::Values::CStringValue> createNumberKeyModeConfig() {
+    g_pNumberKeyModeConfig =
+        makeShared<Config::Values::CStringValue>("plugin:hyprexpo:number_key_mode", "raw number-key handling: workspace, index, or passthrough", HyprexpoConfig::NUMBER_KEY_MODE_DEFAULT);
+    return g_pNumberKeyModeConfig;
+}
+
 void resetDispatcherRuntime() {
     g_unloading = true;
     g_pCancelKeyConfig.reset();
+    g_pNumberKeyModeConfig.reset();
 }
 
 bool isRenderingOverview() {

--- a/Dispatchers.hpp
+++ b/Dispatchers.hpp
@@ -7,6 +7,7 @@
 #include <hyprland/src/devices/IKeyboard.hpp>
 
 SP<Config::Values::CStringValue> createCancelKeyConfig();
+SP<Config::Values::CStringValue> createNumberKeyModeConfig();
 void                             resetDispatcherRuntime();
 void                             registerHyprexpoDispatchers();
 void                             syncExpoGestureFromConfig();

--- a/PluginConfig.cpp
+++ b/PluginConfig.cpp
@@ -63,7 +63,7 @@ void registerHyprexpoConfigValues() {
 
     // keyboard navigation + styling
     addConfigValue(makeShared<Config::Values::CIntValue>("plugin:hyprexpo:keynav_enable", "key navigation enable", HyprexpoConfig::KEYNAV_ENABLE_DEFAULT));
-    addConfigValue(makeShared<Config::Values::CStringValue>("plugin:hyprexpo:number_key_mode", "raw number-key handling: workspace, index, or passthrough", HyprexpoConfig::NUMBER_KEY_MODE_DEFAULT));
+    addConfigValue(createNumberKeyModeConfig());
     // Border configuration - supports both solid colors and gradients
     // Solid: rgb(rrggbb) or 0xAARRGGBB
     // Gradient: rgba(rrggbbaa) rgba(rrggbbaa) 45deg

--- a/main.cpp
+++ b/main.cpp
@@ -34,9 +34,10 @@ static void hkRenderWorkspace(void* thisptr, PHLMONITOR pMonitor, PHLWORKSPACE p
 }
 
 static void hkAddDamageA(void* thisptr, const CBox& box) {
-    const auto PMONITOR = (Monitor::CMonitor*)thisptr;
+    const auto PMONITOR   = (Monitor::CMonitor*)thisptr;
+    const auto PMONITORSP = PMONITOR ? PMONITOR->m_self.lock() : PHLMONITOR{};
 
-    if (!g_pOverview || !g_pOverview->shouldRenderOverviewForMonitor(PMONITOR->m_self.lock()) || g_pOverview->blockDamageReporting) {
+    if (!g_pOverview || !PMONITORSP || !g_pOverview->shouldRenderOverviewForMonitor(PMONITORSP) || g_pOverview->blockDamageReporting) {
         ((origAddDamageA)g_pAddDamageHookA->m_original)(thisptr, box);
         return;
     }
@@ -45,9 +46,10 @@ static void hkAddDamageA(void* thisptr, const CBox& box) {
 }
 
 static void hkAddDamageB(void* thisptr, const pixman_region32_t* rg) {
-    const auto PMONITOR = (Monitor::CMonitor*)thisptr;
+    const auto PMONITOR   = (Monitor::CMonitor*)thisptr;
+    const auto PMONITORSP = PMONITOR ? PMONITOR->m_self.lock() : PHLMONITOR{};
 
-    if (!g_pOverview || !g_pOverview->shouldRenderOverviewForMonitor(PMONITOR->m_self.lock()) || g_pOverview->blockDamageReporting) {
+    if (!g_pOverview || !PMONITORSP || !g_pOverview->shouldRenderOverviewForMonitor(PMONITORSP) || g_pOverview->blockDamageReporting) {
         ((origAddDamageB)g_pAddDamageHookB->m_original)(thisptr, rg);
         return;
     }

--- a/tests/OverviewSourceTests.cpp
+++ b/tests/OverviewSourceTests.cpp
@@ -102,8 +102,16 @@ int main() {
 
     const auto rawNumberSelection = extractFunction(dispatchersSource, "bool shouldSelectWorkspaceFromKey(const IKeyboard::SKeyEvent& event) {");
     expect(!rawNumberSelection.empty(), "raw number-key selection function exists");
-    expect(rawNumberSelection.find("plugin:hyprexpo:number_key_mode") != std::string::npos,
-           "raw number-key handling reads the dedicated mode");
+    expect(rawNumberSelection.find("g_pNumberKeyModeConfig") != std::string::npos,
+           "raw number-key handling reads the dedicated retained mode");
+    expect(rawNumberSelection.find("g_pNumberKeyModeConfig->value()") != std::string::npos,
+           "raw number-key handling reads the retained V2 string value");
+    expect(rawNumberSelection.find("HyprlandAPI::getConfigValue") == std::string::npos,
+           "raw number-key handling does not dereference the deprecated config API");
+    expect(configSource.find("addConfigValue(createNumberKeyModeConfig())") != std::string::npos,
+           "number-key mode registration retains the V2 config value");
+    expect(dispatchersSource.find("g_pNumberKeyModeConfig.reset()") != std::string::npos,
+           "number-key mode releases its retained V2 config value during teardown");
     const auto passthroughMode = rawNumberSelection.find("ENumberKeyMode::Passthrough");
     const auto indexMode       = rawNumberSelection.find("ENumberKeyMode::Index", passthroughMode);
     const auto workspaceMode   = rawNumberSelection.find("return changeToSingleDigitWorkspace(arg).success;", indexMode);


### PR DESCRIPTION
## Summary

- retain Aditya Mangal's `f1138de` addDamage monitor-lifetime guard as its own authored commit, with the original hash recorded by `cherry-pick -x`
- fix the actual issue #87 stack by retaining the V2 `CStringValue` for `number_key_mode` instead of dereferencing the deprecated legacy getter under Lua configuration
- add source regression coverage for V2 registration, typed value access, legacy-getter exclusion, and teardown

The attached issue crash report resolves to `shouldSelectWorkspaceFromKey+0x136`; that instruction dereferences the null legacy config pointer. The XBoy-352 addDamage commit protects a separate SIGBUS path, so it is preserved independently and is not presented as the number-key fix.

## Verification

- `make test`
- ASan/UBSan `HyprexpoLogicTests`
- `make all` against installed Hyprland 0.56.1, commit `5c9377c15f85c50648f35ca5a213754f95b93ca0` (the same version and hash as the reporter)
- `file hyprexpo.so`, `ldd hyprexpo.so`, and `git diff --check`
- nested Hyprland Lua-config runtime: loaded `v0.56.1-dev+c271d8c`, mapped a Kitty client, opened Hyprexpo, injected a real virtual-keyboard `1` press, observed submap transition `hyprexpo` to `default`, compositor remained alive, and `hyprctl configerrors` stayed empty
- stable patch IDs for original `f1138de` and retained `cbf4b2c` are identical: `8ba545978997ce15ddb0023acc7c82f7351a43cd`

References #87. The issue should remain open pending reporter confirmation.
