### PR TITLE
Hide workspace labels immediately when closing overview

### DIFF
--- a/OverviewRender.cpp
+++ b/OverviewRender.cpp
@@ -595,8 +595,8 @@ void COverview::fullRender() {
     if (!std::string{*PSELECTMAP}.empty())
         selectionTokens = splitCommaList(std::string{*PSELECTMAP});
 
-    if (**PLABELEN || **PSELECTEN || showWorkspaceNumbers) {
-        const int labelHoveredID = closing ? -1 : hoveredID;
+    if (!closing && (**PLABELEN || **PSELECTEN || showWorkspaceNumbers)) {
+        const int labelHoveredID = hoveredID;
         const std::string modernAnchor = Hyprexpo::trimString(std::string{*PLABELPOS});
         const std::string labelAnchor  = normalizeAnchor(modernAnchor.empty() ? std::string{*PLABELPOSL} : modernAnchor);
         const int labelFontSize = **PLABELSIZE > 0 ? **PLABELSIZE : std::max(8, (int)**PLABELSIZEL / 2);

--- a/tests/OverviewSourceTests.cpp
+++ b/tests/OverviewSourceTests.cpp
@@ -170,6 +170,8 @@ int main() {
     expect(!fullRender.empty(), "overview fullRender function exists");
     expect(fullRender.find("Hyprexpo::shouldShowWorkspaceLabel(") != std::string::npos,
            "runtime label rendering uses modern label_enable and label_show policy in every grid mode");
+    expect(fullRender.find("if (!closing && (**PLABELEN || **PSELECTEN || showWorkspaceNumbers))") != std::string::npos,
+           "workspace and selection labels stop rendering as soon as overview close begins");
     expect(fullRender.find("Hyprexpo::resolveBorderSpec(") != std::string::npos,
            "runtime border rendering uses modern-first border resolution with legacy fallback");
 


### PR DESCRIPTION
## Summary

- stop workspace, forced-number, and selection labels from rendering as soon as overview close begins
- preserve the existing workspace expansion, border rendering, selection, and delayed teardown behavior
- remove the now-unreachable closing fallback from hover-label selection
- add a source regression assertion for the close-state overlay guard

## Root cause

`COverview::close()` marks the overview as closing but intentionally keeps it alive until the exit animation ends. `COverview::fullRender()` did not include that state in its label-overlay predicate, so the selected workspace could be fully expanded while its label remained composited until delayed teardown.

## Verification

- baseline regression demonstrated RED before the runtime edit and GREEN afterward
- `make test`
- ASan+UBSan runs of `HyprexpoLogicTests` and `OverviewSourceTests`
- `make all` against installed Hyprland 0.56.1 headers
- `file hyprexpo.so`, `ldd hyprexpo.so`, and `git diff --check origin/master...HEAD`
- nested Hyprland runtime with labels forced visible: labels render while the overview is open, disappear by the 50 ms close-frame sample while the workspace is still expanding, and remain absent after the workspace settles; plugin stays loaded, compositor stays alive, and `hyprctl configerrors` is empty
- visual-verdict score: 97/100, pass

Resolves #88
