### PR TITLE
Grow first-anchored grid to keep active workspace visible (#91)

### DIFF
--- a/HyprexpoLogic.cpp
+++ b/HyprexpoLogic.cpp
@@ -148,6 +148,28 @@ int clampGridColumns(int columns) {
     return std::clamp(columns, HyprexpoConfig::COLUMNS_MIN, HyprexpoConfig::COLUMNS_MAX);
 }
 
+// For a "first"-anchored square overview grid whose tiles start at
+// firstWorkspaceID and count upward, return the grid side length (columns)
+// needed so the active workspace is visible. The grid only grows past the
+// configured columns; it never shrinks below them and never exceeds
+// maxColumns. When even maxColumns cannot reach the active workspace the
+// result is clamped to maxColumns (best effort).
+int gridColumnsToIncludeWorkspace(int configuredColumns, int firstWorkspaceID, int activeWorkspaceID, int maxColumns) {
+    const int cap  = std::max(HyprexpoConfig::COLUMNS_MIN, maxColumns);
+    int       cols = std::clamp(configuredColumns, HyprexpoConfig::COLUMNS_MIN, cap);
+
+    // Active workspace is at or before the anchor, so the existing grid already
+    // starts on (or after) it; nothing to grow.
+    if (activeWorkspaceID <= firstWorkspaceID)
+        return cols;
+
+    const long long needed = static_cast<long long>(activeWorkspaceID) - firstWorkspaceID + 1;
+    while (static_cast<long long>(cols) * cols < needed && cols < cap)
+        ++cols;
+
+    return cols;
+}
+
 int tileIndexFromPoint(double x, double y, double width, double height, int sideLength) {
     if (width <= 0 || height <= 0 || sideLength <= 0)
         return -1;

--- a/HyprexpoLogic.hpp
+++ b/HyprexpoLogic.hpp
@@ -106,6 +106,7 @@ STileLayout              computeTileLayout(int index, int visibleCount, SGridSha
 int                      tileIndexAtPoint(double x, double y, int visibleCount, SGridShape shape, SSize total, double gap, bool centerPartialRows);
 
 int                      clampGridColumns(int columns);
+int                      gridColumnsToIncludeWorkspace(int configuredColumns, int firstWorkspaceID, int activeWorkspaceID, int maxColumns);
 int                      tileIndexFromPoint(double x, double y, double width, double height, int sideLength);
 int                      numberKeyToVisibleIndex(int number);
 ENumberKeyMode           numberKeyModeFromString(const std::string& mode);

--- a/Overview.cpp
+++ b/Overview.cpp
@@ -767,12 +767,25 @@ COverview::COverview(PHLWORKSPACE startedOn_, bool swipe_) : startedOn(startedOn
     // Get workspace method for this specific monitor
     auto [methodCenter, methodStartID] = getWorkspaceMethodForMonitor(pMonitor.lock());
 
-    images.resize(SIDE_LENGTH * SIDE_LENGTH);
-
     // r includes empty workspaces; m skips over them
     const bool    skipEmpty    = **PSKIP;
     const int64_t maxWorkspace = std::max<Hyprlang::INT>(0, **PMAXWS);
     std::string   selector     = skipEmpty ? "m" : "r";
+
+    // With a "first"-anchored method the grid starts at a fixed workspace and
+    // counts upward, so a currently-active workspace beyond the last tile is
+    // not shown at all. When that happens the overview would treat the anchor
+    // tile as active (zooming to the wrong workspace on open and close). Grow
+    // the grid so the active workspace stays visible. This intentionally
+    // overrides the configured columns for this instance, but only upward and
+    // only when the sequential tile IDs line up with workspace IDs (i.e. not
+    // skip_empty and not a max_workspace cap). See issue #91.
+    if (!methodCenter && !skipEmpty && maxWorkspace <= 0 && startedOn) {
+        SIDE_LENGTH = Hyprexpo::gridColumnsToIncludeWorkspace(SIDE_LENGTH, methodStartID, (int)startedOn->m_id, HyprexpoConfig::COLUMNS_MAX);
+        gridShape   = {SIDE_LENGTH, SIDE_LENGTH};
+    }
+
+    images.resize(SIDE_LENGTH * SIDE_LENGTH);
 
     if (!skipEmpty && maxWorkspace > 0) {
         const int64_t tileCount = SIDE_LENGTH * SIDE_LENGTH;

--- a/docs/guides/multi-monitor.md
+++ b/docs/guides/multi-monitor.md
@@ -31,6 +31,18 @@ plugin {
 }
 ```
 
+## Active workspace beyond the grid
+
+`first <workspace>` anchors the grid to a fixed workspace and counts upward, so
+the configured `columns` normally bound how many workspaces are visible. When
+the currently active workspace sits past the last tile (for example `first 1`
+with `columns = 3` shows workspaces 1–9, but the active workspace is 10), the
+overview temporarily grows the grid so the active workspace stays visible and
+the open/close animation focuses on it instead of the anchor tile. The grid only
+grows — never below the configured `columns` — and is capped at the maximum of 7
+columns. This applies to plain sequential grids (not `skip_empty` or
+`max_workspace`, which keep their explicit bounds).
+
 ## Troubleshooting Monitor Names
 
 If a per-monitor entry does not apply, check the monitor name reported by Hyprland and use that exact name in the comma-separated list.

--- a/tests/HyprexpoLogicTests.cpp
+++ b/tests/HyprexpoLogicTests.cpp
@@ -160,6 +160,17 @@ int main() {
     expect(clampGridColumns(-1) == 1, "columns clamp lower bound");
     expect(clampGridColumns(3) == 3, "columns keep valid value");
     expect(clampGridColumns(99) == 7, "columns clamp upper bound");
+
+    // issue #91: a "first"-anchored grid must grow so an active workspace beyond
+    // the last tile stays visible instead of falling back to the anchor tile.
+    expect(gridColumnsToIncludeWorkspace(3, 1, 9, 7) == 3, "first-anchor grid keeps columns when active workspace fits");
+    expect(gridColumnsToIncludeWorkspace(3, 1, 10, 7) == 4, "first-anchor grid grows to include an active workspace just past the grid");
+    expect(gridColumnsToIncludeWorkspace(3, 1, 16, 7) == 4, "first-anchor grid grows to exactly fill the last tile");
+    expect(gridColumnsToIncludeWorkspace(3, 1, 17, 7) == 5, "first-anchor grid grows another column past a full grid");
+    expect(gridColumnsToIncludeWorkspace(3, 5, 12, 7) == 3, "first-anchor grid accounts for a non-1 anchor when sizing");
+    expect(gridColumnsToIncludeWorkspace(3, 5, 4, 7) == 3, "first-anchor grid never shrinks for an active workspace before the anchor");
+    expect(gridColumnsToIncludeWorkspace(3, 1, 1000, 7) == 7, "first-anchor grid is capped at the max columns as a best effort");
+    expect(gridColumnsToIncludeWorkspace(5, 1, 4, 7) == 5, "first-anchor grid never shrinks below the configured columns");
     expect(HyprexpoConfig::SHOW_PINNED_WINDOWS_DEFAULT == 0, "pinned windows are hidden from previews by default");
     expect(std::string{HyprexpoConfig::NUMBER_KEY_MODE_DEFAULT} == "workspace", "raw number keys keep selecting workspace IDs by default");
     expect(numberKeyModeFromString("workspace") == ENumberKeyMode::Workspace, "workspace number-key mode parses");


### PR DESCRIPTION
## Summary

Fixes #91.

With `workspace_method = "first N"`, the overview grid is anchored to a fixed workspace and counts upward, bounded by `columns`. When the active workspace sits **past the last tile** — e.g. `first 1` with `columns = 3` shows workspaces 1–9, but the active workspace is 10 — no tile matched the active workspace. The overview then treated the anchor tile (workspace 1) as active:

- the open animation focused on workspace 1, and
- closing zoomed back to workspace 1, briefly flashing its contents before the real active workspace appeared.

## Fix

Grow the square grid for that overview instance so the active workspace stays visible — the reporter's preferred approach. The grid:

- only ever grows **past** the configured `columns`, never below it;
- is capped at the maximum of **7** columns (best effort if the active workspace is very far out);
- only applies to plain sequential grids where tile IDs line up with workspace IDs, so `skip_empty` and `max_workspace` keep their explicit bounds.

Concretely, `first 1` + active workspace 10 now temporarily expands to a 4×4 grid (workspaces 1–16), and the animation correctly focuses on workspace 10.

## Changes

- New pure helper `gridColumnsToIncludeWorkspace(...)` in `HyprexpoLogic` with unit coverage.
- Wired into the `COverview` constructor for the `first`-anchored, non-`skip_empty`, non-`max_workspace` case.
- Documented the behavior in the multi-monitor guide.

## Testing

- `HyprexpoLogicTests` — new assertions for `gridColumnsToIncludeWorkspace` (anchor offset, growth, cap, never-shrink).
- `OverviewSourceTests` — passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)