### PR TITLE
Remove explanatory comments around first-anchor grid growth

### DIFF
--- a/HyprexpoLogic.cpp
+++ b/HyprexpoLogic.cpp
@@ -148,18 +148,10 @@ int clampGridColumns(int columns) {
     return std::clamp(columns, HyprexpoConfig::COLUMNS_MIN, HyprexpoConfig::COLUMNS_MAX);
 }
 
-// For a "first"-anchored square overview grid whose tiles start at
-// firstWorkspaceID and count upward, return the grid side length (columns)
-// needed so the active workspace is visible. The grid only grows past the
-// configured columns; it never shrinks below them and never exceeds
-// maxColumns. When even maxColumns cannot reach the active workspace the
-// result is clamped to maxColumns (best effort).
 int gridColumnsToIncludeWorkspace(int configuredColumns, int firstWorkspaceID, int activeWorkspaceID, int maxColumns) {
     const int cap  = std::max(HyprexpoConfig::COLUMNS_MIN, maxColumns);
     int       cols = std::clamp(configuredColumns, HyprexpoConfig::COLUMNS_MIN, cap);
 
-    // Active workspace is at or before the anchor, so the existing grid already
-    // starts on (or after) it; nothing to grow.
     if (activeWorkspaceID <= firstWorkspaceID)
         return cols;
 

--- a/Overview.cpp
+++ b/Overview.cpp
@@ -772,14 +772,6 @@ COverview::COverview(PHLWORKSPACE startedOn_, bool swipe_) : startedOn(startedOn
     const int64_t maxWorkspace = std::max<Hyprlang::INT>(0, **PMAXWS);
     std::string   selector     = skipEmpty ? "m" : "r";
 
-    // With a "first"-anchored method the grid starts at a fixed workspace and
-    // counts upward, so a currently-active workspace beyond the last tile is
-    // not shown at all. When that happens the overview would treat the anchor
-    // tile as active (zooming to the wrong workspace on open and close). Grow
-    // the grid so the active workspace stays visible. This intentionally
-    // overrides the configured columns for this instance, but only upward and
-    // only when the sequential tile IDs line up with workspace IDs (i.e. not
-    // skip_empty and not a max_workspace cap). See issue #91.
     if (!methodCenter && !skipEmpty && maxWorkspace <= 0 && startedOn) {
         SIDE_LENGTH = Hyprexpo::gridColumnsToIncludeWorkspace(SIDE_LENGTH, methodStartID, (int)startedOn->m_id, HyprexpoConfig::COLUMNS_MAX);
         gridShape   = {SIDE_LENGTH, SIDE_LENGTH};

--- a/tests/HyprexpoLogicTests.cpp
+++ b/tests/HyprexpoLogicTests.cpp
@@ -161,8 +161,6 @@ int main() {
     expect(clampGridColumns(3) == 3, "columns keep valid value");
     expect(clampGridColumns(99) == 7, "columns clamp upper bound");
 
-    // issue #91: a "first"-anchored grid must grow so an active workspace beyond
-    // the last tile stays visible instead of falling back to the anchor tile.
     expect(gridColumnsToIncludeWorkspace(3, 1, 9, 7) == 3, "first-anchor grid keeps columns when active workspace fits");
     expect(gridColumnsToIncludeWorkspace(3, 1, 10, 7) == 4, "first-anchor grid grows to include an active workspace just past the grid");
     expect(gridColumnsToIncludeWorkspace(3, 1, 16, 7) == 4, "first-anchor grid grows to exactly fill the last tile");


### PR DESCRIPTION
Removes the inline comments added for the grid-growth fix in `Overview.cpp`, `HyprexpoLogic.cpp`, and `HyprexpoLogicTests.cpp` (including the issue-number references). The code and the `gridColumnsToIncludeWorkspace` helper name speak for themselves.

No functional change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)