### PR TITLE
fix(labels): honor explicit legacy settings

### DIFF
--- a/HyprexpoLogic.cpp
+++ b/HyprexpoLogic.cpp
@@ -422,6 +422,17 @@ std::string resolveBorderSpec(const std::string& modernSpec, const std::string& 
     return modern.empty() ? trimString(legacySpec) : modern;
 }
 
+std::string resolveLabelPosition(const std::string& modernValue, bool modernSetByUser, const std::string& legacyValue, bool legacySetByUser) {
+    if (modernSetByUser || !legacySetByUser)
+        return trimString(modernValue);
+    return trimString(legacyValue);
+}
+
+int resolveLabelFontSize(int modernValue, bool modernSetByUser, int legacyValue, bool legacySetByUser) {
+    const int selected = modernSetByUser || !legacySetByUser ? modernValue : legacyValue / 2;
+    return std::max(8, selected);
+}
+
 static std::vector<std::string> splitWhitespace(const std::string& value) {
     std::vector<std::string> tokens;
     size_t                   cursor = 0;

--- a/HyprexpoLogic.hpp
+++ b/HyprexpoLogic.hpp
@@ -125,6 +125,8 @@ SGradientSpec            parseGradientSpec(const std::string& value);
 bool                     isGradientBorderSpec(const std::string& value);
 bool                     shouldShowWorkspaceLabel(bool labelEnabled, const std::string& labelShow, bool isHovered, bool isFocused, bool isCurrent);
 std::string              resolveBorderSpec(const std::string& modernSpec, const std::string& legacySpec);
+std::string              resolveLabelPosition(const std::string& modernValue, bool modernSetByUser, const std::string& legacyValue, bool legacySetByUser);
+int                      resolveLabelFontSize(int modernValue, bool modernSetByUser, int legacyValue, bool legacySetByUser);
 
 SWorkspaceMethodSpec     parseWorkspaceMethodSpec(const std::string& method);
 SWorkspaceMethodSpec     resolveWorkspaceMethodForMonitor(const std::string& config, const std::string& monitorName);

--- a/HyprlandConfigCompat.hpp
+++ b/HyprlandConfigCompat.hpp
@@ -21,6 +21,7 @@ struct SConfigValueCompat {
 };
 
 SConfigValueCompat* getConfigValue(HANDLE handle, const std::string& name);
+bool                configValueSetByUser(const std::string& name);
 
 Config::INTEGER intValue(const std::string& name);
 Config::STRING  stringValue(const std::string& name);

--- a/Overview.cpp
+++ b/Overview.cpp
@@ -210,6 +210,10 @@ SConfigValueCompat* getConfigValue(HANDLE, const std::string& name) {
     return &compat;
 }
 
+bool configValueSetByUser(const std::string& name) {
+    return Config::mgr()->getConfigValue(name).setByUser;
+}
+
 Config::INTEGER intValue(const std::string& name) {
     const auto VALUE = Config::mgr()->getConfigValue(name);
     if (!VALUE.dataptr || !VALUE.type || *VALUE.type != typeid(Config::INTEGER))

--- a/OverviewRender.cpp
+++ b/OverviewRender.cpp
@@ -597,9 +597,13 @@ void COverview::fullRender() {
 
     if (!closing && (**PLABELEN || **PSELECTEN || showWorkspaceNumbers)) {
         const int labelHoveredID = hoveredID;
-        const std::string modernAnchor = Hyprexpo::trimString(std::string{*PLABELPOS});
-        const std::string labelAnchor  = normalizeAnchor(modernAnchor.empty() ? std::string{*PLABELPOSL} : modernAnchor);
-        const int labelFontSize = **PLABELSIZE > 0 ? **PLABELSIZE : std::max(8, (int)**PLABELSIZEL / 2);
+        const bool modernPositionSet = CompatHyprlandAPI::configValueSetByUser("plugin:hyprexpo:label_position");
+        const bool legacyPositionSet = CompatHyprlandAPI::configValueSetByUser("plugin:hyprexpo:label_pos");
+        const bool modernSizeSet     = CompatHyprlandAPI::configValueSetByUser("plugin:hyprexpo:label_font_size");
+        const bool legacySizeSet     = CompatHyprlandAPI::configValueSetByUser("plugin:hyprexpo:label_size");
+        const std::string labelAnchor = normalizeAnchor(
+            Hyprexpo::resolveLabelPosition(std::string{*PLABELPOS}, modernPositionSet, std::string{*PLABELPOSL}, legacyPositionSet));
+        const int labelFontSize = Hyprexpo::resolveLabelFontSize(**PLABELSIZE, modernSizeSet, **PLABELSIZEL, legacySizeSet);
 
         auto resolveState = [&](int id) -> int {
             if (id == kbFocusID)

--- a/tests/HyprexpoLogicTests.cpp
+++ b/tests/HyprexpoLogicTests.cpp
@@ -198,6 +198,15 @@ int main() {
     expect(resolveBorderSpec("rgb(010203)", "0xffaabbcc") == "rgb(010203)", "modern border spec takes precedence over legacy color");
     expect(resolveBorderSpec("", "0xffaabbcc") == "0xffaabbcc", "legacy border color is used only when the modern spec is empty");
 
+    expect(resolveLabelPosition("center", false, "top_right", false) == "center", "modern position default wins when neither key is explicit");
+    expect(resolveLabelPosition("center", false, " top_right ", true) == "top_right", "explicit legacy position overrides an implicit modern default");
+    expect(resolveLabelPosition(" bottom-left ", true, "top_right", true) == "bottom-left", "explicit modern position wins when both keys are explicit");
+
+    expect(resolveLabelFontSize(16, false, 72, false) == 16, "modern size default wins when neither key is explicit");
+    expect(resolveLabelFontSize(16, false, 72, true) == 36, "explicit legacy badge size converts to the historical font size");
+    expect(resolveLabelFontSize(24, true, 72, true) == 24, "explicit modern font size wins when both keys are explicit");
+    expect(resolveLabelFontSize(0, true, 72, true) == 8, "explicit modern font size is clamped instead of falling back to legacy");
+
     expect(tileIndexFromPoint(0, 0, 300, 300, 3) == 0, "legacy tile index top-left");
     expect(tileIndexFromPoint(299, 299, 300, 300, 3) == 8, "legacy tile index bottom-right inside");
     expect(tileIndexFromPoint(300, 300, 300, 300, 3) == 8, "legacy tile index clamps monitor edge");

--- a/tests/OverviewSourceTests.cpp
+++ b/tests/OverviewSourceTests.cpp
@@ -174,6 +174,12 @@ int main() {
            "workspace and selection labels stop rendering as soon as overview close begins");
     expect(fullRender.find("Hyprexpo::resolveBorderSpec(") != std::string::npos,
            "runtime border rendering uses modern-first border resolution with legacy fallback");
+    expect(fullRender.find("Hyprexpo::resolveLabelPosition(") != std::string::npos && fullRender.find("Hyprexpo::resolveLabelFontSize(") != std::string::npos,
+           "runtime label rendering resolves explicit modern and legacy option precedence");
+    expect(fullRender.find("CompatHyprlandAPI::configValueSetByUser(") != std::string::npos,
+           "runtime label compatibility checks whether each option was explicitly configured");
+    expect(source.find("Config::mgr()->getConfigValue(name).setByUser") != std::string::npos,
+           "config compatibility exposes explicit-setting metadata for both config providers");
 
     expect(dispatchersSource.find("HyprlandAPI::getConfigValue") == std::string::npos,
            "gesture config avoids the legacy hyprlang getter, which is null under CONFIG_LUA");


### PR DESCRIPTION
## Summary

- resolve label position and font size using Hyprland's `setByUser` metadata
- give explicit modern settings precedence over explicit legacy settings
- preserve modern defaults when neither counterpart is configured
- add regression coverage for modern-only, legacy-only, both-set, and neither-set cases

## Why

The renderer currently chooses `label_position` whenever it is non-empty and
`label_font_size` whenever it is positive. Their defaults are `center` and `16`,
so the documented `label_pos` and `label_size` compatibility keys can never take
effect, even when explicitly configured.

The corrected precedence is:

1. explicit modern value
2. explicit legacy value
3. modern default

This restores compatibility without changing defaults for new configurations.

## Validation

- `make test`
- `make all TARGET=/tmp/hyprexpo-legacy-label-test.so`
- `make check-version`
- `make check-pins REF=HEAD`
- `git diff --check`
