### PR TITLE
Restore the previous submap on close instead of hardcoding reset

### DIFF
--- a/Overview.hpp
+++ b/Overview.hpp
@@ -126,6 +126,7 @@ class COverview {
     int                          kbFocusID = -1;
     int                          hoveredID = -1;
     bool                         submapActive = false;
+    std::string                  previousSubmap = "";
 
     Vector2D                     dragStartLocal = Vector2D{};
     int                          dragSourceID   = -1;

--- a/OverviewInteraction.cpp
+++ b/OverviewInteraction.cpp
@@ -8,6 +8,7 @@
 #include <hyprland/src/output/Monitor.hpp>
 #include <hyprland/src/pointer/cursor/CursorShapeOverrideController.hpp>
 #include <hyprland/src/managers/eventLoop/EventLoopManager.hpp>
+#include <hyprland/src/managers/KeybindManager.hpp>
 #include <hyprland/src/state/WorkspaceState.hpp>
 #include <hyprland/src/config/shared/actions/ConfigActions.hpp>
 #include <algorithm>
@@ -654,6 +655,12 @@ void COverview::onSwipeEnd() {
 void COverview::enterSubmapIfEnabled() {
     static auto* const* PKEYNAV = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:keynav_enable")->getDataStaticPtr();
     if (**PKEYNAV && !submapActive) {
+        // remember whatever submap was active so we can restore it exactly on close, instead
+        // of always dropping back to Hyprland's bare default submap. Configs that nest their
+        // entire keybind set inside a named submap (a common pattern for e.g. a "disable all
+        // keybinds" toggle) would otherwise get silently kicked out of it every time the
+        // overview closes.
+        previousSubmap = g_pKeybindManager->getCurrentSubmap().name;
         // switch to a dedicated submap for hyprexpo navigation
         (void)Config::Actions::setSubmap("hyprexpo");
         submapActive = true;
@@ -662,7 +669,7 @@ void COverview::enterSubmapIfEnabled() {
 
 void COverview::resetSubmapIfNeeded() {
     if (submapActive) {
-        (void)Config::Actions::setSubmap("reset");
+        (void)Config::Actions::setSubmap(previousSubmap);
         submapActive = false;
     }
 }

--- a/tests/OverviewSourceTests.cpp
+++ b/tests/OverviewSourceTests.cpp
@@ -131,6 +131,28 @@ int main() {
 
     const auto interactionSource = readFile("OverviewInteraction.cpp");
     expect(!interactionSource.empty(), "OverviewInteraction.cpp can be read from repo root");
+
+    const auto enterSubmap = extractFunction(interactionSource, "void COverview::enterSubmapIfEnabled() {");
+    expect(!enterSubmap.empty(), "keyboard navigation submap entry function exists");
+    const auto captureSubmapPos = enterSubmap.find("previousSubmap = g_pKeybindManager->getCurrentSubmap().name;");
+    const auto enterSubmapPos   = enterSubmap.find("Config::Actions::setSubmap(\"hyprexpo\");");
+    const auto activateGuardPos = enterSubmap.find("submapActive = true;");
+    expect(captureSubmapPos != std::string::npos, "submap entry captures the exact active Hyprland submap");
+    expect(enterSubmapPos != std::string::npos, "submap entry switches to the hyprexpo navigation submap");
+    expect(activateGuardPos != std::string::npos, "submap entry marks the navigation submap active");
+    expect(captureSubmapPos < enterSubmapPos, "active submap capture happens before entering hyprexpo");
+    expect(enterSubmapPos < activateGuardPos, "submap-active guard is set only after entering hyprexpo");
+
+    const auto resetSubmap = extractFunction(interactionSource, "void COverview::resetSubmapIfNeeded() {");
+    expect(!resetSubmap.empty(), "keyboard navigation submap reset function exists");
+    const auto restoreSubmapPos = resetSubmap.find("Config::Actions::setSubmap(previousSubmap);");
+    const auto clearGuardPos    = resetSubmap.find("submapActive = false;");
+    expect(restoreSubmapPos != std::string::npos, "submap reset restores the exact captured submap");
+    expect(resetSubmap.find("Config::Actions::setSubmap(\"reset\");") == std::string::npos,
+           "submap reset never hardcodes Hyprland's default submap");
+    expect(clearGuardPos != std::string::npos, "submap reset clears the active guard");
+    expect(restoreSubmapPos < clearGuardPos, "captured submap restoration happens before clearing the active guard");
+
     const auto numberSelection = extractFunction(interactionSource, "void COverview::onKbSelectNumber(int num) {");
     expect(!numberSelection.empty(), "workspace-number dispatcher selection function exists");
     expect(numberSelection.find("selectWorkspaceByID(num)") != std::string::npos,
@@ -166,6 +188,16 @@ int main() {
 
     const auto renderSource = readFile("OverviewRender.cpp");
     expect(!renderSource.empty(), "OverviewRender.cpp can be read from repo root");
+    const auto closeOverview = extractFunction(renderSource, "void COverview::close(bool switchToSelection) {");
+    expect(!closeOverview.empty(), "overview close function exists");
+    expect(closeOverview.find("resetSubmapIfNeeded();") != std::string::npos,
+           "normal overview close restores the captured submap");
+
+    const auto overviewDestructor = extractFunction(source, "COverview::~COverview() {");
+    expect(!overviewDestructor.empty(), "overview destructor exists");
+    expect(overviewDestructor.find("resetSubmapIfNeeded();") != std::string::npos,
+           "overview teardown restores the captured submap");
+
     const auto fullRender = extractFunction(renderSource, "void COverview::fullRender(");
     expect(!fullRender.empty(), "overview fullRender function exists");
     expect(fullRender.find("Hyprexpo::shouldShowWorkspaceLabel(") != std::string::npos,


### PR DESCRIPTION
Resolves #99

## Summary
- `enterSubmapIfEnabled()` switches to a dedicated `hyprexpo` submap for keyboard navigation while the overview is open, but `resetSubmapIfNeeded()` always called `Config::Actions::setSubmap("reset")` on close, unconditionally dropping back to Hyprland's bare default submap.
- Any config that nests its entire keybind set inside a named submap (a common pattern for implementing a "disable all keybinds" toggle, e.g. entering a `virtual-machine` submap to temporarily suspend bindings) gets silently kicked out of that submap on every overview close - breaking every keybind, including hyprexpo's own toggle, until something else happens to re-enter it. Reproduced with `keynav_enable = 1` and a config where the whole keybind set lives inside `submap = global`: opening the overview once works, but the very next close leaves the compositor in the default submap and no configured bind (including `Super, G, hyprexpo:expo, toggle`) resolves anymore.
- Fix: capture the active submap via `g_pKeybindManager->getCurrentSubmap()` before switching to `hyprexpo`, and restore that exact submap on close instead of `"reset"`. Behavior for the common case (no custom submap active, i.e. the default `""` submap) is unchanged, since `setSubmap("")` and `setSubmap("reset")` are equivalent there.

## Test plan
- Built with `make all`, hot-swapped into a running Hyprland session via `hyprctl plugin unload/load`.
- With no named submap declared/active (the common case): opened and closed the overview repeatedly with `keynav_enable = 1`; submap stayed on the default `""` throughout, matching pre-patch behavior.
- With a real `submap = hyprexpo { ... }` declared and a config that lives inside a named submap (`global`) at rest: confirmed submap correctly transitions `global -> hyprexpo` on open and `hyprexpo -> global` on close, across multiple open/close cycles, instead of dropping to the bare default.