### PR TITLE
feat(expo): add an all-monitors mode

### DIFF
--- a/Dispatchers.cpp
+++ b/Dispatchers.cpp
@@ -190,11 +190,14 @@ static void closeOverviews(bool switchToSelection) {
     forEachOverview([switchToSelection](COverview& overview) { overview.close(switchToSelection); });
 }
 
-// Open on the monitor under the cursor.
-static void openOverviews() {
+// Open on every monitor, or just the one under the cursor.
+static void openOverviews(bool allMonitors) {
     renderingOverview = true;
 
-    if (const auto PMONITOR = State::monitorState()->query().vec(g_pInputManager->getMouseCoordsInternal()).run())
+    if (allMonitors) {
+        for (const auto& MONITOR : State::monitorState()->monitors())
+            createOverview(MONITOR);
+    } else if (const auto PMONITOR = State::monitorState()->query().vec(g_pInputManager->getMouseCoordsInternal()).run())
         createOverview(PMONITOR);
 
     renderingOverview = false;
@@ -455,7 +458,10 @@ static int luaGesture(lua_State* L) {
 }
 
 static SDispatchResult onExpoDispatcher(std::string arg) {
-    arg = lowerString(trimString(arg));
+    const auto COMMAND = Hyprexpo::parseExpoCommand(lowerString(trimString(arg)));
+
+    arg                     = COMMAND.command;
+    const bool ALL_MONITORS = COMMAND.allMonitors;
 
     if (auto* const OV = activeOverview(); OV && OV->m_isSwiping)
         return {.success = false, .error = "already swiping"};
@@ -485,7 +491,7 @@ static SDispatchResult onExpoDispatcher(std::string arg) {
         if (overviewOpen())
             closeOverviews(false);
         else
-            openOverviews();
+            openOverviews(ALL_MONITORS);
         return {};
     }
 
@@ -502,7 +508,7 @@ static SDispatchResult onExpoDispatcher(std::string arg) {
     if (overviewOpen())
         return {};
 
-    openOverviews();
+    openOverviews(ALL_MONITORS);
     return {};
 }
 

--- a/Dispatchers.cpp
+++ b/Dispatchers.cpp
@@ -179,17 +179,6 @@ static SDispatchResult bringWindowFromWorkspace(int64_t sourceWorkspaceID) {
     return {};
 }
 
-// Close every open overview. Only `selecting` applies its own selection; the
-// others dismiss without changing their monitor's workspace, so acting on one
-// monitor does not silently switch the rest.
-static void closeOverviewsSelecting(COverview* selecting) {
-    forEachOverview([selecting](COverview& overview) { overview.close(&overview == selecting); });
-}
-
-static void closeOverviews(bool switchToSelection) {
-    forEachOverview([switchToSelection](COverview& overview) { overview.close(switchToSelection); });
-}
-
 // Open on every monitor, or just the one under the cursor.
 static void openOverviews(bool allMonitors) {
     renderingOverview = true;
@@ -290,8 +279,8 @@ bool shouldSelectWorkspaceFromKey(const IKeyboard::SKeyEvent& event) {
     if (mode == Hyprexpo::ENumberKeyMode::Index) {
         const int visibleIndex = Hyprexpo::numberKeyToVisibleIndex(arg[0] - '0');
         if (visibleIndex >= 0) {
-            if (auto* const OV = activeOverview())
-                OV->onKbSelectToken(visibleIndex);
+            if (auto* const OV = activeOverview(); OV && OV->onKbSelectToken(visibleIndex))
+                closeOverviewsSelecting(OV);
         }
         return true;
     }
@@ -471,15 +460,16 @@ static SDispatchResult onExpoDispatcher(std::string arg) {
 
     if (arg == "select") {
         if (auto* const OV = activeOverview()) {
-            OV->selectHoveredWorkspace();
-            closeOverviewsSelecting(OV);
+            if (OV->selectHoveredWorkspace())
+                closeOverviewsSelecting(OV);
         }
         return {};
     }
 
     if (arg == "bring") {
         if (auto* const OV = activeOverview()) {
-            OV->selectHoveredWorkspace();
+            if (!OV->selectHoveredWorkspace())
+                return {.success = false, .error = "no workspace under pointer"};
             const auto result = bringWindowFromWorkspace(OV->selectedWorkspaceID());
             closeOverviews(false);
             return result;
@@ -502,6 +492,11 @@ static SDispatchResult onExpoDispatcher(std::string arg) {
 
     if (arg == "off" || arg == "close" || arg == "disable") {
         closeOverviews(false);
+        return {};
+    }
+
+    if (ALL_MONITORS && (arg == "on" || arg == "enable")) {
+        openOverviews(true);
         return {};
     }
 
@@ -596,7 +591,8 @@ static SDispatchResult onKbConfirmDispatcher(std::string arg) {
     if (!OV)
         return {};
 
-    OV->onKbConfirm();
+    if (OV->onKbConfirm())
+        closeOverviewsSelecting(OV);
     return {};
 }
 
@@ -613,7 +609,8 @@ static SDispatchResult onKbSelectNumberDispatcher(std::string arg) {
     if (!parseStrictInteger(arg, num))
         return {.success = false, .error = "invalid number"};
 
-    OV->onKbSelectNumber(num);
+    if (OV->onKbSelectNumber(num))
+        closeOverviewsSelecting(OV);
     return {};
 }
 
@@ -639,7 +636,8 @@ static SDispatchResult onKbSelectIndexDispatcher(std::string arg) {
     if (idx <= 0)
         return {.success = false, .error = "invalid index (expected >= 1)"};
     // convert to 0-based visible index
-    OV->onKbSelectToken(idx - 1);
+    if (OV->onKbSelectToken(idx - 1))
+        closeOverviewsSelecting(OV);
     return {};
 }
 

--- a/Dispatchers.cpp
+++ b/Dispatchers.cpp
@@ -116,7 +116,7 @@ static bool matchesCancelKey(xkb_keysym_t keysym) {
 }
 
 bool shouldCancelOverview(const IKeyboard::SKeyEvent& event) {
-    if (!g_pOverview || event.state != WL_KEYBOARD_KEY_STATE_PRESSED)
+    if (!overviewOpen() || event.state != WL_KEYBOARD_KEY_STATE_PRESSED)
         return false;
 
     const auto KEYCODE  = event.keycode + 8;
@@ -179,6 +179,27 @@ static SDispatchResult bringWindowFromWorkspace(int64_t sourceWorkspaceID) {
     return {};
 }
 
+// Close every open overview. Only `selecting` applies its own selection; the
+// others dismiss without changing their monitor's workspace, so acting on one
+// monitor does not silently switch the rest.
+static void closeOverviewsSelecting(COverview* selecting) {
+    forEachOverview([selecting](COverview& overview) { overview.close(&overview == selecting); });
+}
+
+static void closeOverviews(bool switchToSelection) {
+    forEachOverview([switchToSelection](COverview& overview) { overview.close(switchToSelection); });
+}
+
+// Open on the monitor under the cursor.
+static void openOverviews() {
+    renderingOverview = true;
+
+    if (const auto PMONITOR = State::monitorState()->query().vec(g_pInputManager->getMouseCoordsInternal()).run())
+        createOverview(PMONITOR);
+
+    renderingOverview = false;
+}
+
 static bool isSingleDigitWorkspaceArg(const std::string& arg) {
     return arg.size() == 1 && arg[0] >= '1' && arg[0] <= '9';
 }
@@ -186,13 +207,13 @@ static bool isSingleDigitWorkspaceArg(const std::string& arg) {
 static SDispatchResult changeToSingleDigitWorkspace(const std::string& arg) {
     const int workspaceID = arg[0] - '0';
 
-    if (g_pOverview) {
-        if (g_pOverview->selectWorkspaceByID(workspaceID)) {
-            g_pOverview->close();
+    if (auto* const OV = activeOverview()) {
+        if (OV->selectWorkspaceByID(workspaceID)) {
+            closeOverviewsSelecting(OV);
             return {};
         }
 
-        g_pOverview->close(false);
+        closeOverviews(false);
     }
 
     const auto change = Config::Actions::changeWorkspace(arg);
@@ -229,7 +250,7 @@ static std::string workspaceArgForKeysym(xkb_keysym_t keysym) {
 }
 
 static std::string workspaceArgForKeyEvent(const IKeyboard::SKeyEvent& event) {
-    if (!g_pOverview || event.state != WL_KEYBOARD_KEY_STATE_PRESSED)
+    if (!overviewOpen() || event.state != WL_KEYBOARD_KEY_STATE_PRESSED)
         return "";
 
     const auto KEYCODE  = event.keycode + 8;
@@ -251,7 +272,7 @@ static std::string workspaceArgForKeyEvent(const IKeyboard::SKeyEvent& event) {
 }
 
 bool shouldSelectWorkspaceFromKey(const IKeyboard::SKeyEvent& event) {
-    if (g_pOverview && g_pOverview->m_isSwiping)
+    if (auto* const OV = activeOverview(); OV && OV->m_isSwiping)
         return false;
 
     const auto arg = workspaceArgForKeyEvent(event);
@@ -265,8 +286,10 @@ bool shouldSelectWorkspaceFromKey(const IKeyboard::SKeyEvent& event) {
 
     if (mode == Hyprexpo::ENumberKeyMode::Index) {
         const int visibleIndex = Hyprexpo::numberKeyToVisibleIndex(arg[0] - '0');
-        if (visibleIndex >= 0)
-            g_pOverview->onKbSelectToken(visibleIndex);
+        if (visibleIndex >= 0) {
+            if (auto* const OV = activeOverview())
+                OV->onKbSelectToken(visibleIndex);
+        }
         return true;
     }
 
@@ -434,66 +457,52 @@ static int luaGesture(lua_State* L) {
 static SDispatchResult onExpoDispatcher(std::string arg) {
     arg = lowerString(trimString(arg));
 
-    if (g_pOverview && g_pOverview->m_isSwiping)
+    if (auto* const OV = activeOverview(); OV && OV->m_isSwiping)
         return {.success = false, .error = "already swiping"};
 
     if (isSingleDigitWorkspaceArg(arg))
         return changeToSingleDigitWorkspace(arg);
 
     if (arg == "select") {
-        if (g_pOverview) {
-            g_pOverview->selectHoveredWorkspace();
-            g_pOverview->close();
+        if (auto* const OV = activeOverview()) {
+            OV->selectHoveredWorkspace();
+            closeOverviewsSelecting(OV);
         }
         return {};
     }
 
     if (arg == "bring") {
-        if (g_pOverview) {
-            g_pOverview->selectHoveredWorkspace();
-            const auto result = bringWindowFromWorkspace(g_pOverview->selectedWorkspaceID());
-            g_pOverview->close(false);
+        if (auto* const OV = activeOverview()) {
+            OV->selectHoveredWorkspace();
+            const auto result = bringWindowFromWorkspace(OV->selectedWorkspaceID());
+            closeOverviews(false);
             return result;
         }
         return {};
     }
 
     if (arg == "toggle") {
-        if (g_pOverview)
-            g_pOverview->close(false);
-        else {
-            const auto PMONITOR = State::monitorState()->query().vec(g_pInputManager->getMouseCoordsInternal()).run();
-            if (!PMONITOR)
-                return {};
-            renderingOverview = true;
-            g_pOverview       = std::make_unique<COverview>(PMONITOR->m_activeWorkspace);
-            renderingOverview = false;
-        }
+        if (overviewOpen())
+            closeOverviews(false);
+        else
+            openOverviews();
         return {};
     }
 
     if (arg == "cancel") {
-        if (g_pOverview)
-            g_pOverview->close(false);
+        closeOverviews(false);
         return {};
     }
 
     if (arg == "off" || arg == "close" || arg == "disable") {
-        if (g_pOverview)
-            g_pOverview->close(false);
+        closeOverviews(false);
         return {};
     }
 
-    if (g_pOverview)
+    if (overviewOpen())
         return {};
 
-    const auto PMONITOR = State::monitorState()->query().vec(g_pInputManager->getMouseCoordsInternal()).run();
-    if (!PMONITOR)
-        return {};
-
-    renderingOverview = true;
-    g_pOverview       = std::make_unique<COverview>(PMONITOR->m_activeWorkspace);
-    renderingOverview = false;
+    openOverviews();
     return {};
 }
 
@@ -564,11 +573,12 @@ void syncExpoGestureFromConfig() {
 }
 
 static SDispatchResult onKbFocusDispatcher(std::string arg) {
-    if (!g_pOverview)
+    auto* const OV = activeOverview();
+    if (!OV)
         return {};
 
     if (arg == "left" || arg == "right" || arg == "up" || arg == "down") {
-        g_pOverview->onKbMoveFocus(arg);
+        OV->onKbMoveFocus(arg);
         return {};
     }
 
@@ -576,15 +586,17 @@ static SDispatchResult onKbFocusDispatcher(std::string arg) {
 }
 
 static SDispatchResult onKbConfirmDispatcher(std::string arg) {
-    if (!g_pOverview)
+    auto* const OV = activeOverview();
+    if (!OV)
         return {};
 
-    g_pOverview->onKbConfirm();
+    OV->onKbConfirm();
     return {};
 }
 
 static SDispatchResult onKbSelectNumberDispatcher(std::string arg) {
-    if (!g_pOverview)
+    auto* const OV = activeOverview();
+    if (!OV)
         return {};
 
     arg = trimString(arg);
@@ -595,22 +607,24 @@ static SDispatchResult onKbSelectNumberDispatcher(std::string arg) {
     if (!parseStrictInteger(arg, num))
         return {.success = false, .error = "invalid number"};
 
-    g_pOverview->onKbSelectNumber(num);
+    OV->onKbSelectNumber(num);
     return {};
 }
 
 static SDispatchResult onKbSelectTokenDispatcher(std::string arg) {
-    if (!g_pOverview)
+    auto* const OV = activeOverview();
+    if (!OV)
         return {};
     arg = trimString(arg);
-    if (!g_pOverview->selectVisibleToken(arg))
+    if (!OV->selectVisibleToken(arg))
         return {.success = false, .error = "no visible workspace for token"};
-    g_pOverview->close();
+    closeOverviewsSelecting(OV);
     return {};
 }
 
 static SDispatchResult onKbSelectIndexDispatcher(std::string arg) {
-    if (!g_pOverview)
+    auto* const OV = activeOverview();
+    if (!OV)
         return {};
     arg = trimString(arg);
     int idx = -1;
@@ -619,12 +633,13 @@ static SDispatchResult onKbSelectIndexDispatcher(std::string arg) {
     if (idx <= 0)
         return {.success = false, .error = "invalid index (expected >= 1)"};
     // convert to 0-based visible index
-    g_pOverview->onKbSelectToken(idx - 1);
+    OV->onKbSelectToken(idx - 1);
     return {};
 }
 
 static SDispatchResult onMovePreviewWindowDispatcher(std::string arg) {
-    if (!g_pOverview)
+    auto* const OV = activeOverview();
+    if (!OV)
         return {.success = false, .error = "overview is not open"};
 
     std::istringstream stream{trimString(arg)};
@@ -649,7 +664,7 @@ static SDispatchResult onMovePreviewWindowDispatcher(std::string arg) {
             return {.success = false, .error = "window address did not match a mapped window"};
     }
 
-    if (!g_pOverview->moveWindowBetweenVisibleIndices(source - 1, target - 1, window))
+    if (!OV->moveWindowBetweenVisibleIndices(source - 1, target - 1, window))
         return {.success = false, .error = "failed to move preview window"};
 
     return {};

--- a/Dispatchers.cpp
+++ b/Dispatchers.cpp
@@ -146,16 +146,14 @@ static PHLWINDOW windowToBringFromWorkspace(const PHLWORKSPACE& workspace) {
     return nullptr;
 }
 
-static SDispatchResult bringWindowFromWorkspace(int64_t sourceWorkspaceID) {
+static SDispatchResult bringWindowFromWorkspace(int64_t sourceWorkspaceID, const PHLMONITOR& destinationMonitor) {
     if (sourceWorkspaceID == WORKSPACE_INVALID)
         return {.success = false, .error = "selected workspace is empty"};
 
-    const auto focusState = Desktop::focusState();
-    const auto monitor    = focusState ? focusState->monitor() : State::monitorState()->query().vec(g_pInputManager->getMouseCoordsInternal()).run();
-    if (!monitor || !monitor->m_activeWorkspace)
+    if (!destinationMonitor || !destinationMonitor->m_activeWorkspace)
         return {.success = false, .error = "no active monitor/workspace"};
 
-    if (sourceWorkspaceID == monitor->activeWorkspaceID())
+    if (sourceWorkspaceID == destinationMonitor->activeWorkspaceID())
         return {};
 
     PHLWORKSPACE sourceWorkspace;
@@ -172,7 +170,8 @@ static SDispatchResult bringWindowFromWorkspace(int64_t sourceWorkspaceID) {
     if (!window)
         return {.success = false, .error = "selected workspace has no mapped windows"};
 
-    Desktop::globalWindowController()->moveWindowToWorkspace(window, monitor->m_activeWorkspace);
+    Desktop::globalWindowController()->moveWindowToWorkspace(window, destinationMonitor->m_activeWorkspace);
+    const auto focusState = Desktop::focusState();
     if (focusState)
         focusState->fullWindowFocus(window, Desktop::FOCUS_REASON_KEYBIND);
     window->warpCursor();
@@ -459,7 +458,7 @@ static SDispatchResult onExpoDispatcher(std::string arg) {
         return changeToSingleDigitWorkspace(arg);
 
     if (arg == "select") {
-        if (auto* const OV = activeOverview()) {
+        if (auto* const OV = overviewForGlobalPoint(g_pInputManager->getMouseCoordsInternal())) {
             if (OV->selectHoveredWorkspace())
                 closeOverviewsSelecting(OV);
         }
@@ -467,10 +466,11 @@ static SDispatchResult onExpoDispatcher(std::string arg) {
     }
 
     if (arg == "bring") {
-        if (auto* const OV = activeOverview()) {
+        if (auto* const OV = overviewForGlobalPoint(g_pInputManager->getMouseCoordsInternal())) {
             if (!OV->selectHoveredWorkspace())
                 return {.success = false, .error = "no workspace under pointer"};
-            const auto result = bringWindowFromWorkspace(OV->selectedWorkspaceID());
+            const auto DESTINATION = OV->pMonitor.lock();
+            const auto result = bringWindowFromWorkspace(OV->selectedWorkspaceID(), DESTINATION);
             closeOverviews(false);
             return result;
         }

--- a/ExpoGesture.cpp
+++ b/ExpoGesture.cpp
@@ -17,16 +17,24 @@ void CExpoGesture::begin(const ITrackpadGesture::STrackpadGestureBegin& e) {
     if (!monitor || !monitor->m_activeWorkspace)
         return;
 
-    if (!g_pOverview)
-        g_pOverview = std::make_unique<COverview>(monitor->m_activeWorkspace, true);
-    else if (!g_pOverview->closeCommitted()) {
-        g_pOverview->selectHoveredWorkspace();
-        g_pOverview->setClosing(true);
+    m_monitor = monitor;
+
+    auto* const OV = overviewForMonitor(monitor);
+    if (!OV)
+        createOverview(monitor, true);
+    else if (!OV->closeCommitted()) {
+        OV->selectHoveredWorkspace();
+        OV->setClosing(true);
     }
 }
 
+COverview* CExpoGesture::overview() const {
+    return overviewForMonitor(m_monitor.lock());
+}
+
 void CExpoGesture::update(const ITrackpadGesture::STrackpadGestureUpdate& e) {
-    if (!g_pOverview || g_pOverview->closeCommitted())
+    auto* const OV = overview();
+    if (!OV || OV->closeCommitted())
         return;
 
     if (m_firstUpdate) {
@@ -39,15 +47,17 @@ void CExpoGesture::update(const ITrackpadGesture::STrackpadGestureUpdate& e) {
     if (m_lastDelta <= 0.01) // plugin will crash if swipe ends at <= 0
         m_lastDelta = 0.01;
 
-    g_pOverview->onSwipeUpdate(m_lastDelta);
+    OV->onSwipeUpdate(m_lastDelta);
 }
 
 void CExpoGesture::end(const ITrackpadGesture::STrackpadGestureEnd& e) {
-    if (!g_pOverview || g_pOverview->closeCommitted())
+    auto* const OV = overview();
+    if (!OV || OV->closeCommitted())
         return;
 
-    g_pOverview->setClosing(false);
-    g_pOverview->onSwipeEnd();
-    if (g_pOverview)
-        g_pOverview->resetSwipe();
+    OV->setClosing(false);
+    OV->onSwipeEnd();
+    // onSwipeEnd can tear the overview down, so re-resolve before touching it.
+    if (auto* const STILL_ALIVE = overview())
+        STILL_ALIVE->resetSwipe();
 }

--- a/ExpoGesture.hpp
+++ b/ExpoGesture.hpp
@@ -1,6 +1,9 @@
 #pragma once
 
 #include <hyprland/src/managers/input/trackpad/gestures/ITrackpadGesture.hpp>
+#include <hyprland/src/desktop/DesktopTypes.hpp>
+
+class COverview;
 
 class CExpoGesture : public ITrackpadGesture {
   public:
@@ -12,6 +15,11 @@ class CExpoGesture : public ITrackpadGesture {
     virtual void end(const ITrackpadGesture::STrackpadGestureEnd& e);
 
   private:
-    float m_lastDelta   = 0.F;
-    bool  m_firstUpdate = false;
+    COverview*    overview() const;
+
+    // Monitor the gesture started on, so update/end keep driving the same
+    // overview even when other monitors have one open too.
+    PHLMONITORREF m_monitor;
+    float         m_lastDelta   = 0.F;
+    bool          m_firstUpdate = false;
 };

--- a/HyprexpoLogic.cpp
+++ b/HyprexpoLogic.cpp
@@ -277,14 +277,16 @@ SOverviewDragTransition transitionOverviewDrag(const SOverviewDragState& state, 
     if (event.type == EOverviewDragEventType::Cancel || event.type == EOverviewDragEventType::AllClose)
         return cleanupOverviewDrag(state);
 
+    const bool sourceLive = containsMonitorKey(liveMonitorKeys, state.sourceMonitorKey);
+    const bool targetLive = state.targetMonitorKey == 0 || containsMonitorKey(liveMonitorKeys, state.targetMonitorKey);
+    if (!sourceLive || !targetLive)
+        return cleanupOverviewDrag(state);
+
     if (event.type == EOverviewDragEventType::MonitorDestroyed) {
         if (!containsMonitorKey(state.affectedMonitorKeys, event.monitorKey))
             return {.next = state, .drop = std::nullopt, .cleanupMonitorKeys = {}, .accepted = false, .cleanup = false};
         return cleanupOverviewDrag(state);
     }
-
-    if (!containsMonitorKey(liveMonitorKeys, state.sourceMonitorKey))
-        return cleanupOverviewDrag(state);
 
     if (event.type == EOverviewDragEventType::Move) {
         auto next  = state;

--- a/HyprexpoLogic.cpp
+++ b/HyprexpoLogic.cpp
@@ -6,6 +6,8 @@
 #include <charconv>
 #include <cctype>
 #include <cmath>
+#include <limits>
+#include <tuple>
 
 namespace Hyprexpo {
 
@@ -142,6 +144,187 @@ int tileIndexAtPoint(double x, double y, int visibleCount, SGridShape shape, SSi
     }
 
     return -1;
+}
+
+static bool validRect(const SRect& rect) {
+    return rect.w > 0.0 && rect.h > 0.0;
+}
+
+static double intervalDistance(double a0, double a1, double b0, double b1) {
+    if (a1 < b0)
+        return b0 - a1;
+    if (b1 < a0)
+        return a0 - b1;
+    return 0.0;
+}
+
+std::optional<STileTarget> selectDirectionalTile(const SRect& source, EDirection direction, const std::vector<SGlobalTile>& candidates) {
+    if (!validRect(source))
+        return std::nullopt;
+
+    const double sourceCenterX = source.x + source.w / 2.0;
+    const double sourceCenterY = source.y + source.h / 2.0;
+    std::optional<STileTarget> best;
+    auto bestRank = std::tuple{std::numeric_limits<double>::infinity(), std::numeric_limits<double>::infinity(), std::numeric_limits<double>::infinity()};
+
+    for (const auto& candidate : candidates) {
+        if (candidate.overviewKey == 0 || candidate.tileIndex < 0 || !validRect(candidate.overviewGlobal) || !validRect(candidate.tileGlobal))
+            continue;
+
+        const double candidateCenterX = candidate.tileGlobal.x + candidate.tileGlobal.w / 2.0;
+        const double candidateCenterY = candidate.tileGlobal.y + candidate.tileGlobal.h / 2.0;
+        double       forward          = 0.0;
+        double       perpendicular    = 0.0;
+        double       centerDistance   = 0.0;
+
+        switch (direction) {
+            case EDirection::Left:
+                if (candidate.tileGlobal.x + candidate.tileGlobal.w > source.x)
+                    continue;
+                forward        = std::max(0.0, source.x - (candidate.tileGlobal.x + candidate.tileGlobal.w));
+                perpendicular  = intervalDistance(source.y, source.y + source.h, candidate.tileGlobal.y, candidate.tileGlobal.y + candidate.tileGlobal.h);
+                centerDistance = std::abs(candidateCenterY - sourceCenterY);
+                break;
+            case EDirection::Right:
+                if (candidate.tileGlobal.x < source.x + source.w)
+                    continue;
+                forward        = std::max(0.0, candidate.tileGlobal.x - (source.x + source.w));
+                perpendicular  = intervalDistance(source.y, source.y + source.h, candidate.tileGlobal.y, candidate.tileGlobal.y + candidate.tileGlobal.h);
+                centerDistance = std::abs(candidateCenterY - sourceCenterY);
+                break;
+            case EDirection::Up:
+                if (candidate.tileGlobal.y + candidate.tileGlobal.h > source.y)
+                    continue;
+                forward        = std::max(0.0, source.y - (candidate.tileGlobal.y + candidate.tileGlobal.h));
+                perpendicular  = intervalDistance(source.x, source.x + source.w, candidate.tileGlobal.x, candidate.tileGlobal.x + candidate.tileGlobal.w);
+                centerDistance = std::abs(candidateCenterX - sourceCenterX);
+                break;
+            case EDirection::Down:
+                if (candidate.tileGlobal.y < source.y + source.h)
+                    continue;
+                forward        = std::max(0.0, candidate.tileGlobal.y - (source.y + source.h));
+                perpendicular  = intervalDistance(source.x, source.x + source.w, candidate.tileGlobal.x, candidate.tileGlobal.x + candidate.tileGlobal.w);
+                centerDistance = std::abs(candidateCenterX - sourceCenterX);
+                break;
+        }
+
+        const auto rank = std::tuple{forward, perpendicular, centerDistance};
+        if (!best || rank < bestRank) {
+            best     = STileTarget{candidate.overviewKey, candidate.tileIndex};
+            bestRank = rank;
+        }
+    }
+
+    return best;
+}
+
+std::optional<STileHit> hitTestGlobalTile(const SPoint& point, const std::vector<SGlobalTile>& tiles) {
+    for (const auto& tile : tiles) {
+        if (tile.overviewKey == 0 || tile.tileIndex < 0 || !validRect(tile.overviewGlobal) || !validRect(tile.tileGlobal))
+            continue;
+        if (point.x < tile.tileGlobal.x || point.x >= tile.tileGlobal.x + tile.tileGlobal.w || point.y < tile.tileGlobal.y || point.y >= tile.tileGlobal.y + tile.tileGlobal.h)
+            continue;
+
+        return STileHit{
+            .overviewKey = tile.overviewKey,
+            .tileIndex   = tile.tileIndex,
+            .pointLocal  = {point.x - tile.overviewGlobal.x, point.y - tile.overviewGlobal.y},
+        };
+    }
+
+    return std::nullopt;
+}
+
+static bool containsMonitorKey(const std::vector<uint64_t>& keys, uint64_t key) {
+    return key != 0 && std::find(keys.begin(), keys.end(), key) != keys.end();
+}
+
+static void appendMonitorKey(std::vector<uint64_t>& keys, uint64_t key) {
+    if (key != 0 && !containsMonitorKey(keys, key))
+        keys.push_back(key);
+}
+
+static SOverviewDragTransition cleanupOverviewDrag(const SOverviewDragState& state) {
+    if (!state.active)
+        return {.next = state, .drop = std::nullopt, .cleanupMonitorKeys = {}, .accepted = false, .cleanup = false};
+
+    return {
+        .next               = {},
+        .drop               = std::nullopt,
+        .cleanupMonitorKeys = state.affectedMonitorKeys,
+        .accepted           = true,
+        .cleanup            = true,
+    };
+}
+
+SOverviewDragTransition transitionOverviewDrag(const SOverviewDragState& state, const SOverviewDragEvent& event, const std::vector<uint64_t>& liveMonitorKeys) {
+    if (event.type == EOverviewDragEventType::Press) {
+        if (state.active || event.tileIndex < 0 || event.windowKey == 0 || !containsMonitorKey(liveMonitorKeys, event.monitorKey))
+            return {.next = state, .drop = std::nullopt, .cleanupMonitorKeys = {}, .accepted = false, .cleanup = false};
+
+        SOverviewDragState next;
+        next.active           = true;
+        next.sourceMonitorKey = event.monitorKey;
+        next.sourceTileIndex  = event.tileIndex;
+        next.windowKey        = event.windowKey;
+        appendMonitorKey(next.affectedMonitorKeys, event.monitorKey);
+        return {.next = std::move(next), .drop = std::nullopt, .cleanupMonitorKeys = {}, .accepted = true, .cleanup = false};
+    }
+
+    if (!state.active)
+        return {.next = state, .drop = std::nullopt, .cleanupMonitorKeys = {}, .accepted = false, .cleanup = false};
+
+    if (event.type == EOverviewDragEventType::Cancel || event.type == EOverviewDragEventType::AllClose)
+        return cleanupOverviewDrag(state);
+
+    if (event.type == EOverviewDragEventType::MonitorDestroyed) {
+        if (!containsMonitorKey(state.affectedMonitorKeys, event.monitorKey))
+            return {.next = state, .drop = std::nullopt, .cleanupMonitorKeys = {}, .accepted = false, .cleanup = false};
+        return cleanupOverviewDrag(state);
+    }
+
+    if (!containsMonitorKey(liveMonitorKeys, state.sourceMonitorKey))
+        return cleanupOverviewDrag(state);
+
+    if (event.type == EOverviewDragEventType::Move) {
+        auto next  = state;
+        next.moved = true;
+        return {.next = std::move(next), .drop = std::nullopt, .cleanupMonitorKeys = {}, .accepted = true, .cleanup = false};
+    }
+
+    if (event.type == EOverviewDragEventType::Target) {
+        if (event.monitorKey == 0) {
+            auto next             = state;
+            next.targetMonitorKey = 0;
+            next.targetTileIndex  = -1;
+            return {.next = std::move(next), .drop = std::nullopt, .cleanupMonitorKeys = {}, .accepted = true, .cleanup = false};
+        }
+        if (event.tileIndex < 0 || !containsMonitorKey(liveMonitorKeys, event.monitorKey))
+            return {.next = state, .drop = std::nullopt, .cleanupMonitorKeys = {}, .accepted = false, .cleanup = false};
+
+        auto next             = state;
+        next.targetMonitorKey = event.monitorKey;
+        next.targetTileIndex  = event.tileIndex;
+        appendMonitorKey(next.affectedMonitorKeys, event.monitorKey);
+        return {.next = std::move(next), .drop = std::nullopt, .cleanupMonitorKeys = {}, .accepted = true, .cleanup = false};
+    }
+
+    if (event.type == EOverviewDragEventType::Release) {
+        auto transition = cleanupOverviewDrag(state);
+        if (state.moved && state.targetTileIndex >= 0 && containsMonitorKey(liveMonitorKeys, state.targetMonitorKey) &&
+            (state.sourceMonitorKey != state.targetMonitorKey || state.sourceTileIndex != state.targetTileIndex)) {
+            transition.drop = SOverviewDropIntent{
+                .sourceMonitorKey = state.sourceMonitorKey,
+                .sourceTileIndex  = state.sourceTileIndex,
+                .targetMonitorKey = state.targetMonitorKey,
+                .targetTileIndex  = state.targetTileIndex,
+                .windowKey        = state.windowKey,
+            };
+        }
+        return transition;
+    }
+
+    return {.next = state, .drop = std::nullopt, .cleanupMonitorKeys = {}, .accepted = false, .cleanup = false};
 }
 
 int clampGridColumns(int columns) {

--- a/HyprexpoLogic.cpp
+++ b/HyprexpoLogic.cpp
@@ -479,6 +479,18 @@ SWorkspaceMethodSpec parseWorkspaceMethodSpec(const std::string& method) {
     return spec;
 }
 
+SExpoCommand parseExpoCommand(const std::string& arg) {
+    const std::string TRIMMED = trimString(arg);
+
+    if (TRIMMED == "all")
+        return {.command = "toggle", .allMonitors = true};
+
+    if (TRIMMED.ends_with(" all"))
+        return {.command = trimString(TRIMMED.substr(0, TRIMMED.size() - 4)), .allMonitors = true};
+
+    return {.command = TRIMMED, .allMonitors = false};
+}
+
 SWorkspaceMethodSpec resolveWorkspaceMethodForMonitor(const std::string& config, const std::string& monitorName) {
     const std::string trimmed = trimString(config);
     if (trimmed.empty())

--- a/HyprexpoLogic.hpp
+++ b/HyprexpoLogic.hpp
@@ -40,6 +40,17 @@ struct SWorkspaceMethodSpec {
     std::string          error;
 };
 
+// Result of stripping an "all monitors" qualifier off an expo dispatcher arg.
+struct SExpoCommand {
+    std::string command;            // the arg with the qualifier removed
+    bool        allMonitors = false;
+};
+
+// Split "toggle all", "on all" or a bare "all" (which means "toggle all") into
+// the underlying command plus the all-monitors flag. Args without the
+// qualifier come back unchanged with allMonitors = false.
+SExpoCommand parseExpoCommand(const std::string& arg);
+
 struct SPoint {
     double x = 0.0;
     double y = 0.0;

--- a/HyprexpoLogic.hpp
+++ b/HyprexpoLogic.hpp
@@ -68,6 +68,75 @@ struct SRect {
     double h = 0.0;
 };
 
+enum class EDirection {
+    Left,
+    Right,
+    Up,
+    Down,
+};
+
+struct SGlobalTile {
+    uint64_t overviewKey = 0;
+    int      tileIndex   = -1;
+    SRect    overviewGlobal;
+    SRect    tileGlobal;
+};
+
+struct STileTarget {
+    uint64_t overviewKey = 0;
+    int      tileIndex   = -1;
+};
+
+struct STileHit {
+    uint64_t overviewKey = 0;
+    int      tileIndex   = -1;
+    SPoint   pointLocal;
+};
+
+enum class EOverviewDragEventType {
+    Press,
+    Move,
+    Target,
+    Release,
+    Cancel,
+    MonitorDestroyed,
+    AllClose,
+};
+
+struct SOverviewDragState {
+    bool                  active             = false;
+    bool                  moved              = false;
+    uint64_t              sourceMonitorKey   = 0;
+    int                   sourceTileIndex    = -1;
+    uint64_t              targetMonitorKey   = 0;
+    int                   targetTileIndex    = -1;
+    uint64_t              windowKey          = 0;
+    std::vector<uint64_t> affectedMonitorKeys;
+};
+
+struct SOverviewDragEvent {
+    EOverviewDragEventType type       = EOverviewDragEventType::Move;
+    uint64_t               monitorKey = 0;
+    int                    tileIndex  = -1;
+    uint64_t               windowKey  = 0;
+};
+
+struct SOverviewDropIntent {
+    uint64_t sourceMonitorKey = 0;
+    int      sourceTileIndex  = -1;
+    uint64_t targetMonitorKey = 0;
+    int      targetTileIndex  = -1;
+    uint64_t windowKey        = 0;
+};
+
+struct SOverviewDragTransition {
+    SOverviewDragState                next;
+    std::optional<SOverviewDropIntent> drop;
+    std::vector<uint64_t>             cleanupMonitorKeys;
+    bool                              accepted = false;
+    bool                              cleanup  = false;
+};
+
 struct SGridShape {
     int cols = 1;
     int rows = 1;
@@ -115,6 +184,9 @@ std::optional<std::vector<int64_t>> expandDynamicWorkspaceIDs(const std::vector<
 SSize                    aspectCorrectTileSize(double screenW, double screenH, int cols, int rows, double gap);
 STileLayout              computeTileLayout(int index, int visibleCount, SGridShape shape, SSize total, double gap, bool centerPartialRows);
 int                      tileIndexAtPoint(double x, double y, int visibleCount, SGridShape shape, SSize total, double gap, bool centerPartialRows);
+std::optional<STileTarget> selectDirectionalTile(const SRect& source, EDirection direction, const std::vector<SGlobalTile>& candidates);
+std::optional<STileHit>    hitTestGlobalTile(const SPoint& point, const std::vector<SGlobalTile>& tiles);
+SOverviewDragTransition    transitionOverviewDrag(const SOverviewDragState& state, const SOverviewDragEvent& event, const std::vector<uint64_t>& liveMonitorKeys);
 
 int                      clampGridColumns(int columns);
 int                      gridColumnsToIncludeWorkspace(int configuredColumns, int firstWorkspaceID, int activeWorkspaceID, int maxColumns);

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ HEADERS = globals.hpp Dispatchers.hpp PluginConfig.hpp HyprlandConfigCompat.hpp 
 TARGET = hyprexpo.so
 TEST_TARGET = HyprexpoLogicTests
 SOURCE_TEST_TARGET = OverviewSourceTests
+REGISTRY_TEST_TARGET = RegistryTeardownTests
 INSTALL_USER ?= $(if $(SUDO_USER),$(SUDO_USER),$(USER))
 INSTALL_DIR ?= /var/cache/hyprpm/$(INSTALL_USER)/hyprexpo
 INSTALL_NAME = hyprexpo.so
@@ -66,17 +67,21 @@ install: $(TARGET)
 	install -Dm755 $(TARGET) $(INSTALL_DIR)/$(INSTALL_NAME)
 
 clean:
-	rm -f ./$(TARGET) ./$(TEST_TARGET) ./$(SOURCE_TEST_TARGET)
+	rm -f ./$(TARGET) ./$(TEST_TARGET) ./$(SOURCE_TEST_TARGET) ./$(REGISTRY_TEST_TARGET)
 
-test: $(TEST_TARGET) $(SOURCE_TEST_TARGET)
+test: $(TEST_TARGET) $(SOURCE_TEST_TARGET) $(REGISTRY_TEST_TARGET)
 	./$(TEST_TARGET)
 	./$(SOURCE_TEST_TARGET)
+	./$(REGISTRY_TEST_TARGET)
 
 $(TEST_TARGET): HyprexpoLogic.cpp HyprexpoLogic.hpp HyprexpoConfig.hpp tests/HyprexpoLogicTests.cpp
 	$(CXX) -std=c++2b -Wall -Wextra -Werror HyprexpoLogic.cpp tests/HyprexpoLogicTests.cpp -o $@
 
 $(SOURCE_TEST_TARGET): tests/OverviewSourceTests.cpp Overview.cpp OverviewRender.cpp Dispatchers.cpp main.cpp
 	$(CXX) -std=c++2b -Wall -Wextra -Werror tests/OverviewSourceTests.cpp -o $@
+
+$(REGISTRY_TEST_TARGET): tests/RegistryTeardownTests.cpp
+	$(CXX) -std=c++2b -Wall -Wextra -Werror tests/RegistryTeardownTests.cpp -o $@
 
 # --- Release ceremony -----------------------------------------------------
 # 1. make check-pins          verify hyprpm pins are on the release history

--- a/Overview.cpp
+++ b/Overview.cpp
@@ -671,6 +671,17 @@ COverview* overviewForMonitorKey(uint64_t key) {
     return nullptr;
 }
 
+COverview* overviewForGlobalPoint(const Vector2D& point) {
+    for (const auto& OV : g_overviews) {
+        const auto MON = OV->pMonitor.lock();
+        if (!MON)
+            continue;
+        if (point.x >= MON->m_position.x && point.x < MON->m_position.x + MON->m_size.x && point.y >= MON->m_position.y && point.y < MON->m_position.y + MON->m_size.y)
+            return OV.get();
+    }
+    return nullptr;
+}
+
 bool overviewRegistered(const COverview* overview) {
     return overview && std::any_of(g_overviews.begin(), g_overviews.end(), [overview](const auto& entry) { return entry.get() == overview; });
 }
@@ -800,7 +811,7 @@ void forEachOverview(const std::function<void(COverview&)>& fn) {
     }
 }
 
-static std::vector<uint64_t> liveOverviewMonitorKeys() {
+std::vector<uint64_t> liveOverviewMonitorKeys() {
     std::vector<uint64_t> keys;
     keys.reserve(g_overviews.size());
     for (const auto& OV : g_overviews)
@@ -1274,51 +1285,73 @@ COverview::COverview(PHLWORKSPACE startedOn_, PHLMONITOR monitor_, bool swipe_) 
     kbFocusID = openedID;
 
     auto onCursorMove = [this](Event::SCallbackInfo& info) {
-        if (closing)
+        if (closing || info.cancelled)
             return;
 
+        info.cancelled = true;
         ensureOverviewCursorVisible();
 
-        info.cancelled    = true;
-        lastMousePosLocal = g_pInputManager->getMouseCoordsInternal() - pMonitor->m_position;
-        updateHoveredFromMouse();
-        updateWindowDrag();
+        const Vector2D GLOBAL = g_pInputManager->getMouseCoordsInternal();
+        for (const auto& OV : g_overviews) {
+            const auto MON = OV->pMonitor.lock();
+            if (!MON || OV->closing)
+                continue;
+            OV->lastMousePosLocal = GLOBAL - MON->m_position;
+            OV->updateHoveredFromMouse();
+        }
+
+        if (auto* const SOURCE = overviewForMonitorKey(g_overviewDrag.state.sourceMonitorKey))
+            SOURCE->updateWindowDrag();
     };
 
     auto onCursorSelect = [this](const IPointer::SButtonEvent& event, Event::SCallbackInfo& info) {
-        if (closing)
+        if (closing || info.cancelled)
             return;
+
+        const Vector2D GLOBAL = g_pInputManager->getMouseCoordsInternal();
+        auto* const    TARGET = overviewForGlobalPoint(GLOBAL);
+        auto* const    SOURCE = overviewForMonitorKey(g_overviewDrag.state.sourceMonitorKey);
+        if (!TARGET && !SOURCE)
+            return;
+
+        info.cancelled = true;
 
         // If expo hasn't animated in enough to be visible, close silently without
         // consuming the event. This prevents phantom triggers (e.g. a bouncing
         // mouse side-button firing the expo keybind) from swallowing real clicks.
-        if (size->getPercent() < 0.05f) {
-            close();
+        if (TARGET && TARGET->size->getPercent() < 0.05f) {
+            TARGET->close(false);
             return;
         }
-
-        info.cancelled = true;
 
         if (event.state == WL_POINTER_BUTTON_STATE_PRESSED) {
-            if (**PDRAGDROPENABLE)
-                beginWindowDrag();
+            if (**PDRAGDROPENABLE && TARGET)
+                TARGET->beginWindowDrag();
             return;
         }
 
-        if (**PDRAGDROPENABLE && finishWindowDrag())
-            return;
+        if (**PDRAGDROPENABLE && SOURCE) {
+            const bool CONSUMED = SOURCE->finishWindowDrag();
+            if (CONSUMED)
+                return;
+        }
 
-        if (selectHoveredWorkspace())
-            closeOverviewsSelecting(this);
+        if (TARGET && TARGET->selectHoveredWorkspace())
+            closeOverviewsSelecting(TARGET);
     };
 
     auto onTouchSelect = [this](Event::SCallbackInfo& info) {
-        if (closing)
+        if (closing || info.cancelled)
+            return;
+
+        const Vector2D GLOBAL = g_pInputManager->getMouseCoordsInternal();
+        auto* const    TARGET = overviewForGlobalPoint(GLOBAL);
+        if (!TARGET)
             return;
 
         info.cancelled = true;
-        if (selectHoveredWorkspace())
-            closeOverviewsSelecting(this);
+        if (TARGET->selectHoveredWorkspace())
+            closeOverviewsSelecting(TARGET);
     };
 
     mouseMoveHook = Event::bus()->m_events.input.mouse.move.listen([onCursorMove](const Vector2D&, Event::SCallbackInfo& info) { onCursorMove(info); });

--- a/Overview.cpp
+++ b/Overview.cpp
@@ -1005,6 +1005,10 @@ Vector2D COverview::zoomSizeForCurrentGrid(const Vector2D& monitorSize) const {
 }
 
 COverview::~COverview() {
+    if (redrawSettleTimer) {
+        redrawSettleTimer->cancel();
+        redrawSettleTimer.reset();
+    }
     Render::GL::g_pHyprOpenGL->makeEGLCurrent();
     images.clear(); // otherwise we get a vram leak
     Pointer::Cursor::overrideController->unsetOverride(Pointer::Cursor::CURSOR_OVERRIDE_UNKNOWN);

--- a/Overview.cpp
+++ b/Overview.cpp
@@ -654,6 +654,27 @@ COverview* overviewForMonitor(const PHLMONITOR& monitor) {
     return nullptr;
 }
 
+uint64_t overviewMonitorKey(const PHLMONITOR& monitor) {
+    return monitor ? static_cast<uint64_t>(monitor->m_id) + 1 : 0;
+}
+
+COverview* overviewForMonitorKey(uint64_t key) {
+    if (key == 0)
+        return nullptr;
+
+    for (const auto& OV : g_overviews) {
+        const auto MON = OV->pMonitor.lock();
+        if (overviewMonitorKey(MON) == key)
+            return OV.get();
+    }
+
+    return nullptr;
+}
+
+bool overviewRegistered(const COverview* overview) {
+    return overview && std::any_of(g_overviews.begin(), g_overviews.end(), [overview](const auto& entry) { return entry.get() == overview; });
+}
+
 COverview* createOverview(const PHLMONITOR& monitor, bool swipe) {
     if (!monitor || !monitor->m_activeWorkspace)
         return nullptr;
@@ -676,6 +697,10 @@ COverview* activeOverview() {
     if (g_overviews.size() == 1)
         return g_overviews.front().get();
 
+    const auto KEYBOARD = g_keyboardOverviewMonitor.lock();
+    if (auto* const OWNED = overviewForMonitor(KEYBOARD))
+        return OWNED;
+
     const auto FOCUS = Desktop::focusState();
     if (auto* const FOCUSED = FOCUS ? overviewForMonitor(FOCUS->monitor()) : nullptr)
         return FOCUSED;
@@ -684,6 +709,78 @@ COverview* activeOverview() {
         return HOVERED;
 
     return g_overviews.front().get();
+}
+
+std::optional<Hyprexpo::SGlobalTile> COverview::focusedGlobalTile() const {
+    const auto MON = pMonitor.lock();
+    if (!MON || !isTileValid(kbFocusID))
+        return std::nullopt;
+
+    const auto& BOX = images[kbFocusID].box;
+    return Hyprexpo::SGlobalTile{
+        .overviewKey   = overviewMonitorKey(MON),
+        .tileIndex     = kbFocusID,
+        .overviewGlobal = {MON->m_position.x, MON->m_position.y, MON->m_size.x, MON->m_size.y},
+        .tileGlobal     = {MON->m_position.x + BOX.x, MON->m_position.y + BOX.y, BOX.w, BOX.h},
+    };
+}
+
+std::vector<Hyprexpo::SGlobalTile> COverview::globalTiles() const {
+    std::vector<Hyprexpo::SGlobalTile> tiles;
+    const auto                         MON = pMonitor.lock();
+    if (!MON)
+        return tiles;
+
+    tiles.reserve(images.size());
+    for (size_t i = 0; i < images.size(); ++i) {
+        if (!isTileValid(i))
+            continue;
+        const auto& BOX = images[i].box;
+        tiles.push_back({
+            .overviewKey   = overviewMonitorKey(MON),
+            .tileIndex     = static_cast<int>(i),
+            .overviewGlobal = {MON->m_position.x, MON->m_position.y, MON->m_size.x, MON->m_size.y},
+            .tileGlobal     = {MON->m_position.x + BOX.x, MON->m_position.y + BOX.y, BOX.w, BOX.h},
+        });
+    }
+    return tiles;
+}
+
+bool COverview::setKeyboardFocus(int tileIndex) {
+    if (closing || !isTileValid(tileIndex))
+        return false;
+    kbFocusID = tileIndex;
+    damage();
+    return true;
+}
+
+bool moveOverviewFocusAcrossMonitors(COverview* source, Hyprexpo::EDirection direction) {
+    if (!overviewRegistered(source))
+        return false;
+
+    const auto SOURCE = source->focusedGlobalTile();
+    if (!SOURCE)
+        return false;
+
+    std::vector<Hyprexpo::SGlobalTile> candidates;
+    for (const auto& OV : g_overviews) {
+        if (OV.get() == source)
+            continue;
+        auto tiles = OV->globalTiles();
+        candidates.insert(candidates.end(), tiles.begin(), tiles.end());
+    }
+
+    const auto DESTINATION = Hyprexpo::selectDirectionalTile(SOURCE->tileGlobal, direction, candidates);
+    if (!DESTINATION)
+        return false;
+
+    auto* const TARGET = overviewForMonitorKey(DESTINATION->overviewKey);
+    if (!TARGET || !TARGET->setKeyboardFocus(DESTINATION->tileIndex))
+        return false;
+
+    g_keyboardOverviewMonitor = TARGET->pMonitor;
+    source->damage();
+    return true;
 }
 
 void forEachOverview(const std::function<void(COverview&)>& fn) {
@@ -703,14 +800,62 @@ void forEachOverview(const std::function<void(COverview&)>& fn) {
     }
 }
 
+static std::vector<uint64_t> liveOverviewMonitorKeys() {
+    std::vector<uint64_t> keys;
+    keys.reserve(g_overviews.size());
+    for (const auto& OV : g_overviews)
+        keys.push_back(overviewMonitorKey(OV->pMonitor.lock()));
+    return keys;
+}
+
+void resetOverviewDrag(Hyprexpo::EOverviewDragEventType type, uint64_t monitorKey) {
+    const auto transition = Hyprexpo::transitionOverviewDrag(g_overviewDrag.state, {.type = type, .monitorKey = monitorKey}, liveOverviewMonitorKeys());
+    g_overviewDrag.state  = transition.next;
+    if (!transition.cleanup)
+        return;
+
+    g_overviewDrag.window      = nullptr;
+    g_overviewDrag.pressGlobal = {};
+    g_overviewDrag.pointerGlobal = {};
+    g_overviewDrag.grabOffset  = {};
+    Pointer::Cursor::overrideController->setOverride("left_ptr", Pointer::Cursor::CURSOR_OVERRIDE_UNKNOWN);
+
+    for (const auto key : transition.cleanupMonitorKeys) {
+        auto* const OV = overviewForMonitorKey(key);
+        if (!OV)
+            continue;
+        OV->damage();
+        if (const auto MON = OV->pMonitor.lock())
+            g_pHyprRenderer->damageMonitor(MON);
+    }
+}
+
+void closeOverviewsSelecting(COverview* selecting) {
+    resetOverviewDrag(Hyprexpo::EOverviewDragEventType::AllClose);
+    g_keyboardOverviewMonitor.reset();
+    forEachOverview([selecting](COverview& overview) { overview.close(&overview == selecting); });
+}
+
+void closeOverviews(bool switchToSelection) {
+    resetOverviewDrag(Hyprexpo::EOverviewDragEventType::AllClose);
+    g_keyboardOverviewMonitor.reset();
+    forEachOverview([switchToSelection](COverview& overview) { overview.close(switchToSelection); });
+}
+
 void destroyOverview(COverview* overview) {
     if (!overview)
         return;
 
+    const auto MON = overview->pMonitor.lock();
+    resetOverviewDrag(Hyprexpo::EOverviewDragEventType::MonitorDestroyed, overviewMonitorKey(MON));
+    if (g_keyboardOverviewMonitor.lock() == MON)
+        g_keyboardOverviewMonitor.reset();
     std::erase_if(g_overviews, [overview](const auto& entry) { return entry.get() == overview; });
 }
 
 void destroyAllOverviews() {
+    resetOverviewDrag(Hyprexpo::EOverviewDragEventType::AllClose);
+    g_keyboardOverviewMonitor.reset();
     g_overviews.clear();
 }
 
@@ -1163,8 +1308,8 @@ COverview::COverview(PHLWORKSPACE startedOn_, PHLMONITOR monitor_, bool swipe_) 
         if (**PDRAGDROPENABLE && finishWindowDrag())
             return;
 
-        selectHoveredWorkspace();
-        close();
+        if (selectHoveredWorkspace())
+            closeOverviewsSelecting(this);
     };
 
     auto onTouchSelect = [this](Event::SCallbackInfo& info) {
@@ -1172,8 +1317,8 @@ COverview::COverview(PHLWORKSPACE startedOn_, PHLMONITOR monitor_, bool swipe_) 
             return;
 
         info.cancelled = true;
-        selectHoveredWorkspace();
-        close();
+        if (selectHoveredWorkspace())
+            closeOverviewsSelecting(this);
     };
 
     mouseMoveHook = Event::bus()->m_events.input.mouse.move.listen([onCursorMove](const Vector2D&, Event::SCallbackInfo& info) { onCursorMove(info); });

--- a/Overview.cpp
+++ b/Overview.cpp
@@ -635,6 +635,8 @@ bool COverview::ownsAnimVar(const WP<Hyprutils::Animation::CBaseAnimatedVariable
 
 COverview* overviewForAnimVar(const WP<Hyprutils::Animation::CBaseAnimatedVariable>& var) {
     for (const auto& OV : g_overviews) {
+        if (!OV)
+            continue;
         if (OV->ownsAnimVar(var))
             return OV.get();
     }
@@ -647,6 +649,8 @@ COverview* overviewForMonitor(const PHLMONITOR& monitor) {
         return nullptr;
 
     for (const auto& OV : g_overviews) {
+        if (!OV)
+            continue;
         if (OV->pMonitor == monitor)
             return OV.get();
     }
@@ -663,6 +667,8 @@ COverview* overviewForMonitorKey(uint64_t key) {
         return nullptr;
 
     for (const auto& OV : g_overviews) {
+        if (!OV)
+            continue;
         const auto MON = OV->pMonitor.lock();
         if (overviewMonitorKey(MON) == key)
             return OV.get();
@@ -673,6 +679,8 @@ COverview* overviewForMonitorKey(uint64_t key) {
 
 COverview* overviewForGlobalPoint(const Vector2D& point) {
     for (const auto& OV : g_overviews) {
+        if (!OV)
+            continue;
         const auto MON = OV->pMonitor.lock();
         if (!MON)
             continue;
@@ -698,7 +706,7 @@ COverview* createOverview(const PHLMONITOR& monitor, bool swipe) {
 }
 
 bool overviewOpen() {
-    return !g_overviews.empty();
+    return std::any_of(g_overviews.begin(), g_overviews.end(), [](const auto& entry) { return static_cast<bool>(entry); });
 }
 
 COverview* activeOverview() {
@@ -719,7 +727,8 @@ COverview* activeOverview() {
     if (auto* const HOVERED = overviewForMonitor(State::monitorState()->query().vec(g_pInputManager->getMouseCoordsInternal()).run()))
         return HOVERED;
 
-    return g_overviews.front().get();
+    const auto FIRST = std::find_if(g_overviews.begin(), g_overviews.end(), [](const auto& entry) { return static_cast<bool>(entry); });
+    return FIRST == g_overviews.end() ? nullptr : FIRST->get();
 }
 
 std::optional<Hyprexpo::SGlobalTile> COverview::focusedGlobalTile() const {
@@ -775,6 +784,8 @@ bool moveOverviewFocusAcrossMonitors(COverview* source, Hyprexpo::EDirection dir
 
     std::vector<Hyprexpo::SGlobalTile> candidates;
     for (const auto& OV : g_overviews) {
+        if (!OV)
+            continue;
         if (OV.get() == source)
             continue;
         auto tiles = OV->globalTiles();
@@ -797,8 +808,10 @@ bool moveOverviewFocusAcrossMonitors(COverview* source, Hyprexpo::EDirection dir
 void forEachOverview(const std::function<void(COverview&)>& fn) {
     std::vector<COverview*> snapshot;
     snapshot.reserve(g_overviews.size());
-    for (const auto& OV : g_overviews)
-        snapshot.push_back(OV.get());
+    for (const auto& OV : g_overviews) {
+        if (OV)
+            snapshot.push_back(OV.get());
+    }
 
     for (auto* const OV : snapshot) {
         // fn may tear down overviews, including this one. Skip dead entries
@@ -814,8 +827,10 @@ void forEachOverview(const std::function<void(COverview&)>& fn) {
 std::vector<uint64_t> liveOverviewMonitorKeys() {
     std::vector<uint64_t> keys;
     keys.reserve(g_overviews.size());
-    for (const auto& OV : g_overviews)
-        keys.push_back(overviewMonitorKey(OV->pMonitor.lock()));
+    for (const auto& OV : g_overviews) {
+        if (OV)
+            keys.push_back(overviewMonitorKey(OV->pMonitor.lock()));
+    }
     return keys;
 }
 
@@ -857,17 +872,27 @@ void destroyOverview(COverview* overview) {
     if (!overview)
         return;
 
+    const auto IT = std::find_if(g_overviews.begin(), g_overviews.end(), [overview](const auto& entry) { return entry && entry.get() == overview; });
+    if (IT == g_overviews.end())
+        return;
+
     const auto MON = overview->pMonitor.lock();
     resetOverviewDrag(Hyprexpo::EOverviewDragEventType::MonitorDestroyed, overviewMonitorKey(MON));
     if (g_keyboardOverviewMonitor.lock() == MON)
         g_keyboardOverviewMonitor.reset();
-    std::erase_if(g_overviews, [overview](const auto& entry) { return entry.get() == overview; });
+
+    auto OWNER = std::move(*IT);
+    g_overviews.erase(IT);
+    OWNER.reset();
 }
 
 void destroyAllOverviews() {
     resetOverviewDrag(Hyprexpo::EOverviewDragEventType::AllClose);
     g_keyboardOverviewMonitor.reset();
-    g_overviews.clear();
+
+    std::vector<std::unique_ptr<COverview>> OWNERS;
+    OWNERS.swap(g_overviews);
+    OWNERS.clear();
 }
 
 void removeOverview(WP<Hyprutils::Animation::CBaseAnimatedVariable> thisptr) {

--- a/Overview.cpp
+++ b/Overview.cpp
@@ -1318,6 +1318,8 @@ COverview::COverview(PHLWORKSPACE startedOn_, PHLMONITOR monitor_, bool swipe_) 
 
         const Vector2D GLOBAL = g_pInputManager->getMouseCoordsInternal();
         for (const auto& OV : g_overviews) {
+            if (!OV)
+                continue;
             const auto MON = OV->pMonitor.lock();
             if (!MON || OV->closing)
                 continue;

--- a/Overview.cpp
+++ b/Overview.cpp
@@ -14,6 +14,7 @@
 #include <hyprland/src/config/ConfigManager.hpp>
 #include <hyprland/src/config/shared/actions/ConfigActions.hpp>
 #include <hyprland/src/config/shared/animation/AnimationTree.hpp>
+#include <hyprland/src/desktop/state/FocusState.hpp>
 #include <hyprland/src/desktop/view/Window.hpp>
 #include <hyprland/src/layout/LayoutManager.hpp>
 #include <hyprland/src/layout/space/Space.hpp>
@@ -359,7 +360,8 @@ SP<Render::ITexture> renderNumberTexture(const std::string& text, const CHyprCol
 }
 
 static void damageMonitor(WP<Hyprutils::Animation::CBaseAnimatedVariable> thisptr) {
-    g_pOverview->damage();
+    if (auto* const OV = overviewForAnimVar(thisptr))
+        OV->damage();
 }
 
 SWorkspacePreviewState applyWorkspacePreviewState(const PHLWORKSPACE& workspace) {
@@ -619,12 +621,106 @@ void restoreActiveWorkspaceAfterPreview(PHLMONITOR monitor, const PHLWORKSPACE& 
     recalculateWorkspaceLayout(workspace);
 }
 
-void removeOverview(WP<Hyprutils::Animation::CBaseAnimatedVariable> thisptr) {
-    if (!g_pOverview)
+bool COverview::ownsAnimVar(const WP<Hyprutils::Animation::CBaseAnimatedVariable>& var) const {
+    // Animated variables live in CUniquePointers, and locking a CWeakPointer
+    // over a unique pointer asserts. get() reads the raw pointer without that
+    // check, and CGenericAnimatedVariable derives from CBaseAnimatedVariable
+    // through plain single inheritance, so the addresses compare directly.
+    const Hyprutils::Animation::CBaseAnimatedVariable* const RAW = var.get();
+    if (!RAW)
+        return false;
+
+    return RAW == size.get() || RAW == pos.get();
+}
+
+COverview* overviewForAnimVar(const WP<Hyprutils::Animation::CBaseAnimatedVariable>& var) {
+    for (const auto& OV : g_overviews) {
+        if (OV->ownsAnimVar(var))
+            return OV.get();
+    }
+
+    return nullptr;
+}
+
+COverview* overviewForMonitor(const PHLMONITOR& monitor) {
+    if (!monitor)
+        return nullptr;
+
+    for (const auto& OV : g_overviews) {
+        if (OV->pMonitor == monitor)
+            return OV.get();
+    }
+
+    return nullptr;
+}
+
+COverview* createOverview(const PHLMONITOR& monitor, bool swipe) {
+    if (!monitor || !monitor->m_activeWorkspace)
+        return nullptr;
+
+    if (overviewForMonitor(monitor))
+        return nullptr;
+
+    g_overviews.push_back(std::make_unique<COverview>(monitor->m_activeWorkspace, monitor, swipe));
+    return g_overviews.back().get();
+}
+
+bool overviewOpen() {
+    return !g_overviews.empty();
+}
+
+COverview* activeOverview() {
+    if (g_overviews.empty())
+        return nullptr;
+
+    if (g_overviews.size() == 1)
+        return g_overviews.front().get();
+
+    const auto FOCUS = Desktop::focusState();
+    if (auto* const FOCUSED = FOCUS ? overviewForMonitor(FOCUS->monitor()) : nullptr)
+        return FOCUSED;
+
+    if (auto* const HOVERED = overviewForMonitor(State::monitorState()->query().vec(g_pInputManager->getMouseCoordsInternal()).run()))
+        return HOVERED;
+
+    return g_overviews.front().get();
+}
+
+void forEachOverview(const std::function<void(COverview&)>& fn) {
+    std::vector<COverview*> snapshot;
+    snapshot.reserve(g_overviews.size());
+    for (const auto& OV : g_overviews)
+        snapshot.push_back(OV.get());
+
+    for (auto* const OV : snapshot) {
+        // fn may tear down overviews, including this one. Skip dead entries
+        // instead of dereferencing a pointer the callback already freed.
+        const bool ALIVE = std::any_of(g_overviews.begin(), g_overviews.end(), [OV](const auto& entry) { return entry.get() == OV; });
+        if (!ALIVE)
+            continue;
+
+        fn(*OV);
+    }
+}
+
+void destroyOverview(COverview* overview) {
+    if (!overview)
         return;
 
-    const auto MON = g_pOverview->pMonitor.lock();
-    g_pOverview.reset();
+    std::erase_if(g_overviews, [overview](const auto& entry) { return entry.get() == overview; });
+}
+
+void destroyAllOverviews() {
+    g_overviews.clear();
+}
+
+void removeOverview(WP<Hyprutils::Animation::CBaseAnimatedVariable> thisptr) {
+    auto* const OV = overviewForAnimVar(thisptr);
+    if (!OV)
+        return;
+
+    const auto MON = OV->pMonitor.lock();
+    destroyOverview(OV);
 
     if (!MON)
         return;
@@ -739,8 +835,8 @@ COverview::~COverview() {
     resetSubmapIfNeeded();
 }
 
-COverview::COverview(PHLWORKSPACE startedOn_, bool swipe_) : startedOn(startedOn_), swipe(swipe_) {
-    const auto PMONITOR = State::monitorState()->query().vec(g_pInputManager->getMouseCoordsInternal()).run();
+COverview::COverview(PHLWORKSPACE startedOn_, PHLMONITOR monitor_, bool swipe_) : startedOn(startedOn_), swipe(swipe_) {
+    const auto PMONITOR = monitor_;
     pMonitor            = PMONITOR;
 
     static auto* const* PCOLUMNS  = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:columns")->getDataStaticPtr();

--- a/Overview.hpp
+++ b/Overview.hpp
@@ -11,6 +11,8 @@
 #include <hyprland/src/helpers/signal/Signal.hpp>
 #include <hyprland/src/managers/eventLoop/EventLoopTimer.hpp>
 #include <chrono>
+#include <functional>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -20,7 +22,9 @@ constexpr bool ENABLE_LOWRES = false;
 
 class COverview {
   public:
-    COverview(PHLWORKSPACE startedOn_, bool swipe = false);
+    // The monitor is passed in rather than resolved from the cursor: with
+    // several overviews alive they would all bind to the same output.
+    COverview(PHLWORKSPACE startedOn_, PHLMONITOR monitor_, bool swipe = false);
     ~COverview();
 
     void render();
@@ -36,6 +40,9 @@ class COverview {
         return m_closeCommitted;
     }
     bool shouldRenderOverviewForMonitor(const PHLMONITOR& monitor) const;
+    // Animation callbacks are handed the variable that fired, not the owner.
+    // With several overviews alive the owner has to be resolved from it.
+    bool ownsAnimVar(const WP<Hyprutils::Animation::CBaseAnimatedVariable>& var) const;
     void onWindowMoveToWorkspace(const PHLWINDOW& window, const PHLWORKSPACE& workspace);
 
     void resetSwipe();
@@ -168,4 +175,36 @@ class COverview {
     friend class COverviewPassElement;
 };
 
-inline std::unique_ptr<COverview> g_pOverview;
+// Overview instances, one per monitor currently showing the overview. A single
+// monitor invocation keeps exactly one entry; "all monitors" mode keeps one per
+// output. Instances are owned here and torn down via destroyOverview().
+inline std::vector<std::unique_ptr<COverview>> g_overviews;
+
+// The instance that owns keyboard input and unqualified dispatcher commands:
+// the one on the focused monitor, else the one under the cursor, else the
+// first. nullptr when no overview is open.
+COverview* activeOverview();
+
+// The instance owning an animated variable, or nullptr.
+COverview* overviewForAnimVar(const WP<Hyprutils::Animation::CBaseAnimatedVariable>& var);
+
+// The instance rendering on a specific monitor, or nullptr.
+COverview* overviewForMonitor(const PHLMONITOR& monitor);
+
+// Create an overview on a monitor and register it. Returns nullptr if the
+// monitor already has one, or if the arguments are unusable.
+COverview* createOverview(const PHLMONITOR& monitor, bool swipe = false);
+
+// True while at least one overview is alive.
+bool       overviewOpen();
+
+// Run fn for every live overview. Safe when the callback destroys overviews:
+// entries torn down mid-iteration are skipped.
+void       forEachOverview(const std::function<void(COverview&)>& fn);
+
+// Destroy one instance. This deletes the object, so a member function
+// destroying itself must return immediately afterwards.
+void       destroyOverview(COverview* overview);
+
+// Destroy every instance.
+void       destroyAllOverviews();

--- a/Overview.hpp
+++ b/Overview.hpp
@@ -112,7 +112,7 @@ class COverview {
     void       beginWindowDrag();
     bool       finishWindowDrag();
     void       updateWindowDrag();
-    void       redrawDraggedWindowTiles(int source, int target);
+    void       redrawDraggedWindowTile(int id);
     void       queueRedrawID(int id);
     void       flushQueuedRedraws();
     PHLWINDOW  windowAtTilePoint(int id, const Vector2D& localPoint) const;
@@ -136,14 +136,6 @@ class COverview {
     int                          kbFocusID = -1;
     int                          hoveredID = -1;
     bool                         submapActive = false;
-
-    Vector2D                     dragStartLocal = Vector2D{};
-    int                          dragSourceID   = -1;
-    bool                         dragMoved      = false;
-    Vector2D                     dragGrabOffset = Vector2D{};
-    PHLWINDOW                    dragWindow;
-    int                          dropIntentTargetID = -1;
-    Hyprexpo::SDropIntentGeometry dropIntent;
 
     std::vector<int>             queuedRedrawIDs;
     std::vector<int>             settlingRedrawIDs;
@@ -199,8 +191,10 @@ inline SOverviewDragRuntime g_overviewDrag;
 // first. nullptr when no overview is open.
 COverview* activeOverview();
 COverview* overviewForMonitorKey(uint64_t key);
+COverview* overviewForGlobalPoint(const Vector2D& point);
 uint64_t   overviewMonitorKey(const PHLMONITOR& monitor);
 bool       overviewRegistered(const COverview* overview);
+std::vector<uint64_t> liveOverviewMonitorKeys();
 bool       moveOverviewFocusAcrossMonitors(COverview* source, Hyprexpo::EDirection direction);
 void       closeOverviewsSelecting(COverview* selecting);
 void       closeOverviews(bool switchToSelection);

--- a/Overview.hpp
+++ b/Overview.hpp
@@ -51,18 +51,21 @@ class COverview {
 
     // close without a selection
     void          close(bool switchToSelection = true);
-    void          selectHoveredWorkspace();
+    bool          selectHoveredWorkspace();
 
     // keyboard navigation interface
-    void          onKbMoveFocus(const std::string& dir);
-    void          onKbConfirm();
-    void          onKbSelectNumber(int num);
-    void          onKbSelectToken(int visibleIdx);
+    bool          onKbMoveFocus(const std::string& dir);
+    bool          onKbConfirm();
+    bool          onKbSelectNumber(int num);
+    bool          onKbSelectToken(int visibleIdx);
     bool          selectVisibleToken(const std::string& token);
     int64_t       selectedWorkspaceID() const;
     bool          selectWorkspaceByID(int64_t workspaceID);
     bool          selectVisibleIndex(size_t index);
     bool          moveWindowBetweenVisibleIndices(size_t sourceIndex, size_t targetIndex, const PHLWINDOW& window = nullptr);
+    std::optional<Hyprexpo::SGlobalTile> focusedGlobalTile() const;
+    std::vector<Hyprexpo::SGlobalTile>   globalTiles() const;
+    bool                                 setKeyboardFocus(int tileIndex);
 
     bool          blockOverviewRendering = false;
     bool          blockDamageReporting   = false;
@@ -103,7 +106,7 @@ class COverview {
     void       updateHoveredFromMouse();
     void       ensureKbFocusInitialized();
     bool       isTileValid(int id) const;
-    void       moveFocus(int dx, int dy);
+    bool       moveFocus(int dx, int dy);
     int        tileForWorkspaceID(int wsid) const;
     int        tileForVisibleIndex(int vIdx) const;
     void       beginWindowDrag();
@@ -179,11 +182,29 @@ class COverview {
 // monitor invocation keeps exactly one entry; "all monitors" mode keeps one per
 // output. Instances are owned here and torn down via destroyOverview().
 inline std::vector<std::unique_ptr<COverview>> g_overviews;
+inline PHLMONITORREF                           g_keyboardOverviewMonitor;
+
+struct SOverviewDragRuntime {
+    Hyprexpo::SOverviewDragState state;
+    Vector2D                     pressGlobal;
+    Vector2D                     pointerGlobal;
+    Vector2D                     grabOffset;
+    PHLWINDOW                    window;
+};
+
+inline SOverviewDragRuntime g_overviewDrag;
 
 // The instance that owns keyboard input and unqualified dispatcher commands:
 // the one on the focused monitor, else the one under the cursor, else the
 // first. nullptr when no overview is open.
 COverview* activeOverview();
+COverview* overviewForMonitorKey(uint64_t key);
+uint64_t   overviewMonitorKey(const PHLMONITOR& monitor);
+bool       overviewRegistered(const COverview* overview);
+bool       moveOverviewFocusAcrossMonitors(COverview* source, Hyprexpo::EDirection direction);
+void       closeOverviewsSelecting(COverview* selecting);
+void       closeOverviews(bool switchToSelection);
+void       resetOverviewDrag(Hyprexpo::EOverviewDragEventType type = Hyprexpo::EOverviewDragEventType::Cancel, uint64_t monitorKey = 0);
 
 // The instance owning an animated variable, or nullptr.
 COverview* overviewForAnimVar(const WP<Hyprutils::Animation::CBaseAnimatedVariable>& var);

--- a/Overview.hpp
+++ b/Overview.hpp
@@ -112,7 +112,7 @@ class COverview {
     void       beginWindowDrag();
     bool       finishWindowDrag();
     void       updateWindowDrag();
-    void       redrawDraggedWindowTile(int id);
+    void       redrawDraggedWorkspace(int64_t workspaceID);
     void       queueRedrawID(int id);
     void       flushQueuedRedraws();
     PHLWINDOW  windowAtTilePoint(int id, const Vector2D& localPoint) const;
@@ -138,7 +138,7 @@ class COverview {
     bool                         submapActive = false;
 
     std::vector<int>             queuedRedrawIDs;
-    std::vector<int>             settlingRedrawIDs;
+    std::vector<int64_t>         settlingRedrawWorkspaceIDs;
     int                          redrawSettleTicks = 0;
     SP<CEventLoopTimer>          redrawSettleTimer;
 

--- a/OverviewInteraction.cpp
+++ b/OverviewInteraction.cpp
@@ -356,7 +356,7 @@ void COverview::redrawDraggedWindowTiles(int source, int target) {
     redrawSettleTimer = makeShared<CEventLoopTimer>(
         75ms,
         [this](SP<CEventLoopTimer> self, void*) {
-            if (!g_pOverview || g_pOverview.get() != this || closing) {
+            if (!overviewOpen() || activeOverview() != this || closing) {
                 self->cancel();
                 redrawSettleTimer.reset();
                 return;
@@ -626,7 +626,7 @@ void COverview::onSwipeEnd() {
         m_isSwiping       = false;
         swipeWasCommenced = false;
         closing           = true;
-        g_pOverview.reset();
+        destroyOverview(this);
         return;
     }
 
@@ -651,18 +651,31 @@ void COverview::onSwipeEnd() {
     m_isSwiping       = false;
 }
 
+// The submap is compositor-global, but every overview enters and leaves it
+// independently. Refcount it so opening on several monitors installs it once
+// and only the last overview to close tears it down: without this the first
+// monitor to close would drop keyboard navigation for the ones still open.
+static int g_submapRefs = 0;
+
 void COverview::enterSubmapIfEnabled() {
     static auto* const* PKEYNAV = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:keynav_enable")->getDataStaticPtr();
-    if (**PKEYNAV && !submapActive) {
+    if (!**PKEYNAV || submapActive)
+        return;
+
+    submapActive = true;
+    if (g_submapRefs++ == 0) {
         // switch to a dedicated submap for hyprexpo navigation
         (void)Config::Actions::setSubmap("hyprexpo");
-        submapActive = true;
     }
 }
 
 void COverview::resetSubmapIfNeeded() {
-    if (submapActive) {
+    if (!submapActive)
+        return;
+
+    submapActive = false;
+    if (--g_submapRefs <= 0) {
+        g_submapRefs = 0;
         (void)Config::Actions::setSubmap("reset");
-        submapActive = false;
     }
 }

--- a/OverviewInteraction.cpp
+++ b/OverviewInteraction.cpp
@@ -402,23 +402,32 @@ void COverview::redrawDraggedWindowTile(int id) {
     if (redrawSettleTimer)
         return;
 
+    const auto OVERVIEWKEY = overviewMonitorKey(pMonitor.lock());
+    if (OVERVIEWKEY == 0)
+        return;
+
     redrawSettleTimer = makeShared<CEventLoopTimer>(
         75ms,
-        [this](SP<CEventLoopTimer> self, void*) {
-            if (!overviewRegistered(this) || closing) {
+        [OVERVIEWKEY](SP<CEventLoopTimer> self, void*) {
+            auto* const OVERVIEW = overviewForMonitorKey(OVERVIEWKEY);
+            if (!OVERVIEW || OVERVIEW->redrawSettleTimer.get() != self.get()) {
                 self->cancel();
-                redrawSettleTimer.reset();
+                return;
+            }
+            if (OVERVIEW->closing) {
+                self->cancel();
+                OVERVIEW->redrawSettleTimer.reset();
                 return;
             }
 
-            for (const auto id : settlingRedrawIDs)
-                queueRedrawID(id);
+            for (const auto id : OVERVIEW->settlingRedrawIDs)
+                OVERVIEW->queueRedrawID(id);
 
-            flushQueuedRedraws();
+            OVERVIEW->flushQueuedRedraws();
 
-            if (--redrawSettleTicks <= 0) {
-                settlingRedrawIDs.clear();
-                redrawSettleTimer.reset();
+            if (--OVERVIEW->redrawSettleTicks <= 0) {
+                OVERVIEW->settlingRedrawIDs.clear();
+                OVERVIEW->redrawSettleTimer.reset();
                 self->cancel();
                 return;
             }

--- a/OverviewInteraction.cpp
+++ b/OverviewInteraction.cpp
@@ -7,6 +7,7 @@
 #include <hyprland/src/desktop/state/GlobalWindowController.hpp>
 #include <hyprland/src/output/Monitor.hpp>
 #include <hyprland/src/pointer/cursor/CursorShapeOverrideController.hpp>
+#include <hyprland/src/managers/input/InputManager.hpp>
 #include <hyprland/src/managers/eventLoop/EventLoopManager.hpp>
 #include <hyprland/src/state/WorkspaceState.hpp>
 #include <hyprland/src/config/shared/actions/ConfigActions.hpp>
@@ -177,37 +178,85 @@ PHLWINDOW COverview::windowAtTilePoint(int id, const Vector2D& localPoint) const
 }
 
 void COverview::beginWindowDrag() {
-    updateHoveredFromMouse();
-    dragStartLocal = lastMousePosLocal;
-    dragSourceID   = hoveredID;
-    dragMoved      = false;
-    dragWindow     = windowAtTilePoint(dragSourceID, dragStartLocal);
-    dragGrabOffset = Vector2D{};
-    dropIntent         = {};
-    dropIntentTargetID = -1;
-
-    if (!dragWindow)
+    if (g_overviewDrag.state.active)
         return;
 
-    const auto POINT = tilePointToWorkspacePoint(dragSourceID, dragStartLocal);
-    const auto BOX   = dragWindow->getWindowMainSurfaceBox();
-    dragGrabOffset   = POINT - Vector2D{BOX.x, BOX.y};
+    std::vector<Hyprexpo::SGlobalTile> tiles;
+    for (const auto& OV : g_overviews) {
+        auto overviewTiles = OV->globalTiles();
+        tiles.insert(tiles.end(), overviewTiles.begin(), overviewTiles.end());
+    }
+
+    const Vector2D GLOBAL = g_pInputManager->getMouseCoordsInternal();
+    const auto     HIT    = Hyprexpo::hitTestGlobalTile({GLOBAL.x, GLOBAL.y}, tiles);
+    const auto     MON    = pMonitor.lock();
+    if (!HIT || !MON || HIT->overviewKey != overviewMonitorKey(MON))
+        return;
+
+    const Vector2D LOCAL{HIT->pointLocal.x, HIT->pointLocal.y};
+    const auto     WINDOW = windowAtTilePoint(HIT->tileIndex, LOCAL);
+    if (!WINDOW)
+        return;
+
+    auto transition = Hyprexpo::transitionOverviewDrag(
+        g_overviewDrag.state,
+        {.type = Hyprexpo::EOverviewDragEventType::Press, .monitorKey = HIT->overviewKey, .tileIndex = HIT->tileIndex, .windowKey = reinterpret_cast<uint64_t>(WINDOW.get())},
+        liveOverviewMonitorKeys());
+    if (!transition.accepted)
+        return;
+
+    transition = Hyprexpo::transitionOverviewDrag(
+        transition.next, {.type = Hyprexpo::EOverviewDragEventType::Target, .monitorKey = HIT->overviewKey, .tileIndex = HIT->tileIndex}, liveOverviewMonitorKeys());
+
+    const auto POINT              = tilePointToWorkspacePoint(HIT->tileIndex, LOCAL);
+    const auto BOX                = WINDOW->getWindowMainSurfaceBox();
+    g_overviewDrag.state          = transition.next;
+    g_overviewDrag.window         = WINDOW;
+    g_overviewDrag.pressGlobal    = GLOBAL;
+    g_overviewDrag.pointerGlobal  = GLOBAL;
+    g_overviewDrag.grabOffset     = POINT - Vector2D{BOX.x, BOX.y};
     Pointer::Cursor::overrideController->setOverride("grabbing", Pointer::Cursor::CURSOR_OVERRIDE_UNKNOWN);
     damage();
 }
 
 void COverview::updateWindowDrag() {
-    if (!dragWindow)
+    const auto MON = pMonitor.lock();
+    if (!MON || !g_overviewDrag.state.active || g_overviewDrag.state.sourceMonitorKey != overviewMonitorKey(MON))
         return;
 
-    const auto dx = lastMousePosLocal.x - dragStartLocal.x;
-    const auto dy = lastMousePosLocal.y - dragStartLocal.y;
-    if (!dragMoved && std::hypot(dx, dy) < 12.0)
+    const Vector2D GLOBAL = g_pInputManager->getMouseCoordsInternal();
+    g_overviewDrag.pointerGlobal = GLOBAL;
+    const auto dx = GLOBAL.x - g_overviewDrag.pressGlobal.x;
+    const auto dy = GLOBAL.y - g_overviewDrag.pressGlobal.y;
+    if (!g_overviewDrag.state.moved && std::hypot(dx, dy) < 12.0)
         return;
 
-    if (!dragMoved)
-        dragMoved = true;
-    damage();
+    if (!g_overviewDrag.state.moved) {
+        const auto move = Hyprexpo::transitionOverviewDrag(g_overviewDrag.state, {.type = Hyprexpo::EOverviewDragEventType::Move}, liveOverviewMonitorKeys());
+        if (!move.accepted)
+            return;
+        g_overviewDrag.state = move.next;
+    }
+
+    std::vector<Hyprexpo::SGlobalTile> tiles;
+    for (const auto& OV : g_overviews) {
+        auto overviewTiles = OV->globalTiles();
+        tiles.insert(tiles.end(), overviewTiles.begin(), overviewTiles.end());
+    }
+
+    const auto HIT = Hyprexpo::hitTestGlobalTile({GLOBAL.x, GLOBAL.y}, tiles);
+    const auto target = Hyprexpo::transitionOverviewDrag(
+        g_overviewDrag.state,
+        HIT ? Hyprexpo::SOverviewDragEvent{.type = Hyprexpo::EOverviewDragEventType::Target, .monitorKey = HIT->overviewKey, .tileIndex = HIT->tileIndex}
+            : Hyprexpo::SOverviewDragEvent{.type = Hyprexpo::EOverviewDragEventType::Target},
+        liveOverviewMonitorKeys());
+    if (target.accepted)
+        g_overviewDrag.state = target.next;
+
+    for (const auto key : g_overviewDrag.state.affectedMonitorKeys) {
+        if (auto* const OV = overviewForMonitorKey(key))
+            OV->damage();
+    }
 }
 
 PHLWORKSPACE COverview::ensureWorkspaceForTile(int id) {
@@ -238,52 +287,47 @@ PHLWORKSPACE COverview::ensureWorkspaceForTile(int id) {
 }
 
 bool COverview::finishWindowDrag() {
-    const auto WINDOW = dragWindow;
-    const int  SOURCE = dragSourceID;
-    const bool MOVED  = dragMoved;
-
-    dragWindow     = nullptr;
-    dragSourceID   = -1;
-    dragMoved      = false;
-    dragGrabOffset = Vector2D{};
-    dropIntent         = {};
-    dropIntentTargetID = -1;
-    Pointer::Cursor::overrideController->setOverride("left_ptr", Pointer::Cursor::CURSOR_OVERRIDE_UNKNOWN);
-
-    if (!WINDOW || !MOVED)
+    const auto MON = pMonitor.lock();
+    if (!MON || !g_overviewDrag.state.active || g_overviewDrag.state.sourceMonitorKey != overviewMonitorKey(MON))
         return false;
 
-    // Drag proxies are render-only; repaint even when release does not move workspace contents.
-    damage();
-    updateHoveredFromMouse();
+    const auto STATE      = g_overviewDrag.state;
+    const auto TRANSITION = Hyprexpo::transitionOverviewDrag(STATE, {.type = Hyprexpo::EOverviewDragEventType::Release}, liveOverviewMonitorKeys());
+    const bool CONSUMED   = STATE.moved;
 
-    const int TARGET = hoveredID;
-    if (!isTileValid(SOURCE) || !isTileValid(TARGET) || SOURCE == TARGET)
-        return true;
+    if (TRANSITION.drop && g_overviewDrag.window && reinterpret_cast<uint64_t>(g_overviewDrag.window.get()) == TRANSITION.drop->windowKey) {
+        auto* const SOURCEOV  = overviewForMonitorKey(TRANSITION.drop->sourceMonitorKey);
+        auto* const TARGETOV  = overviewForMonitorKey(TRANSITION.drop->targetMonitorKey);
+        const auto  TARGETMON = TARGETOV ? TARGETOV->pMonitor.lock() : PHLMONITOR{};
+        const int   SOURCE    = TRANSITION.drop->sourceTileIndex;
+        const int   TARGET    = TRANSITION.drop->targetTileIndex;
 
-    PHLWORKSPACE SOURCEWS;
-    if (images[SOURCE].pWorkspace) {
-        SOURCEWS = images[SOURCE].pWorkspace;
-    }
-    else {
-        for (const auto& w : State::workspaceState()->workspacesCopy()) {
-            if (w->m_id == images[SOURCE].workspaceID) {
-                SOURCEWS = w;
-                break;
+        if (SOURCEOV && TARGETOV && TARGETMON && SOURCEOV->isTileValid(SOURCE) && TARGETOV->isTileValid(TARGET)) {
+            PHLWORKSPACE SOURCEWS = SOURCEOV->images[SOURCE].pWorkspace;
+            if (!SOURCEWS) {
+                for (const auto& workspace : State::workspaceState()->workspacesCopy()) {
+                    if (workspace->m_id == SOURCEOV->images[SOURCE].workspaceID) {
+                        SOURCEWS = workspace;
+                        break;
+                    }
+                }
+            }
+
+            const auto TARGETWS = TARGETOV->ensureWorkspaceForTile(TARGET);
+            if (TARGETWS && TARGETWS->m_monitor.lock() != TARGETMON)
+                Log::logger->log(Log::ERR, "[hyprexpo] rejected drag target workspace on the wrong monitor");
+            else if (windowVisibleOnWorkspace(g_overviewDrag.window, SOURCEWS) && TARGETWS && TARGETWS != SOURCEWS) {
+                SOURCEOV->images[SOURCE].pWorkspace = SOURCEWS;
+                Desktop::globalWindowController()->moveWindowToWorkspace(g_overviewDrag.window, TARGETWS);
+                settleWorkspaceMoveAnimation(g_overviewDrag.window);
+                SOURCEOV->redrawDraggedWindowTile(SOURCE);
+                TARGETOV->redrawDraggedWindowTile(TARGET);
             }
         }
     }
 
-    const auto TARGETWS = ensureWorkspaceForTile(TARGET);
-
-    if (!windowVisibleOnWorkspace(WINDOW, SOURCEWS) || !TARGETWS || TARGETWS == SOURCEWS)
-        return true;
-
-    images[SOURCE].pWorkspace = SOURCEWS;
-    Desktop::globalWindowController()->moveWindowToWorkspace(WINDOW, TARGETWS);
-    settleWorkspaceMoveAnimation(WINDOW);
-    redrawDraggedWindowTiles(SOURCE, TARGET);
-    return true;
+    resetOverviewDrag(Hyprexpo::EOverviewDragEventType::Release);
+    return CONSUMED;
 }
 
 bool COverview::moveWindowBetweenVisibleIndices(size_t sourceIndex, size_t targetIndex, const PHLWINDOW& requestedWindow) {
@@ -335,13 +379,13 @@ bool COverview::moveWindowBetweenVisibleIndices(size_t sourceIndex, size_t targe
     images[SOURCE].pWorkspace = SOURCEWS;
     Desktop::globalWindowController()->moveWindowToWorkspace(window, TARGETWS);
     settleWorkspaceMoveAnimation(window);
-    redrawDraggedWindowTiles(SOURCE, TARGET);
+    redrawDraggedWindowTile(SOURCE);
+    redrawDraggedWindowTile(TARGET);
     return true;
 }
 
-void COverview::redrawDraggedWindowTiles(int source, int target) {
-    queueRedrawID(source);
-    queueRedrawID(target);
+void COverview::redrawDraggedWindowTile(int id) {
+    queueRedrawID(id);
 
     for (const auto id : queuedRedrawIDs) {
         if (std::find(settlingRedrawIDs.begin(), settlingRedrawIDs.end(), id) == settlingRedrawIDs.end())

--- a/OverviewInteraction.cpp
+++ b/OverviewInteraction.cpp
@@ -183,6 +183,8 @@ void COverview::beginWindowDrag() {
 
     std::vector<Hyprexpo::SGlobalTile> tiles;
     for (const auto& OV : g_overviews) {
+        if (!OV)
+            continue;
         auto overviewTiles = OV->globalTiles();
         tiles.insert(tiles.end(), overviewTiles.begin(), overviewTiles.end());
     }
@@ -240,6 +242,8 @@ void COverview::updateWindowDrag() {
 
     std::vector<Hyprexpo::SGlobalTile> tiles;
     for (const auto& OV : g_overviews) {
+        if (!OV)
+            continue;
         auto overviewTiles = OV->globalTiles();
         tiles.insert(tiles.end(), overviewTiles.begin(), overviewTiles.end());
     }

--- a/OverviewInteraction.cpp
+++ b/OverviewInteraction.cpp
@@ -321,11 +321,13 @@ bool COverview::finishWindowDrag() {
             if (TARGETWS && TARGETWS->m_monitor.lock() != TARGETMON)
                 Log::logger->log(Log::ERR, "[hyprexpo] rejected drag target workspace on the wrong monitor");
             else if (windowVisibleOnWorkspace(g_overviewDrag.window, SOURCEWS) && TARGETWS && TARGETWS != SOURCEWS) {
+                const int64_t SOURCEWORKSPACEID = SOURCEOV->images[SOURCE].workspaceID;
+                const int64_t TARGETWORKSPACEID = TARGETOV->images[TARGET].workspaceID;
                 SOURCEOV->images[SOURCE].pWorkspace = SOURCEWS;
                 Desktop::globalWindowController()->moveWindowToWorkspace(g_overviewDrag.window, TARGETWS);
                 settleWorkspaceMoveAnimation(g_overviewDrag.window);
-                SOURCEOV->redrawDraggedWindowTile(SOURCE);
-                TARGETOV->redrawDraggedWindowTile(TARGET);
+                SOURCEOV->redrawDraggedWorkspace(SOURCEWORKSPACEID);
+                TARGETOV->redrawDraggedWorkspace(TARGETWORKSPACEID);
             }
         }
     }
@@ -381,22 +383,24 @@ bool COverview::moveWindowBetweenVisibleIndices(size_t sourceIndex, size_t targe
         return false;
 
     images[SOURCE].pWorkspace = SOURCEWS;
+    const int64_t SOURCEWORKSPACEID = images[SOURCE].workspaceID;
+    const int64_t TARGETWORKSPACEID = images[TARGET].workspaceID;
     Desktop::globalWindowController()->moveWindowToWorkspace(window, TARGETWS);
     settleWorkspaceMoveAnimation(window);
-    redrawDraggedWindowTile(SOURCE);
-    redrawDraggedWindowTile(TARGET);
+    redrawDraggedWorkspace(SOURCEWORKSPACEID);
+    redrawDraggedWorkspace(TARGETWORKSPACEID);
     return true;
 }
 
-void COverview::redrawDraggedWindowTile(int id) {
-    queueRedrawID(id);
+void COverview::redrawDraggedWorkspace(int64_t workspaceID) {
+    if (workspaceID == WORKSPACE_INVALID)
+        return;
 
-    for (const auto id : queuedRedrawIDs) {
-        if (std::find(settlingRedrawIDs.begin(), settlingRedrawIDs.end(), id) == settlingRedrawIDs.end())
-            settlingRedrawIDs.push_back(id);
-    }
-    redrawSettleTicks = 4;
+    if (std::find(settlingRedrawWorkspaceIDs.begin(), settlingRedrawWorkspaceIDs.end(), workspaceID) == settlingRedrawWorkspaceIDs.end())
+        settlingRedrawWorkspaceIDs.push_back(workspaceID);
+    redrawSettleTicks = 8;
 
+    queueRedrawID(tileForWorkspaceID(workspaceID));
     flushQueuedRedraws();
 
     if (redrawSettleTimer)
@@ -420,13 +424,13 @@ void COverview::redrawDraggedWindowTile(int id) {
                 return;
             }
 
-            for (const auto id : OVERVIEW->settlingRedrawIDs)
-                OVERVIEW->queueRedrawID(id);
+            for (const auto workspaceID : OVERVIEW->settlingRedrawWorkspaceIDs)
+                OVERVIEW->queueRedrawID(OVERVIEW->tileForWorkspaceID(workspaceID));
 
             OVERVIEW->flushQueuedRedraws();
 
             if (--OVERVIEW->redrawSettleTicks <= 0) {
-                OVERVIEW->settlingRedrawIDs.clear();
+                OVERVIEW->settlingRedrawWorkspaceIDs.clear();
                 OVERVIEW->redrawSettleTimer.reset();
                 self->cancel();
                 return;
@@ -457,6 +461,8 @@ void COverview::flushQueuedRedraws() {
         redrawID(id);
 
     damage();
+    if (const auto MON = pMonitor.lock())
+        MON->scheduleFrame();
 }
 
 bool COverview::selectVisibleToken(const std::string& token) {

--- a/OverviewInteraction.cpp
+++ b/OverviewInteraction.cpp
@@ -16,12 +16,13 @@
 
 using namespace std::chrono_literals;
 
-void COverview::selectHoveredWorkspace() {
+bool COverview::selectHoveredWorkspace() {
     if (closing)
-        return;
+        return false;
 
     updateHoveredFromMouse();
     closeOnID = hoveredID >= 0 && hoveredID < (int)images.size() ? hoveredID : -1;
+    return closeOnID != -1;
 }
 
 int64_t COverview::selectedWorkspaceID() const {
@@ -356,7 +357,7 @@ void COverview::redrawDraggedWindowTiles(int source, int target) {
     redrawSettleTimer = makeShared<CEventLoopTimer>(
         75ms,
         [this](SP<CEventLoopTimer> self, void*) {
-            if (!overviewOpen() || activeOverview() != this || closing) {
+            if (!overviewRegistered(this) || closing) {
                 self->cancel();
                 redrawSettleTimer.reset();
                 return;
@@ -431,10 +432,10 @@ bool COverview::selectVisibleToken(const std::string& token) {
     return selectVisibleIndex(visibleIndex);
 }
 
-void COverview::moveFocus(int dx, int dy) {
+bool COverview::moveFocus(int dx, int dy) {
     ensureKbFocusInitialized();
     if (kbFocusID == -1)
-        return;
+        return false;
 
     const auto shape = currentGridShape();
     int x = kbFocusID % shape.cols;
@@ -461,7 +462,7 @@ void COverview::moveFocus(int dx, int dy) {
                 }
                 if (isTileValid(idx)) {
                     kbFocusID = idx;
-                    return;
+                    return true;
                 }
             }
         } else {
@@ -478,7 +479,7 @@ void COverview::moveFocus(int dx, int dy) {
                 const int nid = nx + y * shape.cols;
                 if (isTileValid(nid)) {
                     kbFocusID = nid;
-                    return;
+                    return true;
                 }
             }
         }
@@ -498,54 +499,69 @@ void COverview::moveFocus(int dx, int dy) {
             const int nid = x + ny * shape.cols;
             if (isTileValid(nid)) {
                 kbFocusID = nid;
-                return;
+                return true;
             }
         }
     }
+    return false;
 }
 
-void COverview::onKbMoveFocus(const std::string& dir) {
+bool COverview::onKbMoveFocus(const std::string& dir) {
     if (closing)
-        return;
-    if (dir == "left")
-        moveFocus(-1, 0);
-    else if (dir == "right")
-        moveFocus(1, 0);
-    else if (dir == "up")
-        moveFocus(0, -1);
-    else if (dir == "down")
-        moveFocus(0, 1);
+        return false;
 
-    damage();
+    int                   dx = 0;
+    int                   dy = 0;
+    Hyprexpo::EDirection direction;
+    if (dir == "left") {
+        dx        = -1;
+        direction = Hyprexpo::EDirection::Left;
+    } else if (dir == "right") {
+        dx        = 1;
+        direction = Hyprexpo::EDirection::Right;
+    } else if (dir == "up") {
+        dy        = -1;
+        direction = Hyprexpo::EDirection::Up;
+    } else if (dir == "down") {
+        dy        = 1;
+        direction = Hyprexpo::EDirection::Down;
+    } else
+        return false;
+
+    if (moveFocus(dx, dy)) {
+        damage();
+        return true;
+    }
+
+    return moveOverviewFocusAcrossMonitors(this, direction);
 }
 
-void COverview::onKbConfirm() {
+bool COverview::onKbConfirm() {
     if (closing)
-        return;
+        return false;
     ensureKbFocusInitialized();
-    if (kbFocusID != -1)
-        closeOnID = kbFocusID;
-    close();
+    if (!isTileValid(kbFocusID))
+        return false;
+    closeOnID = kbFocusID;
+    return true;
 }
 
-void COverview::onKbSelectNumber(int num) {
+bool COverview::onKbSelectNumber(int num) {
     if (closing)
-        return;
+        return false;
 
     if (num == 0)
         num = 10;
 
-    if (selectWorkspaceByID(num))
-        close();
+    return selectWorkspaceByID(num);
 }
 
-void COverview::onKbSelectToken(int visibleIdx) {
+bool COverview::onKbSelectToken(int visibleIdx) {
     if (closing)
-        return;
+        return false;
     if (visibleIdx < 0)
-        return;
-    if (selectVisibleIndex(visibleIdx))
-        close();
+        return false;
+    return selectVisibleIndex(visibleIdx);
 }
 
 static float lerpFloat(const float& from, const float& to, const float perc) {

--- a/OverviewPassElement.cpp
+++ b/OverviewPassElement.cpp
@@ -2,15 +2,18 @@
 #include <hyprland/src/render/OpenGL.hpp>
 #include "Overview.hpp"
 
-COverviewPassElement::COverviewPassElement() {
+COverviewPassElement::COverviewPassElement(PHLMONITOR monitor) : m_monitor(monitor) {
     ;
 }
 
-std::vector<UP<IPassElement>> COverviewPassElement::draw() {
-    if (!g_pOverview)
-        return {};
+COverview* COverviewPassElement::overview() const {
+    return overviewForMonitor(m_monitor.lock());
+}
 
-    g_pOverview->fullRender();
+std::vector<UP<IPassElement>> COverviewPassElement::draw() {
+    if (auto* const OV = overview())
+        OV->fullRender();
+
     return {};
 }
 
@@ -23,22 +26,16 @@ bool COverviewPassElement::needsPrecomputeBlur() {
 }
 
 std::optional<CBox> COverviewPassElement::boundingBox() {
-    if (!g_pOverview)
-        return std::nullopt;
-
-    const auto MON = g_pOverview->pMonitor.lock();
-    if (!MON)
+    const auto MON = m_monitor.lock();
+    if (!overview() || !MON)
         return std::nullopt;
 
     return CBox{{}, MON->m_size};
 }
 
 CRegion COverviewPassElement::opaqueRegion() {
-    if (!g_pOverview)
-        return CRegion{};
-
-    const auto MON = g_pOverview->pMonitor.lock();
-    if (!MON)
+    const auto MON = m_monitor.lock();
+    if (!overview() || !MON)
         return CRegion{};
 
     return CBox{{}, MON->m_size};

--- a/OverviewPassElement.hpp
+++ b/OverviewPassElement.hpp
@@ -1,11 +1,14 @@
 #pragma once
 #include <hyprland/src/render/pass/PassElement.hpp>
+#include <hyprland/src/desktop/DesktopTypes.hpp>
 
 class COverview;
 
 class COverviewPassElement : public IPassElement {
   public:
-    COverviewPassElement();
+    // The pass element can outlive its overview, so it stores the monitor and
+    // resolves the owner per call instead of holding a dangling pointer.
+    explicit COverviewPassElement(PHLMONITOR monitor);
     virtual ~COverviewPassElement() = default;
 
     virtual std::vector<UP<IPassElement>> draw();
@@ -18,4 +21,9 @@ class COverviewPassElement : public IPassElement {
     virtual const char*                   passName() {
         return "COverviewPassElement";
     }
+
+  private:
+    COverview*    overview() const;
+
+    PHLMONITORREF m_monitor;
 };

--- a/OverviewRender.cpp
+++ b/OverviewRender.cpp
@@ -697,76 +697,49 @@ void COverview::fullRender() {
     if (kbFocusID != -1)
         drawBorderForID(kbFocusID, std::string{*PBCOLFOC}, std::string{*PBGREFOC}, RND_FOC);
 
-    if (dragMoved && dragSourceID != -1) {
+    const auto OVERVIEWKEY = overviewMonitorKey(MON);
+    if (g_overviewDrag.state.moved && g_overviewDrag.state.sourceMonitorKey == OVERVIEWKEY && isTileValid(g_overviewDrag.state.sourceTileIndex)) {
         const std::string sourceBorder = std::string{*PDRAGSOURCEBORDER}.empty() ? std::string{*PBCOLFOC} : std::string{*PDRAGSOURCEBORDER};
         const int         sourceWidth  = **PDRAGSOURCEBWIDTH >= 0 ? **PDRAGSOURCEBWIDTH : (int)**PBWIDTH;
-        drawBorderForID(dragSourceID, sourceBorder, std::string{*PBGREFOC}, RND_FOC, sourceWidth);
+        drawBorderForID(g_overviewDrag.state.sourceTileIndex, sourceBorder, std::string{*PBGREFOC}, RND_FOC, sourceWidth);
     }
 
-    dropIntent         = {};
-    dropIntentTargetID = -1;
-
-    if (dragWindow && isTileValid(dragSourceID)) {
-        const auto windowBox = dragWindow->getWindowMainSurfaceBox();
+    if (g_overviewDrag.window && g_overviewDrag.state.targetMonitorKey == OVERVIEWKEY && isTileValid(g_overviewDrag.state.targetTileIndex)) {
+        const auto windowBox = g_overviewDrag.window->getWindowMainSurfaceBox();
         if (windowBox.w > 0 && windowBox.h > 0) {
-            const CBox& sourceBox = tileBoxes[dragSourceID];
-            const double scaleX   = sourceBox.w / MON->m_size.x;
-            const double scaleY   = sourceBox.h / MON->m_size.y;
-            const double minW     = std::min(sourceBox.w, 24.0 * MON->m_scale);
-            const double minH     = std::min(sourceBox.h, 24.0 * MON->m_scale);
-
-            CBox proxy{
-                lastMousePosLocal.x * MON->m_scale - dragGrabOffset.x * scaleX,
-                lastMousePosLocal.y * MON->m_scale - dragGrabOffset.y * scaleY,
-                std::clamp(windowBox.w * scaleX, minW, sourceBox.w),
-                std::clamp(windowBox.h * scaleY, minH, sourceBox.h),
-            };
-            proxy.round();
-
-            const int maxProxyRound = std::max(0, (int)std::floor(std::min(proxy.w, proxy.h) / 2.0));
-            const int autoRound     = std::min(RND_FOC, maxProxyRound);
-            const int round        = **PDRAGPROXYROUND >= 0 ? std::min(std::max(0, (int)std::lround((double)**PDRAGPROXYROUND * MON->m_scale)), maxProxyRound) : autoRound;
-
-            if (dragMoved && hoveredID != -1 && hoveredID != dragSourceID && isTileValid(hoveredID)) {
-                const auto targetTileBox = tileBoxForIndex(hoveredID, SIZE, GAPSIZE, OUTER, true);
-                const Hyprexpo::SRect targetTileLocal{targetTileBox.x, targetTileBox.y, targetTileBox.w, targetTileBox.h};
-                dropIntent = Hyprexpo::computeDropIntentGeometry({
-                    .targetValid     = true,
-                    .pointerLocal    = {lastMousePosLocal.x, lastMousePosLocal.y},
-                    .targetTileLocal = targetTileLocal,
-                    .workspaceSize   = {MON->m_size.x, MON->m_size.y},
-                    .windowSize      = {windowBox.w, windowBox.h},
-                    .grabOffset      = {dragGrabOffset.x, dragGrabOffset.y},
-                });
-                dropIntentTargetID = dropIntent.valid ? hoveredID : -1;
-            }
-
+            const int  TARGET             = g_overviewDrag.state.targetTileIndex;
+            const auto targetTileBox      = tileBoxForIndex(TARGET, SIZE, GAPSIZE, OUTER, true);
+            const Vector2D pointerLocal   = g_overviewDrag.pointerGlobal - MON->m_position;
+            const auto dropIntent = Hyprexpo::computeDropIntentGeometry({
+                .targetValid     = true,
+                .pointerLocal    = {pointerLocal.x, pointerLocal.y},
+                .targetTileLocal = {targetTileBox.x, targetTileBox.y, targetTileBox.w, targetTileBox.h},
+                .workspaceSize   = {MON->m_size.x, MON->m_size.y},
+                .windowSize      = {windowBox.w, windowBox.h},
+                .grabOffset      = {g_overviewDrag.grabOffset.x, g_overviewDrag.grabOffset.y},
+            });
             if (dropIntent.valid) {
-                CBox targetProxy{
+                CBox proxy{
                     dropIntent.targetProxyLocal.x,
                     dropIntent.targetProxyLocal.y,
                     dropIntent.targetProxyLocal.w,
                     dropIntent.targetProxyLocal.h,
                 };
-                targetProxy.scale(MON->m_scale).translate(pos->value());
-                targetProxy.round();
+                proxy.scale(MON->m_scale).translate(pos->value());
+                proxy.round();
 
-                const int targetMaxRound = std::max(0, (int)std::floor(std::min(targetProxy.w, targetProxy.h) / 2.0));
-                const int targetRound    = **PDRAGPROXYROUND >= 0 ? std::min(std::max(0, (int)std::lround((double)**PDRAGPROXYROUND * MON->m_scale)), targetMaxRound) : std::min(RND_FOC, targetMaxRound);
-                Render::GL::g_pHyprOpenGL->renderRect(targetProxy, CHyprColor{(uint64_t)**PDRAGPROXYACTCOL}, {.round = targetRound, .roundingPower = ROUND_PWR});
+                const int maxProxyRound = std::max(0, (int)std::floor(std::min(proxy.w, proxy.h) / 2.0));
+                const int autoRound     = std::min(RND_FOC, maxProxyRound);
+                const int round        = **PDRAGPROXYROUND >= 0 ? std::min(std::max(0, (int)std::lround((double)**PDRAGPROXYROUND * MON->m_scale)), maxProxyRound) : autoRound;
 
-                const int   borderWidth   = **PDRAGPROXYBWIDTH >= 0 ? **PDRAGPROXYBWIDTH : std::max(2, (int)**PBWIDTH + 1);
-                const std::string effectiveSpec = std::string{*PDRAGPROXYBORDER}.empty() ? std::string{*PBCOLFOC} : std::string{*PDRAGPROXYBORDER};
-                drawProxyBorder(targetProxy, targetRound, borderWidth, effectiveSpec, std::string{*PBGREFOC});
+                Render::GL::g_pHyprOpenGL->renderRect(proxy, CHyprColor{(uint64_t)(g_overviewDrag.state.moved ? **PDRAGPROXYACTCOL : **PDRAGPROXYCOL)}, {.round = round, .roundingPower = ROUND_PWR});
+
+                const int borderWidth = **PDRAGPROXYBWIDTH >= 0 ? **PDRAGPROXYBWIDTH : std::max(2, (int)**PBWIDTH + 1);
+                std::string effectiveSpec = std::string{*PDRAGPROXYBORDER}.empty() ? std::string{*PBCOLFOC} : std::string{*PDRAGPROXYBORDER};
+                if (effectiveSpec.empty())
+                    effectiveSpec = std::string{*PBGREFOC};
+                drawProxyBorder(proxy, round, borderWidth, effectiveSpec, std::string{*PBGREFOC});
             }
-
-            Render::GL::g_pHyprOpenGL->renderRect(proxy, CHyprColor{(uint64_t)(dragMoved ? **PDRAGPROXYACTCOL : **PDRAGPROXYCOL)}, {.round = round, .roundingPower = ROUND_PWR});
-
-            const int   borderWidth   = **PDRAGPROXYBWIDTH >= 0 ? **PDRAGPROXYBWIDTH : std::max(2, (int)**PBWIDTH + 1);
-            std::string effectiveSpec = std::string{*PDRAGPROXYBORDER}.empty() ? std::string{*PBCOLFOC} : std::string{*PDRAGPROXYBORDER};
-            if (effectiveSpec.empty())
-                effectiveSpec = std::string{*PBGREFOC};
-            drawProxyBorder(proxy, round, borderWidth, effectiveSpec, std::string{*PBGREFOC});
         }
     }
 

--- a/OverviewRender.cpp
+++ b/OverviewRender.cpp
@@ -228,11 +228,23 @@ void COverview::close(bool switchToSelection) {
         // which case some tiles will be left with this ID intentionally.
         const int  NEWID = TILE.workspaceID == WORKSPACE_INVALID ? getWorkspaceIDNameFromString("emptynm").id : TILE.workspaceID;
 
+        // A tile can name a workspace that does not exist yet -- an anchored
+        // grid (workspace_method "<output> first N") lays out max_workspace
+        // slots whether or not those workspaces have ever been opened. Reuse
+        // the same helper the drag paths use: it returns the existing
+        // workspace or creates it. Without this, selecting such a tile fell
+        // through to changeWorkspace(id), which cannot create one, and the
+        // selection silently did nothing.
         PHLWORKSPACE NEWIDWS;
-        for (const auto& w : State::workspaceState()->workspacesCopy()) {
-            if (w->m_id == NEWID) {
-                NEWIDWS = w;
-                break;
+        if (TILE.workspaceID != WORKSPACE_INVALID)
+            NEWIDWS = ensureWorkspaceForTile(SAFEID);
+
+        if (!NEWIDWS) {
+            for (const auto& w : State::workspaceState()->workspacesCopy()) {
+                if (w->m_id == NEWID) {
+                    NEWIDWS = w;
+                    break;
+                }
             }
         }
 

--- a/OverviewRender.cpp
+++ b/OverviewRender.cpp
@@ -238,9 +238,10 @@ void COverview::close(bool switchToSelection) {
 
         const auto OLDWS = MON->m_activeWorkspace;
 
-        const auto CHANGE = !NEWIDWS ? Config::Actions::changeWorkspace(std::to_string(NEWID)) : Config::Actions::changeWorkspace(NEWIDWS->getConfigName());
-        if (!CHANGE)
-            Log::logger->log(Log::ERR, "[hyprexpo] failed to change workspace: {}", CHANGE.error().message);
+        if (NEWIDWS)
+            MON->changeWorkspace(NEWIDWS);
+        else
+            MON->changeWorkspace(NEWID);
 
         Animation::Workspace::startAnimation(MON->m_activeWorkspace, Animation::Workspace::ANIMATION_TYPE_IN, true, true);
         Animation::Workspace::startAnimation(OLDWS, Animation::Workspace::ANIMATION_TYPE_OUT, false, true);

--- a/OverviewRender.cpp
+++ b/OverviewRender.cpp
@@ -196,14 +196,14 @@ void COverview::close(bool switchToSelection) {
     const auto MON = pMonitor.lock();
     if (!MON) {
         closing = true;
-        g_pOverview.reset();
+        destroyOverview(this);
         return;
     }
 
     resetSubmapIfNeeded();
 
     if (images.empty()) {
-        g_pOverview.reset();
+        destroyOverview(this);
         return;
     }
 
@@ -281,7 +281,7 @@ void COverview::onWorkspaceChange() {
 }
 
 void COverview::render() {
-    g_pHyprRenderer->m_renderPass.add(makeUnique<COverviewPassElement>());
+    g_pHyprRenderer->m_renderPass.add(makeUnique<COverviewPassElement>(pMonitor.lock()));
 }
 
 bool COverview::shouldRenderOverviewForMonitor(const PHLMONITOR& monitor) const {

--- a/docs/configuration/keyboard.md
+++ b/docs/configuration/keyboard.md
@@ -71,6 +71,15 @@ the active config system. On Hyprland 0.55+ Lua configs, that means
 `hl.define_submap("hyprexpo", ...)`; a `submap = hyprexpo` block in
 `hyprland.conf` is not loaded by a `hyprland.lua` setup.
 
+When the overview is open on every monitor, one overview is the explicit keyboard owner.
+Arrow movement first searches that overview's grid, so local wrapping takes precedence
+whenever `keynav_wrap_h` or `keynav_wrap_v` provides a
+valid tile. Only a direction with no local result crosses to the nearest tile on
+another monitor by global logical geometry. The destination remains the
+keyboard owner for later focus and selection commands even if compositor focus
+has not moved yet. A successful selection switches that destination monitor and
+closes every overview; invalid selection leaves them open.
+
 For vim-style navigation, bind `h`, `j`, `k`, and `l` inside the same Lua
 submap:
 

--- a/docs/guides/multi-monitor.md
+++ b/docs/guides/multi-monitor.md
@@ -43,6 +43,33 @@ grows — never below the configured `columns` — and is capped at the maximum 
 columns. This applies to plain sequential grids (not `skip_empty` or
 `max_workspace`, which keep their explicit bounds).
 
+## Opening on Every Monitor
+
+By default the overview opens only on the monitor under the cursor. Append `all`
+to the dispatcher argument to open one overview per monitor instead:
+
+```ini
+bind = SUPER, g, hyprexpo:expo, toggle all
+```
+
+Each monitor builds its own grid from its own anchor, so this composes with
+per-monitor `workspace_method`. With the placement below, the overview on
+`DP-1` shows workspaces 1-4 and the one on `HDMI-1` shows 5-8:
+
+```ini
+plugin {
+    hyprexpo {
+        columns = 2
+        max_workspace = 8
+        workspace_method = DP-1 first 1, HDMI-1 first 5
+    }
+}
+```
+
+Keyboard navigation stays on one overview at a time: the one on the focused
+monitor, falling back to the one under the cursor. Arrow keys do not cross
+monitor boundaries, and dragging a window between monitors is not supported yet.
+
 ## Troubleshooting Monitor Names
 
 If a per-monitor entry does not apply, check the monitor name reported by Hyprland and use that exact name in the comma-separated list.

--- a/docs/guides/multi-monitor.md
+++ b/docs/guides/multi-monitor.md
@@ -66,9 +66,18 @@ plugin {
 }
 ```
 
-Keyboard navigation stays on one overview at a time: the one on the focused
-monitor, falling back to the one under the cursor. Arrow keys do not cross
-monitor boundaries, and dragging a window between monitors is not supported yet.
+Keyboard navigation has one explicit keyboard owner. Movement stays inside that
+overview while a valid local tile (including a configured wrap target) exists.
+At an exhausted edge, the plugin uses global logical geometry to choose the
+nearest tile in that direction on another monitor. Selecting it switches only
+the target monitor, then dismisses every open overview.
+
+Window previews can also be dragged between monitor overviews. The monitor under
+the pointer renders the proxy with the target monitor's own logical tile layout
+and scale. After a valid drop, source and target thumbnails refresh
+independently. Releasing over a gap, the source tile, or an invalid target moves
+nothing; cleanup still removes highlights, restores the cursor, and repaints
+every monitor visited by the drag.
 
 ## Troubleshooting Monitor Names
 

--- a/docs/reference/dispatchers.md
+++ b/docs/reference/dispatchers.md
@@ -28,12 +28,19 @@ bind = SUPER, g, hyprexpo:expo, toggle all
 | --- | --- |
 | `all` | shorthand for `toggle all` |
 | `toggle all` | show the overview on every monitor if hidden, hide it everywhere if shown |
-| `on all` or `enable all` | show the overview on every monitor |
+| `on all` or `enable all` | show the overview on every monitor; if some are already open, fills any missing monitor overviews |
 
 The qualifier only affects opening. `off`, `cancel` and `select` always apply to
 every open overview, so a single bind closes them all. Selecting a workspace
 applies only on the monitor you acted on; the others dismiss without changing
 their workspace.
+
+`on all` and `enable all` are idempotent. Repeating either command keeps the
+existing entries and fills any missing monitor overviews. `toggle all` keeps its
+toggle behavior: if any overview is open, it closes every open overview instead
+of filling the missing monitors. Every successful keyboard, pointer, or touch
+selection also closes every open overview; only the overview that owns the
+selected tile changes workspace.
 
 Keyboard navigation dispatchers are active during overview:
 

--- a/docs/reference/dispatchers.md
+++ b/docs/reference/dispatchers.md
@@ -16,6 +16,25 @@ bind = SUPER, g, hyprexpo:expo, toggle
 | `bring` | move the top mapped window from the hovered workspace into the current workspace |
 | `1`..`9` | select that workspace by ID while overview is open; otherwise dispatch a normal workspace switch |
 
+Append `all` to open on every monitor at once instead of only the one under the
+cursor. Each monitor renders its own grid, honoring per-monitor
+[workspace placement](../guides/multi-monitor).
+
+```ini
+bind = SUPER, g, hyprexpo:expo, toggle all
+```
+
+| option | description |
+| --- | --- |
+| `all` | shorthand for `toggle all` |
+| `toggle all` | show the overview on every monitor if hidden, hide it everywhere if shown |
+| `on all` or `enable all` | show the overview on every monitor |
+
+The qualifier only affects opening. `off`, `cancel` and `select` always apply to
+every open overview, so a single bind closes them all. Selecting a workspace
+applies only on the monitor you acted on; the others dismiss without changing
+their workspace.
+
 Keyboard navigation dispatchers are active during overview:
 
 | dispatcher | argument | description |

--- a/docs/reference/dispatchers.md
+++ b/docs/reference/dispatchers.md
@@ -42,6 +42,11 @@ of filling the missing monitors. Every successful keyboard, pointer, or touch
 selection also closes every open overview; only the overview that owns the
 selected tile changes workspace.
 
+Pointer-driven `select` and `bring` always act on the overview for the monitor under the pointer.
+This remains true after keyboard focus has crossed to another
+monitor: `bring` moves the chosen window into the pointer monitor's active
+workspace rather than the keyboard-owned or compositor-focused monitor.
+
 Keyboard navigation dispatchers are active during overview:
 
 | dispatcher | argument | description |

--- a/main.cpp
+++ b/main.cpp
@@ -122,8 +122,7 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     static auto PKEY = Event::bus()->m_events.input.keyboard.key.listen([](IKeyboard::SKeyEvent event, Event::SCallbackInfo& info) {
         if (shouldCancelOverview(event)) {
             info.cancelled = true;
-            // Cancelling dismisses every open overview, not just the focused one.
-            forEachOverview([](COverview& overview) { overview.close(false); });
+            closeOverviews(false);
             return;
         }
 

--- a/main.cpp
+++ b/main.cpp
@@ -27,34 +27,40 @@ typedef void (*origAddDamageA)(void*, const CBox&);
 typedef void (*origAddDamageB)(void*, const pixman_region32_t*);
 
 static void hkRenderWorkspace(void* thisptr, PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace, const Time::steady_tp& now, const CBox& geometry) {
-    if (!g_pOverview || isRenderingOverview() || g_pOverview->blockOverviewRendering || !g_pOverview->shouldRenderOverviewForMonitor(pMonitor))
+    auto* const OV = overviewForMonitor(pMonitor);
+
+    if (!OV || isRenderingOverview() || OV->blockOverviewRendering || !OV->shouldRenderOverviewForMonitor(pMonitor))
         ((origRenderWorkspace)(g_pRenderWorkspaceHook->m_original))(thisptr, pMonitor, pWorkspace, now, geometry);
     else
-        g_pOverview->render();
+        OV->render();
 }
 
 static void hkAddDamageA(void* thisptr, const CBox& box) {
     const auto PMONITOR   = (Monitor::CMonitor*)thisptr;
     const auto PMONITORSP = PMONITOR ? PMONITOR->m_self.lock() : PHLMONITOR{};
 
-    if (!g_pOverview || !PMONITORSP || !g_pOverview->shouldRenderOverviewForMonitor(PMONITORSP) || g_pOverview->blockDamageReporting) {
+    auto* const OV = overviewForMonitor(PMONITORSP);
+
+    if (!OV || !OV->shouldRenderOverviewForMonitor(PMONITORSP) || OV->blockDamageReporting) {
         ((origAddDamageA)g_pAddDamageHookA->m_original)(thisptr, box);
         return;
     }
 
-    g_pOverview->onDamageReported();
+    OV->onDamageReported();
 }
 
 static void hkAddDamageB(void* thisptr, const pixman_region32_t* rg) {
     const auto PMONITOR   = (Monitor::CMonitor*)thisptr;
     const auto PMONITORSP = PMONITOR ? PMONITOR->m_self.lock() : PHLMONITOR{};
 
-    if (!g_pOverview || !PMONITORSP || !g_pOverview->shouldRenderOverviewForMonitor(PMONITORSP) || g_pOverview->blockDamageReporting) {
+    auto* const OV = overviewForMonitor(PMONITORSP);
+
+    if (!OV || !OV->shouldRenderOverviewForMonitor(PMONITORSP) || OV->blockDamageReporting) {
         ((origAddDamageB)g_pAddDamageHookB->m_original)(thisptr, rg);
         return;
     }
 
-    g_pOverview->onDamageReported();
+    OV->onDamageReported();
 }
 
 static void failNotif(const std::string& reason) {
@@ -109,15 +115,15 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     }
 
     static auto P = Event::bus()->m_events.render.pre.listen([](PHLMONITOR pMonitor) {
-        if (!g_pOverview)
-            return;
-        g_pOverview->onPreRender();
+        if (auto* const OV = overviewForMonitor(pMonitor))
+            OV->onPreRender();
     });
 
     static auto PKEY = Event::bus()->m_events.input.keyboard.key.listen([](IKeyboard::SKeyEvent event, Event::SCallbackInfo& info) {
         if (shouldCancelOverview(event)) {
             info.cancelled = true;
-            g_pOverview->close(false);
+            // Cancelling dismisses every open overview, not just the focused one.
+            forEachOverview([](COverview& overview) { overview.close(false); });
             return;
         }
 
@@ -141,7 +147,7 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
 APICALL EXPORT void PLUGIN_EXIT() {
     disableExpoGestureRegistration();
 
-    g_pOverview.reset();
+    destroyAllOverviews();
     g_pHyprRenderer->m_renderPass.removeAllOfType("COverviewPassElement");
 
     Config::mgr()->reload();

--- a/scripts/run-nested.sh
+++ b/scripts/run-nested.sh
@@ -112,6 +112,7 @@ plugin {
 
 # toggle with an unmodified function key to avoid host grabs
 bind = , F10, hyprexpo:expo, toggle
+bind = , F11, hyprexpo:expo, toggle all
 
 # nested-session test controls
 bind = SUPER, Return, exec, $TERMINAL

--- a/scripts/run-nested.sh
+++ b/scripts/run-nested.sh
@@ -10,12 +10,45 @@ BUILD_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/hyprexpo"
 SO="${HYPREXPO_DEV_SO:-$BUILD_DIR/hyprexpo.so}"
 CONF="${XDG_CACHE_HOME:-$HOME/.cache}/hyprexpo-dev.conf"
 
+# A nested Wayland output advertises no preferred mode, so "preferred" resolves
+# to 0x0 and Hyprland refuses to render it. Always pin an explicit mode.
+MODE="${HYPREXPO_DEV_MODE:-1280x720@60}"
+MODE_W="${MODE%%x*}"
+
+# Number of nested outputs. Set to 2+ to exercise multi-monitor behavior; each
+# extra output is created at runtime and appears as its own host window.
+OUTPUTS="${HYPREXPO_DEV_OUTPUTS:-1}"
+
+# Pick a terminal that actually exists on this machine instead of assuming one.
+TERMINAL="${HYPREXPO_DEV_TERMINAL:-}"
+if [[ -z "$TERMINAL" ]]; then
+  for candidate in kitty ghostty alacritty foot wezterm; do
+    if command -v "$candidate" >/dev/null 2>&1; then
+      TERMINAL="$candidate"
+      break
+    fi
+  done
+fi
+if [[ -z "$TERMINAL" ]]; then
+  echo "[run-nested] warning: no terminal found; SUPER+Return will do nothing" >&2
+  TERMINAL="kitty"
+fi
+
+EXTRA_OUTPUTS=""
+for ((i = 2; i <= OUTPUTS; i++)); do
+  EXTRA_OUTPUTS+="exec-once = hyprctl output create auto"$'\n'
+done
+
 mkdir -p "$(dirname "$CONF")" "$(dirname "$SO")"
 echo "[run-nested] Building local plugin at $SO"
 make -C "$REPO_ROOT" all TARGET="$SO"
 
 cat > "$CONF" <<EOF
-monitor=,preferred,auto,auto
+monitor=WAYLAND-1,$MODE,0x0,1
+monitor=WAYLAND-2,$MODE,${MODE_W}x0,1
+monitor=,$MODE,auto,1
+
+$EXTRA_OUTPUTS
 
 debug {
   disable_logs = false
@@ -81,7 +114,7 @@ plugin {
 bind = , F10, hyprexpo:expo, toggle
 
 # nested-session test controls
-bind = SUPER, Return, exec, kitty
+bind = SUPER, Return, exec, $TERMINAL
 bind = SUPER, Q, killactive
 bind = SUPER SHIFT, Q, exit
 bind = SUPER, 1, workspace, 1
@@ -124,4 +157,6 @@ submap = reset
 EOF
 
 echo "[run-nested] Launching nested Hyprland with $CONF"
-exec env WLR_BACKENDS=wayland WLR_RENDERER=pixman WLR_NO_HARDWARE_CURSORS=1 HYPRLAND_NO_LOGO=1 Hyprland -c "$CONF"
+# Hyprland 0.56 uses aquamarine, not wlroots: the old WLR_* variables are
+# inert. Aquamarine selects its Wayland backend from WAYLAND_DISPLAY.
+exec env HYPRLAND_NO_LOGO=1 Hyprland -c "$CONF"

--- a/tests/HyprexpoLogicTests.cpp
+++ b/tests/HyprexpoLogicTests.cpp
@@ -463,6 +463,16 @@ int main() {
         const auto FORMER_TARGET_DESTROY = transitionOverviewDrag(targetBState, {.type = EOverviewDragEventType::MonitorDestroyed, .monitorKey = 2}, {1, 3});
         expect(FORMER_TARGET_DESTROY.cleanup && !FORMER_TARGET_DESTROY.next.active, "destroying a former target invalidates and cleans the whole session");
 
+        const auto UNKNOWN_LOST_SOURCE = transitionOverviewDrag(targetState, {.type = EOverviewDragEventType::MonitorDestroyed}, {2, 3});
+        expect(UNKNOWN_LOST_SOURCE.cleanup && !UNKNOWN_LOST_SOURCE.next.active,
+               "an expired source resets the session even when the destruction key is unavailable");
+        const auto UNKNOWN_LOST_TARGET = transitionOverviewDrag(targetState, {.type = EOverviewDragEventType::MonitorDestroyed, .monitorKey = 99}, {1, 3});
+        expect(UNKNOWN_LOST_TARGET.cleanup && !UNKNOWN_LOST_TARGET.next.active,
+               "an expired target resets the session before an unknown destruction key is rejected");
+        const auto UNKNOWN_ALL_LIVE = transitionOverviewDrag(targetState, {.type = EOverviewDragEventType::MonitorDestroyed, .monitorKey = 99}, LIVE);
+        expect(!UNKNOWN_ALL_LIVE.cleanup && UNKNOWN_ALL_LIVE.next.active,
+               "an unrelated destruction key leaves a fully live session intact");
+
         const auto LOST_TARGET_RELEASE = transitionOverviewDrag(targetState, {.type = EOverviewDragEventType::Release}, {1, 3});
         expect(!LOST_TARGET_RELEASE.drop && LOST_TARGET_RELEASE.cleanup, "release rejects a target that disappeared without a destruction callback");
 

--- a/tests/HyprexpoLogicTests.cpp
+++ b/tests/HyprexpoLogicTests.cpp
@@ -25,6 +25,10 @@ bool near(double a, double b, double eps = 0.001) {
     return std::abs(a - b) < eps;
 }
 
+bool containsKey(const std::vector<uint64_t>& keys, uint64_t key) {
+    return std::find(keys.begin(), keys.end(), key) != keys.end();
+}
+
 Hyprexpo::SSize makeSize(double w, double h) {
     return {w, h};
 }
@@ -334,6 +338,129 @@ int main() {
     checkGeometryForMonitor(makeSize(1600, 900));
     checkGeometryForMonitor(makeSize(900, 1600));
     checkGeometryForMonitor(makeSize(2560, 1080));
+
+    // --- global multi-monitor geometry ---
+    {
+        const SRect source{100, 100, 80, 80};
+        const std::vector<SGlobalTile> candidates{
+            {.overviewKey = 2, .tileIndex = 0, .overviewGlobal = {240, 0, 200, 300}, .tileGlobal = {240, 100, 60, 60}},
+            {.overviewKey = 2, .tileIndex = 1, .overviewGlobal = {240, 0, 200, 300}, .tileGlobal = {320, 100, 60, 60}},
+            {.overviewKey = 3, .tileIndex = 0, .overviewGlobal = {-200, 40, 180, 260}, .tileGlobal = {-100, 110, 50, 50}},
+            {.overviewKey = 4, .tileIndex = 0, .overviewGlobal = {20, -240, 220, 180}, .tileGlobal = {110, -100, 50, 40}},
+            {.overviewKey = 5, .tileIndex = 0, .overviewGlobal = {0, 260, 280, 220}, .tileGlobal = {115, 280, 70, 50}},
+        };
+
+        const auto RIGHT = selectDirectionalTile(source, EDirection::Right, candidates);
+        expect(RIGHT && RIGHT->overviewKey == 2 && RIGHT->tileIndex == 0, "right selects nearest forward boundary tile");
+        const auto LEFT = selectDirectionalTile(source, EDirection::Left, candidates);
+        expect(LEFT && LEFT->overviewKey == 3, "left selects a negative-coordinate monitor tile");
+        const auto UP = selectDirectionalTile(source, EDirection::Up, candidates);
+        expect(UP && UP->overviewKey == 4, "up selects a stacked monitor tile");
+        const auto DOWN = selectDirectionalTile(source, EDirection::Down, candidates);
+        expect(DOWN && DOWN->overviewKey == 5, "down selects a gapped monitor tile");
+
+        const std::vector<SGlobalTile> ranked{
+            {.overviewKey = 10, .tileIndex = 0, .overviewGlobal = {200, 0, 300, 300}, .tileGlobal = {220, 260, 40, 40}},
+            {.overviewKey = 11, .tileIndex = 0, .overviewGlobal = {200, 0, 300, 300}, .tileGlobal = {220, 130, 40, 40}},
+            {.overviewKey = 12, .tileIndex = 0, .overviewGlobal = {200, 0, 300, 300}, .tileGlobal = {240, 110, 40, 40}},
+        };
+        const auto PERPENDICULAR = selectDirectionalTile(source, EDirection::Right, ranked);
+        expect(PERPENDICULAR && PERPENDICULAR->overviewKey == 11, "perpendicular interval distance ranks before center distance");
+
+        const std::vector<SGlobalTile> stableTie{
+            {.overviewKey = 20, .tileIndex = 3, .overviewGlobal = {200, 0, 300, 300}, .tileGlobal = {220, 100, 40, 40}},
+            {.overviewKey = 21, .tileIndex = 1, .overviewGlobal = {200, 0, 300, 300}, .tileGlobal = {220, 100, 40, 40}},
+        };
+        const auto TIE = selectDirectionalTile(source, EDirection::Right, stableTie);
+        expect(TIE && TIE->overviewKey == 20 && TIE->tileIndex == 3, "directional ties retain stable input order");
+
+        const std::vector<SGlobalTile> partialRow{
+            {.overviewKey = 30, .tileIndex = 3, .overviewGlobal = {220, 0, 400, 300}, .tileGlobal = {220, 20, 80, 80}},
+            {.overviewKey = 30, .tileIndex = 4, .overviewGlobal = {220, 0, 400, 300}, .tileGlobal = {220, 120, 80, 80}},
+        };
+        const auto PARTIAL = selectDirectionalTile(source, EDirection::Right, partialRow);
+        expect(PARTIAL && PARTIAL->tileIndex == 4, "partial-row candidate nearest the source interval wins");
+
+        const std::vector<SGlobalTile> invalid{
+            {.overviewKey = 0, .tileIndex = 0, .overviewGlobal = {200, 0, 100, 100}, .tileGlobal = {220, 100, 40, 40}},
+            {.overviewKey = 2, .tileIndex = -1, .overviewGlobal = {200, 0, 100, 100}, .tileGlobal = {220, 100, 40, 40}},
+            {.overviewKey = 2, .tileIndex = 0, .overviewGlobal = {200, 0, 100, 100}, .tileGlobal = {220, 100, 0, 40}},
+            {.overviewKey = 2, .tileIndex = 1, .overviewGlobal = {0, 0, 100, 100}, .tileGlobal = {20, 100, 40, 40}},
+        };
+        expect(!selectDirectionalTile(source, EDirection::Right, invalid), "invalid and wrong-half-plane candidates are ignored");
+    }
+
+    // --- global overview/tile hit testing ---
+    {
+        const std::vector<SGlobalTile> tiles{
+            {.overviewKey = 1, .tileIndex = 0, .overviewGlobal = {-1920, 0, 1920, 1080}, .tileGlobal = {-1900, 20, 900, 500}},
+            {.overviewKey = 2, .tileIndex = 4, .overviewGlobal = {100, 200, 1280, 720}, .tileGlobal = {140, 240, 500, 200}},
+        };
+        const auto FIRST = hitTestGlobalTile({-1900, 20}, tiles);
+        expect(FIRST && FIRST->overviewKey == 1 && FIRST->tileIndex == 0, "global hit includes the top-left tile edge");
+        expect(FIRST && near(FIRST->pointLocal.x, 20) && near(FIRST->pointLocal.y, 20), "hit result converts to first overview-local coordinates");
+        const auto SECOND = hitTestGlobalTile({639.999, 439.999}, tiles);
+        expect(SECOND && SECOND->overviewKey == 2 && SECOND->tileIndex == 4, "global hit resolves a differently sized target overview");
+        expect(SECOND && near(SECOND->pointLocal.x, 539.999) && near(SECOND->pointLocal.y, 239.999), "hit result converts to target-local coordinates");
+        expect(!hitTestGlobalTile({640, 440}, tiles), "global hit excludes exact bottom-right tile edges");
+        expect(!hitTestGlobalTile({50, 100}, tiles), "global hit rejects monitor gaps and points outside every tile");
+    }
+
+    // --- executable shared drag coordinator ---
+    {
+        SOverviewDragState state;
+        const std::vector<uint64_t> LIVE{1, 2, 3};
+
+        auto step = transitionOverviewDrag(state, {.type = EOverviewDragEventType::Press, .monitorKey = 1, .tileIndex = 2, .windowKey = 77}, LIVE);
+        expect(step.accepted && step.next.active && step.next.sourceMonitorKey == 1, "press claims one live source owner");
+        state = step.next;
+
+        const auto SECOND_PRESS = transitionOverviewDrag(state, {.type = EOverviewDragEventType::Press, .monitorKey = 2, .tileIndex = 0, .windowKey = 88}, LIVE);
+        expect(!SECOND_PRESS.accepted && SECOND_PRESS.next.sourceMonitorKey == 1, "a concurrent second press cannot steal drag ownership");
+
+        step = transitionOverviewDrag(state, {.type = EOverviewDragEventType::Move}, LIVE);
+        expect(step.accepted && step.next.moved, "move crosses the drag threshold once");
+        state = step.next;
+        step = transitionOverviewDrag(state, {.type = EOverviewDragEventType::Target, .monitorKey = 2, .tileIndex = 4}, LIVE);
+        expect(step.accepted && step.next.targetMonitorKey == 2, "target A becomes current");
+        state = step.next;
+        step = transitionOverviewDrag(state, {.type = EOverviewDragEventType::Target, .monitorKey = 3, .tileIndex = 1}, LIVE);
+        expect(step.accepted && step.next.targetMonitorKey == 3, "target B replaces target A");
+        expect(containsKey(step.next.affectedMonitorKeys, 1) && containsKey(step.next.affectedMonitorKeys, 2) && containsKey(step.next.affectedMonitorKeys, 3), "source and every visited target remain affected");
+        state = step.next;
+
+        step = transitionOverviewDrag(state, {.type = EOverviewDragEventType::Release}, LIVE);
+        expect(step.drop && step.drop->sourceMonitorKey == 1 && step.drop->targetMonitorKey == 3 && step.drop->windowKey == 77, "release emits one validated source-to-current-target drop");
+        expect(step.cleanup && !step.next.active, "release returns cleanup and leaves the coordinator idle");
+        expect(step.cleanupMonitorKeys.size() == 3, "release cleanup damages each affected monitor once");
+        state = step.next;
+        const auto DUPLICATE_RELEASE = transitionOverviewDrag(state, {.type = EOverviewDragEventType::Release}, LIVE);
+        expect(!DUPLICATE_RELEASE.drop && !DUPLICATE_RELEASE.cleanup && !DUPLICATE_RELEASE.next.active, "duplicate release is idempotent and emits no second drop");
+
+        const auto STALE_PRESS = transitionOverviewDrag({}, {.type = EOverviewDragEventType::Press, .monitorKey = 9, .tileIndex = 0, .windowKey = 1}, LIVE);
+        expect(!STALE_PRESS.accepted && !STALE_PRESS.next.active, "press rejects a stale source monitor key");
+        const auto VALID_PRESS = transitionOverviewDrag({}, {.type = EOverviewDragEventType::Press, .monitorKey = 1, .tileIndex = 0, .windowKey = 1}, LIVE);
+        const auto STALE_TARGET = transitionOverviewDrag(VALID_PRESS.next, {.type = EOverviewDragEventType::Target, .monitorKey = 9, .tileIndex = 0}, LIVE);
+        expect(!STALE_TARGET.accepted && !STALE_TARGET.next.targetMonitorKey, "target change rejects a stale target monitor key");
+
+        auto noTarget = transitionOverviewDrag(VALID_PRESS.next, {.type = EOverviewDragEventType::Move}, LIVE).next;
+        const auto NO_TARGET_RELEASE = transitionOverviewDrag(noTarget, {.type = EOverviewDragEventType::Release}, LIVE);
+        expect(!NO_TARGET_RELEASE.drop && NO_TARGET_RELEASE.cleanup && !NO_TARGET_RELEASE.next.active, "release without a target cleans up without a drop");
+
+        auto targetState = transitionOverviewDrag(noTarget, {.type = EOverviewDragEventType::Target, .monitorKey = 2, .tileIndex = 1}, LIVE).next;
+        const auto TARGET_DESTROY = transitionOverviewDrag(targetState, {.type = EOverviewDragEventType::MonitorDestroyed, .monitorKey = 2}, {1, 3});
+        expect(TARGET_DESTROY.cleanup && !TARGET_DESTROY.drop && !TARGET_DESTROY.next.active, "target destruction cancels and cleans the session");
+        expect(containsKey(TARGET_DESTROY.cleanupMonitorKeys, 1) && containsKey(TARGET_DESTROY.cleanupMonitorKeys, 2), "target destruction retains source and destroyed-target cleanup keys");
+
+        const auto SOURCE_DESTROY = transitionOverviewDrag(targetState, {.type = EOverviewDragEventType::MonitorDestroyed, .monitorKey = 1}, {2, 3});
+        expect(SOURCE_DESTROY.cleanup && !SOURCE_DESTROY.next.active, "source destruction cancels and cleans the session");
+        const auto CANCEL = transitionOverviewDrag(targetState, {.type = EOverviewDragEventType::Cancel}, LIVE);
+        expect(CANCEL.cleanup && !CANCEL.next.active && !CANCEL.drop, "cancel cleans without emitting a drop");
+        const auto ALL_CLOSE = transitionOverviewDrag(targetState, {.type = EOverviewDragEventType::AllClose}, {});
+        expect(ALL_CLOSE.cleanup && !ALL_CLOSE.next.active && ALL_CLOSE.cleanupMonitorKeys.size() == 2, "all-close cleans and de-duplicates affected monitors");
+        const auto IDLE_CANCEL = transitionOverviewDrag({}, {.type = EOverviewDragEventType::Cancel}, LIVE);
+        expect(!IDLE_CANCEL.cleanup && !IDLE_CANCEL.next.active, "repeated cleanup while idle is harmless");
+    }
 
     // --- "all monitors" qualifier on expo dispatcher args ---
     {

--- a/tests/HyprexpoLogicTests.cpp
+++ b/tests/HyprexpoLogicTests.cpp
@@ -335,6 +335,38 @@ int main() {
     checkGeometryForMonitor(makeSize(900, 1600));
     checkGeometryForMonitor(makeSize(2560, 1080));
 
+    // --- "all monitors" qualifier on expo dispatcher args ---
+    {
+        const auto BARE = Hyprexpo::parseExpoCommand("all");
+        expect(BARE.allMonitors, "bare all targets every monitor");
+        expect(BARE.command == "toggle", "bare all means toggle all");
+
+        const auto TOGGLE = Hyprexpo::parseExpoCommand("toggle all");
+        expect(TOGGLE.allMonitors, "toggle all targets every monitor");
+        expect(TOGGLE.command == "toggle", "toggle all keeps the toggle command");
+
+        const auto ON = Hyprexpo::parseExpoCommand("on all");
+        expect(ON.allMonitors, "on all targets every monitor");
+        expect(ON.command == "on", "on all keeps the on command");
+
+        const auto PLAIN = Hyprexpo::parseExpoCommand("toggle");
+        expect(!PLAIN.allMonitors, "plain toggle stays single-monitor");
+        expect(PLAIN.command == "toggle", "plain toggle is unchanged");
+
+        const auto EMPTY = Hyprexpo::parseExpoCommand("");
+        expect(!EMPTY.allMonitors, "empty arg stays single-monitor");
+        expect(EMPTY.command.empty(), "empty arg stays empty");
+
+        const auto PADDED = Hyprexpo::parseExpoCommand("  toggle   all  ");
+        expect(PADDED.allMonitors, "surrounding whitespace does not hide the qualifier");
+        expect(PADDED.command == "toggle", "whitespace is trimmed off the command");
+
+        // "all" only counts as a qualifier on its own or as a trailing word.
+        const auto SUBSTRING = Hyprexpo::parseExpoCommand("install");
+        expect(!SUBSTRING.allMonitors, "a command merely ending in the letters all is not a qualifier");
+        expect(SUBSTRING.command == "install", "non-qualifier command is unchanged");
+    }
+
     if (failures != 0)
         return 1;
 

--- a/tests/HyprexpoLogicTests.cpp
+++ b/tests/HyprexpoLogicTests.cpp
@@ -448,6 +448,24 @@ int main() {
         expect(!NO_TARGET_RELEASE.drop && NO_TARGET_RELEASE.cleanup && !NO_TARGET_RELEASE.next.active, "release without a target cleans up without a drop");
 
         auto targetState = transitionOverviewDrag(noTarget, {.type = EOverviewDragEventType::Target, .monitorKey = 2, .tileIndex = 1}, LIVE).next;
+        const auto sameTile = transitionOverviewDrag(
+            transitionOverviewDrag(VALID_PRESS.next, {.type = EOverviewDragEventType::Move}, LIVE).next,
+            {.type = EOverviewDragEventType::Target, .monitorKey = 1, .tileIndex = 0}, LIVE).next;
+        const auto SAME_TILE_RELEASE = transitionOverviewDrag(sameTile, {.type = EOverviewDragEventType::Release}, LIVE);
+        expect(!SAME_TILE_RELEASE.drop && SAME_TILE_RELEASE.cleanup, "same-tile release is consumed without emitting a drop");
+
+        const auto CLEARED_TARGET = transitionOverviewDrag(targetState, {.type = EOverviewDragEventType::Target}, LIVE);
+        expect(CLEARED_TARGET.accepted && !CLEARED_TARGET.next.targetMonitorKey, "leaving every overview clears the current target without forgetting affected monitors");
+        const auto GAP_RELEASE = transitionOverviewDrag(CLEARED_TARGET.next, {.type = EOverviewDragEventType::Release}, LIVE);
+        expect(!GAP_RELEASE.drop && GAP_RELEASE.cleanup && GAP_RELEASE.cleanupMonitorKeys.size() == 2, "gap release cleans source and former target without a drop");
+
+        auto targetBState = transitionOverviewDrag(targetState, {.type = EOverviewDragEventType::Target, .monitorKey = 3, .tileIndex = 0}, LIVE).next;
+        const auto FORMER_TARGET_DESTROY = transitionOverviewDrag(targetBState, {.type = EOverviewDragEventType::MonitorDestroyed, .monitorKey = 2}, {1, 3});
+        expect(FORMER_TARGET_DESTROY.cleanup && !FORMER_TARGET_DESTROY.next.active, "destroying a former target invalidates and cleans the whole session");
+
+        const auto LOST_TARGET_RELEASE = transitionOverviewDrag(targetState, {.type = EOverviewDragEventType::Release}, {1, 3});
+        expect(!LOST_TARGET_RELEASE.drop && LOST_TARGET_RELEASE.cleanup, "release rejects a target that disappeared without a destruction callback");
+
         const auto TARGET_DESTROY = transitionOverviewDrag(targetState, {.type = EOverviewDragEventType::MonitorDestroyed, .monitorKey = 2}, {1, 3});
         expect(TARGET_DESTROY.cleanup && !TARGET_DESTROY.drop && !TARGET_DESTROY.next.active, "target destruction cancels and cleans the session");
         expect(containsKey(TARGET_DESTROY.cleanupMonitorKeys, 1) && containsKey(TARGET_DESTROY.cleanupMonitorKeys, 2), "target destruction retains source and destroyed-target cleanup keys");

--- a/tests/OverviewSourceTests.cpp
+++ b/tests/OverviewSourceTests.cpp
@@ -328,6 +328,19 @@ int main() {
     expect(closeOverview.find("resetSubmapIfNeeded();") != std::string::npos,
            "normal overview close restores the captured submap");
 
+    // An anchored grid (workspace_method "<output> first N") lays out
+    // max_workspace slots whether or not those workspaces exist. Selecting a
+    // tile for one that has never been opened must create it: changeWorkspace()
+    // cannot, and the selection used to silently do nothing.
+    const auto ensureTileWsPos = closeOverview.find("ensureWorkspaceForTile(SAFEID)");
+    const auto changeWsPos     = closeOverview.find("MON->changeWorkspace(");
+    expect(ensureTileWsPos != std::string::npos,
+           "selection resolves the tile's workspace through the creating helper");
+    expect(changeWsPos != std::string::npos && ensureTileWsPos < changeWsPos,
+           "the tile's workspace is created before the monitor is switched to it");
+    expect(closeOverview.find("if (TILE.workspaceID != WORKSPACE_INVALID)") != std::string::npos,
+           "a WORKSPACE_INVALID tile still falls back to the next empty workspace");
+
     // overviewDestructor is already extracted above, next to the settle-timer checks.
     expect(!overviewDestructor.empty(), "overview destructor exists");
     expect(overviewDestructor.find("resetSubmapIfNeeded();") != std::string::npos,

--- a/tests/OverviewSourceTests.cpp
+++ b/tests/OverviewSourceTests.cpp
@@ -219,8 +219,23 @@ int main() {
     expect(byPoint.find("if (!OV)") < byPoint.find("OV->pMonitor"), "point lookup skips null registry slots before dereference");
     expect(source.find("if (OV)\n            snapshot.push_back(OV.get());") != std::string::npos,
            "safe registry snapshots never publish null overview pointers");
-    expect(interactionSource.find("overviewRegistered(this)") != std::string::npos && interactionSource.find("activeOverview() != this") == std::string::npos,
-           "settle timer liveness uses exact registry membership instead of active ownership");
+    expect(interactionSource.find("activeOverview() != this") == std::string::npos,
+           "settle timer liveness never depends on whichever overview currently owns keyboard input");
+
+    const auto redrawTimer = extractFunction(interactionSource, "void COverview::redrawDraggedWindowTile(int id) {");
+    expect(redrawTimer.find("[this]") == std::string::npos,
+           "settle timer callbacks never capture a raw overview pointer");
+    expect(redrawTimer.find("const auto OVERVIEWKEY = overviewMonitorKey(") != std::string::npos && redrawTimer.find("[OVERVIEWKEY]") != std::string::npos &&
+               redrawTimer.find("overviewForMonitorKey(OVERVIEWKEY)") != std::string::npos,
+           "settle timer callbacks re-resolve their overview by stable monitor key on every tick");
+    expect(redrawTimer.find("OVERVIEW->redrawSettleTimer.get() != self.get()") != std::string::npos,
+           "a timer cannot mutate a replacement overview registered on the same monitor");
+
+    const auto overviewDestructor = extractFunction(source, "COverview::~COverview() {");
+    const auto cancelTimerPos     = overviewDestructor.find("redrawSettleTimer->cancel();");
+    const auto restoreCursorPos   = overviewDestructor.find("Pointer::Cursor::overrideController->unsetOverride");
+    expect(cancelTimerPos != std::string::npos && restoreCursorPos != std::string::npos && cancelTimerPos < restoreCursorPos,
+           "overview teardown cancels and detaches settle timers before cursor restoration can re-enter callbacks");
 
     const auto headerSource = readFile("Overview.hpp");
     expect(headerSource.find("dragStartLocal") == std::string::npos && headerSource.find("dragSourceID") == std::string::npos && headerSource.find("dragWindow") == std::string::npos,

--- a/tests/OverviewSourceTests.cpp
+++ b/tests/OverviewSourceTests.cpp
@@ -50,6 +50,13 @@ std::string extractFunction(const std::string& source, const std::string& signat
     return {};
 }
 
+size_t countOccurrences(const std::string& source, const std::string& needle) {
+    size_t count = 0;
+    for (size_t pos = source.find(needle); pos != std::string::npos; pos = source.find(needle, pos + needle.size()))
+        ++count;
+    return count;
+}
+
 }
 
 int main() {
@@ -194,6 +201,28 @@ int main() {
     expect(interactionSource.find("overviewRegistered(this)") != std::string::npos && interactionSource.find("activeOverview() != this") == std::string::npos,
            "settle timer liveness uses exact registry membership instead of active ownership");
 
+    const auto headerSource = readFile("Overview.hpp");
+    expect(headerSource.find("dragStartLocal") == std::string::npos && headerSource.find("dragSourceID") == std::string::npos && headerSource.find("dragWindow") == std::string::npos,
+           "per-overview drag ownership fields are removed in favor of the registry session");
+    const auto beginDrag  = extractFunction(interactionSource, "void COverview::beginWindowDrag() {");
+    const auto updateDrag = extractFunction(interactionSource, "void COverview::updateWindowDrag() {");
+    const auto finishDrag = extractFunction(interactionSource, "bool COverview::finishWindowDrag() {");
+    expect(beginDrag.find("hitTestGlobalTile(") != std::string::npos && beginDrag.find("EOverviewDragEventType::Press") != std::string::npos,
+           "drag press ownership comes from pure global hit testing and the shared coordinator");
+    expect(updateDrag.find("sourceMonitorKey") != std::string::npos && updateDrag.find("EOverviewDragEventType::Move") != std::string::npos &&
+               updateDrag.find("EOverviewDragEventType::Target") != std::string::npos,
+           "only the shared source owner advances move and target transitions");
+    expect(finishDrag.find("EOverviewDragEventType::Release") != std::string::npos && finishDrag.find("resetOverviewDrag(") != std::string::npos,
+           "release consumes the pure coordinator result and terminates through centralized reset");
+    expect(finishDrag.find("TARGETWS->m_monitor.lock() != TARGETMON") != std::string::npos,
+           "release rejects a target workspace that does not belong to the target overview monitor");
+    expect(countOccurrences(finishDrag, "moveWindowToWorkspace(") == 1,
+           "validated release moves the window exactly once");
+    expect(finishDrag.find("SOURCEOV->redrawDraggedWindowTile(") != std::string::npos && finishDrag.find("TARGETOV->redrawDraggedWindowTile(") != std::string::npos,
+           "source and destination thumbnails refresh independently");
+    expect(finishDrag.find("\"left_ptr\"") == std::string::npos,
+           "release cannot restore the cursor outside centralized reset");
+
     const auto overviewConstructor = extractFunction(source, "COverview::COverview(");
     expect(!overviewConstructor.empty(), "overview constructor exists");
     const auto gapExpansionPos = overviewConstructor.find("Hyprexpo::expandDynamicWorkspaceIDs(");
@@ -220,6 +249,10 @@ int main() {
            "runtime label rendering resolves explicit modern and legacy option precedence");
     expect(fullRender.find("CompatHyprlandAPI::configValueSetByUser(") != std::string::npos,
            "runtime label compatibility checks whether each option was explicitly configured");
+    expect(fullRender.find("g_overviewDrag.state.sourceMonitorKey") != std::string::npos && fullRender.find("g_overviewDrag.state.targetMonitorKey") != std::string::npos,
+           "source and destination overview renders query the one shared drag session");
+    expect(fullRender.find(".pointerLocal") != std::string::npos && fullRender.find("MON->m_scale") != std::string::npos,
+           "destination proxy geometry uses target-local pointer coordinates and target monitor scale");
     expect(source.find("Config::mgr()->getConfigValue(name).setByUser") != std::string::npos,
            "config compatibility exposes explicit-setting metadata for both config providers");
 
@@ -244,6 +277,17 @@ int main() {
     expect(disablePos < reloadPos, "the registration fence is set before the teardown reload re-runs the config");
 
     expect(mainSource.find("config.reloaded.listen") != std::string::npos, "the gesture is re-applied after every config reload");
+
+    const auto multiMonitorDocs = readFile("docs/guides/multi-monitor.md");
+    const auto keyboardDocs     = readFile("docs/configuration/keyboard.md");
+    const auto dispatcherDocs   = readFile("docs/reference/dispatchers.md");
+    expect(multiMonitorDocs.find("global logical geometry") != std::string::npos && multiMonitorDocs.find("target monitor") != std::string::npos &&
+               multiMonitorDocs.find("not supported yet") == std::string::npos,
+           "multi-monitor guide documents geometry-based navigation and target-local drag/drop");
+    expect(keyboardDocs.find("local wrapping takes precedence") != std::string::npos && keyboardDocs.find("keyboard owner") != std::string::npos,
+           "keyboard guide documents explicit ownership and local-wrap precedence");
+    expect(dispatcherDocs.find("fills any missing monitor overviews") != std::string::npos && dispatcherDocs.find("closes every open overview") != std::string::npos,
+           "dispatcher reference distinguishes idempotent enabling from toggle close and peer dismissal");
 
     if (failures != 0)
         return 1;

--- a/tests/OverviewSourceTests.cpp
+++ b/tests/OverviewSourceTests.cpp
@@ -59,8 +59,8 @@ int main() {
     const auto function = extractFunction(source, "void removeOverview(");
     expect(!function.empty(), "removeOverview function exists");
 
-    const auto lockPos     = function.find("const auto MON = g_pOverview->pMonitor.lock();");
-    const auto resetPos    = function.find("g_pOverview.reset();");
+    const auto lockPos     = function.find("const auto MON = OV->pMonitor.lock();");
+    const auto resetPos    = function.find("destroyOverview(OV);");
     const auto damagePos   = function.find("g_pHyprRenderer->damageMonitor(MON);");
     const auto schedulePos = function.find("MON->scheduleFrame();");
 
@@ -97,7 +97,7 @@ int main() {
 
     const auto numberKeyDispatcher = extractFunction(dispatchersSource, "static SDispatchResult changeToSingleDigitWorkspace(const std::string& arg) {");
     expect(!numberKeyDispatcher.empty(), "number-key dispatcher function exists");
-    expect(numberKeyDispatcher.find("g_pOverview->selectWorkspaceByID(workspaceID)") != std::string::npos,
+    expect(numberKeyDispatcher.find("OV->selectWorkspaceByID(workspaceID)") != std::string::npos,
            "workspace-mode raw number keys preserve workspace-ID selection");
 
     const auto rawNumberSelection = extractFunction(dispatchersSource, "bool shouldSelectWorkspaceFromKey(const IKeyboard::SKeyEvent& event) {");
@@ -119,7 +119,7 @@ int main() {
                rawNumberSelection.substr(passthroughMode, indexMode - passthroughMode).find("return false;") != std::string::npos,
            "passthrough mode leaves raw number keys uncancelled");
     expect(indexMode != std::string::npos && workspaceMode != std::string::npos &&
-               rawNumberSelection.substr(indexMode, workspaceMode - indexMode).find("g_pOverview->onKbSelectToken(visibleIndex)") != std::string::npos &&
+               rawNumberSelection.substr(indexMode, workspaceMode - indexMode).find("OV->onKbSelectToken(visibleIndex)") != std::string::npos &&
                rawNumberSelection.substr(indexMode, workspaceMode - indexMode).find("return true;") != std::string::npos,
            "index mode selects from active-overview visible tile positions");
     expect(workspaceMode != std::string::npos,
@@ -140,20 +140,20 @@ int main() {
 
     const auto numberDispatcher = extractFunction(dispatchersSource, "static SDispatchResult onKbSelectNumberDispatcher(std::string arg) {");
     const auto indexDispatcher  = extractFunction(dispatchersSource, "static SDispatchResult onKbSelectIndexDispatcher(std::string arg) {");
-    expect(numberDispatcher.find("g_pOverview->onKbSelectNumber(num)") != std::string::npos,
+    expect(numberDispatcher.find("OV->onKbSelectNumber(num)") != std::string::npos,
            "kb_selectn keeps routing to workspace-number selection");
-    expect(indexDispatcher.find("g_pOverview->onKbSelectToken(idx - 1)") != std::string::npos,
+    expect(indexDispatcher.find("OV->onKbSelectToken(idx - 1)") != std::string::npos,
            "kb_selecti keeps routing to one-based visible-index selection");
 
     const auto toggleStart = expoDispatcher.find("if (arg == \"toggle\")");
     const auto cancelStart = expoDispatcher.find("if (arg == \"cancel\")", toggleStart);
     const auto toggleBlock = toggleStart == std::string::npos || cancelStart == std::string::npos ? std::string{} : expoDispatcher.substr(toggleStart, cancelStart - toggleStart);
-    expect(toggleBlock.find("g_pOverview->close(false);") != std::string::npos, "plain toggle close does not select a fallback workspace");
+    expect(toggleBlock.find("closeOverviews(false);") != std::string::npos, "plain toggle close does not select a fallback workspace");
 
     const auto offStart = expoDispatcher.find("if (arg == \"off\" || arg == \"close\" || arg == \"disable\")");
-    const auto offEnd   = expoDispatcher.find("\n    if (g_pOverview)\n        return {};", offStart);
+    const auto offEnd   = expoDispatcher.find("\n    if (overviewOpen())\n        return {};", offStart);
     const auto offBlock = offStart == std::string::npos || offEnd == std::string::npos ? std::string{} : expoDispatcher.substr(offStart, offEnd - offStart);
-    expect(offBlock.find("g_pOverview->close(false);") != std::string::npos, "plain off and close commands do not select a fallback workspace");
+    expect(offBlock.find("closeOverviews(false);") != std::string::npos, "plain off and close commands do not select a fallback workspace");
 
     const auto overviewConstructor = extractFunction(source, "COverview::COverview(");
     expect(!overviewConstructor.empty(), "overview constructor exists");

--- a/tests/OverviewSourceTests.cpp
+++ b/tests/OverviewSourceTests.cpp
@@ -131,7 +131,7 @@ int main() {
 
     const auto interactionSource = readFile("OverviewInteraction.cpp");
     expect(!interactionSource.empty(), "OverviewInteraction.cpp can be read from repo root");
-    const auto numberSelection = extractFunction(interactionSource, "void COverview::onKbSelectNumber(int num) {");
+    const auto numberSelection = extractFunction(interactionSource, "bool COverview::onKbSelectNumber(int num) {");
     expect(!numberSelection.empty(), "workspace-number dispatcher selection function exists");
     expect(numberSelection.find("selectWorkspaceByID(num)") != std::string::npos,
            "kb_selectn remains workspace-ID based");
@@ -140,10 +140,10 @@ int main() {
 
     const auto numberDispatcher = extractFunction(dispatchersSource, "static SDispatchResult onKbSelectNumberDispatcher(std::string arg) {");
     const auto indexDispatcher  = extractFunction(dispatchersSource, "static SDispatchResult onKbSelectIndexDispatcher(std::string arg) {");
-    expect(numberDispatcher.find("OV->onKbSelectNumber(num)") != std::string::npos,
-           "kb_selectn keeps routing to workspace-number selection");
-    expect(indexDispatcher.find("OV->onKbSelectToken(idx - 1)") != std::string::npos,
-           "kb_selecti keeps routing to one-based visible-index selection");
+    expect(numberDispatcher.find("if (OV->onKbSelectNumber(num))") != std::string::npos && numberDispatcher.find("closeOverviewsSelecting(OV);") != std::string::npos,
+           "kb_selectn closes every overview only after successful workspace-number selection");
+    expect(indexDispatcher.find("if (OV->onKbSelectToken(idx - 1))") != std::string::npos && indexDispatcher.find("closeOverviewsSelecting(OV);") != std::string::npos,
+           "kb_selecti closes every overview only after successful visible-index selection");
 
     const auto toggleStart = expoDispatcher.find("if (arg == \"toggle\")");
     const auto cancelStart = expoDispatcher.find("if (arg == \"cancel\")", toggleStart);
@@ -154,6 +154,45 @@ int main() {
     const auto offEnd   = expoDispatcher.find("\n    if (overviewOpen())\n        return {};", offStart);
     const auto offBlock = offStart == std::string::npos || offEnd == std::string::npos ? std::string{} : expoDispatcher.substr(offStart, offEnd - offStart);
     expect(offBlock.find("closeOverviews(false);") != std::string::npos, "plain off and close commands do not select a fallback workspace");
+
+    const auto enableAllStart = expoDispatcher.find("if (ALL_MONITORS && (arg == \"on\" || arg == \"enable\"))");
+    const auto alreadyOpen    = expoDispatcher.find("if (overviewOpen())", enableAllStart);
+    expect(enableAllStart != std::string::npos && alreadyOpen != std::string::npos && enableAllStart < alreadyOpen,
+           "on all and enable all fill missing monitor entries before the already-open early return");
+    expect(toggleBlock.find("openOverviews(ALL_MONITORS);") != std::string::npos && toggleBlock.find("closeOverviews(false);") != std::string::npos,
+           "toggle all preserves close-when-any-open semantics");
+
+    const auto activeFunction = extractFunction(source, "COverview* activeOverview() {");
+    expect(activeFunction.find("g_keyboardOverviewMonitor.lock()") != std::string::npos && activeFunction.find("overviewForMonitor(KEYBOARD)") != std::string::npos,
+           "active overview honors a persistent explicit keyboard owner before compositor focus");
+    expect(source.find("bool overviewRegistered(const COverview* overview)") != std::string::npos,
+           "registry exposes exact overview liveness for delayed callbacks");
+
+    const auto moveFocus = extractFunction(interactionSource, "bool COverview::moveFocus(int dx, int dy) {");
+    const auto kbMove    = extractFunction(interactionSource, "bool COverview::onKbMoveFocus(const std::string& dir) {");
+    expect(!moveFocus.empty() && moveFocus.find("return true;") != std::string::npos && moveFocus.find("return false;") != std::string::npos,
+           "local focus movement reports whether it found a tile");
+    expect(kbMove.find("moveOverviewFocusAcrossMonitors(this") != std::string::npos,
+           "cross-monitor focus runs only after local movement fails");
+    expect(source.find("Hyprexpo::selectDirectionalTile(") != std::string::npos && source.find("g_keyboardOverviewMonitor = TARGET->pMonitor;") != std::string::npos,
+           "cross-monitor focus uses pure geometry and persists destination keyboard ownership");
+
+    expect(source.find("void closeOverviewsSelecting(COverview* selecting)") != std::string::npos &&
+               dispatchersSource.find("static void closeOverviewsSelecting(") == std::string::npos,
+           "one registry coordinator owns selector and peer closure");
+    expect(interactionSource.find("bool COverview::selectHoveredWorkspace()") != std::string::npos,
+           "pointer and touch selection can distinguish success from an invalid tile");
+
+    const auto resetDrag = extractFunction(source, "void resetOverviewDrag(");
+    expect(!resetDrag.empty(), "registry provides one centralized idempotent drag reset");
+    expect(resetDrag.find("transitionOverviewDrag(") != std::string::npos && resetDrag.find("\"left_ptr\"") != std::string::npos && resetDrag.find("damageMonitor") != std::string::npos,
+           "central drag reset clears pure state, restores left_ptr, and damages affected live monitors");
+    const auto destroyOne = extractFunction(source, "void destroyOverview(COverview* overview) {");
+    const auto destroyAll = extractFunction(source, "void destroyAllOverviews() {");
+    expect(destroyOne.find("resetOverviewDrag(") < destroyOne.find("std::erase_if("), "single-overview destruction resets drag before erasing ownership");
+    expect(destroyAll.find("resetOverviewDrag(") < destroyAll.find("g_overviews.clear();"), "all-overview destruction resets drag before clearing ownership");
+    expect(interactionSource.find("overviewRegistered(this)") != std::string::npos && interactionSource.find("activeOverview() != this") == std::string::npos,
+           "settle timer liveness uses exact registry membership instead of active ownership");
 
     const auto overviewConstructor = extractFunction(source, "COverview::COverview(");
     expect(!overviewConstructor.empty(), "overview constructor exists");
@@ -168,6 +207,9 @@ int main() {
     expect(!renderSource.empty(), "OverviewRender.cpp can be read from repo root");
     const auto fullRender = extractFunction(renderSource, "void COverview::fullRender(");
     expect(!fullRender.empty(), "overview fullRender function exists");
+    const auto closeFunction = extractFunction(renderSource, "void COverview::close(bool switchToSelection) {");
+    expect(closeFunction.find("MON->changeWorkspace(") != std::string::npos && closeFunction.find("Config::Actions::changeWorkspace(") == std::string::npos,
+           "selection switches the workspace through the overview's owning monitor");
     expect(fullRender.find("Hyprexpo::shouldShowWorkspaceLabel(") != std::string::npos,
            "runtime label rendering uses modern label_enable and label_show policy in every grid mode");
     expect(fullRender.find("if (!closing && (**PLABELEN || **PSELECTEN || showWorkspaceNumbers))") != std::string::npos,

--- a/tests/OverviewSourceTests.cpp
+++ b/tests/OverviewSourceTests.cpp
@@ -169,6 +169,25 @@ int main() {
     expect(toggleBlock.find("openOverviews(ALL_MONITORS);") != std::string::npos && toggleBlock.find("closeOverviews(false);") != std::string::npos,
            "toggle all preserves close-when-any-open semantics");
 
+    const auto selectStart = expoDispatcher.find("if (arg == \"select\")");
+    const auto bringStart  = expoDispatcher.find("if (arg == \"bring\")", selectStart);
+    const auto toggleAfterBring = expoDispatcher.find("if (arg == \"toggle\")", bringStart);
+    const auto selectBlock = selectStart == std::string::npos || bringStart == std::string::npos ? std::string{} : expoDispatcher.substr(selectStart, bringStart - selectStart);
+    const auto bringBlock  = bringStart == std::string::npos || toggleAfterBring == std::string::npos ? std::string{} : expoDispatcher.substr(bringStart, toggleAfterBring - bringStart);
+    expect(selectBlock.find("overviewForGlobalPoint(") != std::string::npos && selectBlock.find("activeOverview()") == std::string::npos,
+           "pointer select resolves the overview under the cursor instead of keyboard ownership");
+    expect(bringBlock.find("overviewForGlobalPoint(") != std::string::npos && bringBlock.find("activeOverview()") == std::string::npos,
+           "pointer bring resolves the overview under the cursor instead of keyboard ownership");
+    expect(bringBlock.find("const auto DESTINATION = OV->pMonitor.lock();") != std::string::npos &&
+               bringBlock.find("bringWindowFromWorkspace(OV->selectedWorkspaceID(), DESTINATION)") != std::string::npos,
+           "bring passes the cursor overview's monitor as the explicit destination");
+
+    const auto bringWindow = extractFunction(dispatchersSource, "static SDispatchResult bringWindowFromWorkspace(int64_t sourceWorkspaceID, const PHLMONITOR& destinationMonitor) {");
+    expect(!bringWindow.empty() && bringWindow.find("destinationMonitor->m_activeWorkspace") != std::string::npos,
+           "bring moves onto the explicitly chosen cursor monitor workspace");
+    expect(bringWindow.find("focusState ? focusState->monitor()") == std::string::npos && bringWindow.find("State::monitorState()->query()") == std::string::npos,
+           "bring never recomputes its destination from keyboard focus or cursor fallback");
+
     const auto activeFunction = extractFunction(source, "COverview* activeOverview() {");
     expect(activeFunction.find("g_keyboardOverviewMonitor.lock()") != std::string::npos && activeFunction.find("overviewForMonitor(KEYBOARD)") != std::string::npos,
            "active overview honors a persistent explicit keyboard owner before compositor focus");
@@ -324,6 +343,8 @@ int main() {
            "keyboard guide documents explicit ownership and local-wrap precedence");
     expect(dispatcherDocs.find("fills any missing monitor overviews") != std::string::npos && dispatcherDocs.find("closes every open overview") != std::string::npos,
            "dispatcher reference distinguishes idempotent enabling from toggle close and peer dismissal");
+    expect(dispatcherDocs.find("monitor under the pointer") != std::string::npos,
+           "dispatcher reference identifies cursor ownership for pointer select and bring");
 
     if (failures != 0)
         return 1;

--- a/tests/OverviewSourceTests.cpp
+++ b/tests/OverviewSourceTests.cpp
@@ -241,7 +241,7 @@ int main() {
     expect(interactionSource.find("activeOverview() != this") == std::string::npos,
            "settle timer liveness never depends on whichever overview currently owns keyboard input");
 
-    const auto redrawTimer = extractFunction(interactionSource, "void COverview::redrawDraggedWindowTile(int id) {");
+    const auto redrawTimer = extractFunction(interactionSource, "void COverview::redrawDraggedWorkspace(int64_t workspaceID) {");
     expect(redrawTimer.find("[this]") == std::string::npos,
            "settle timer callbacks never capture a raw overview pointer");
     expect(redrawTimer.find("const auto OVERVIEWKEY = overviewMonitorKey(") != std::string::npos && redrawTimer.find("[OVERVIEWKEY]") != std::string::npos &&
@@ -249,6 +249,8 @@ int main() {
            "settle timer callbacks re-resolve their overview by stable monitor key on every tick");
     expect(redrawTimer.find("OVERVIEW->redrawSettleTimer.get() != self.get()") != std::string::npos,
            "a timer cannot mutate a replacement overview registered on the same monitor");
+    expect(redrawTimer.find("settlingRedrawWorkspaceIDs") != std::string::npos && redrawTimer.find("OVERVIEW->tileForWorkspaceID(workspaceID)") != std::string::npos,
+           "every settle tick re-resolves the queued workspace identity to its current tile");
 
     const auto overviewDestructor = extractFunction(source, "COverview::~COverview() {");
     const auto cancelTimerPos     = overviewDestructor.find("redrawSettleTimer->cancel();");
@@ -273,8 +275,18 @@ int main() {
            "release rejects a target workspace that does not belong to the target overview monitor");
     expect(countOccurrences(finishDrag, "moveWindowToWorkspace(") == 1,
            "validated release moves the window exactly once");
-    expect(finishDrag.find("SOURCEOV->redrawDraggedWindowTile(") != std::string::npos && finishDrag.find("TARGETOV->redrawDraggedWindowTile(") != std::string::npos,
-           "source and destination thumbnails refresh independently");
+    const auto moveWindowPos    = finishDrag.find("moveWindowToWorkspace(");
+    const auto settleWindowPos  = finishDrag.find("settleWorkspaceMoveAnimation(", moveWindowPos);
+    const auto sourceCapturePos = finishDrag.find("SOURCEOV->redrawDraggedWorkspace(SOURCEWORKSPACEID)", settleWindowPos);
+    const auto targetCapturePos = finishDrag.find("TARGETOV->redrawDraggedWorkspace(TARGETWORKSPACEID)", settleWindowPos);
+    expect(moveWindowPos != std::string::npos && settleWindowPos != std::string::npos && sourceCapturePos != std::string::npos && targetCapturePos != std::string::npos &&
+               moveWindowPos < settleWindowPos && settleWindowPos < sourceCapturePos && settleWindowPos < targetCapturePos,
+           "source and destination workspace identities queue independent recaptures only after move animations settle");
+    expect(headerSource.find("settlingRedrawWorkspaceIDs") != std::string::npos && headerSource.find("settlingRedrawIDs") == std::string::npos,
+           "settled recapture state stores workspace identities instead of stale tile indices");
+    const auto flushRedraws = extractFunction(interactionSource, "void COverview::flushQueuedRedraws() {");
+    expect(flushRedraws.find("MON->scheduleFrame();") != std::string::npos,
+           "every completed framebuffer recapture schedules a compositor frame");
     expect(finishDrag.find("\"left_ptr\"") == std::string::npos,
            "release cannot restore the cursor outside centralized reset");
 

--- a/tests/OverviewSourceTests.cpp
+++ b/tests/OverviewSourceTests.cpp
@@ -196,8 +196,27 @@ int main() {
            "central drag reset clears pure state, restores left_ptr, and damages affected live monitors");
     const auto destroyOne = extractFunction(source, "void destroyOverview(COverview* overview) {");
     const auto destroyAll = extractFunction(source, "void destroyAllOverviews() {");
-    expect(destroyOne.find("resetOverviewDrag(") < destroyOne.find("std::erase_if("), "single-overview destruction resets drag before erasing ownership");
-    expect(destroyAll.find("resetOverviewDrag(") < destroyAll.find("g_overviews.clear();"), "all-overview destruction resets drag before clearing ownership");
+    const auto moveOwnerPos   = destroyOne.find("auto OWNER = std::move(*IT);");
+    const auto eraseSlotPos   = destroyOne.find("g_overviews.erase(IT);");
+    const auto destroyOwnerPos = destroyOne.find("OWNER.reset();");
+    expect(destroyOne.find("resetOverviewDrag(") < moveOwnerPos, "single-overview destruction resets drag before unregistering ownership");
+    expect(moveOwnerPos != std::string::npos && eraseSlotPos != std::string::npos && destroyOwnerPos != std::string::npos && moveOwnerPos < eraseSlotPos && eraseSlotPos < destroyOwnerPos,
+           "single-overview teardown unregisters the moved owner before its cursor-restoring destructor runs");
+    const auto swapRegistryPos = destroyAll.find("OWNERS.swap(g_overviews);");
+    const auto clearOwnersPos  = destroyAll.find("OWNERS.clear();");
+    expect(destroyAll.find("resetOverviewDrag(") < swapRegistryPos && swapRegistryPos < clearOwnersPos,
+           "all-overview teardown empties the registry before any owner destructor runs");
+
+    const auto byAnimVar  = extractFunction(source, "COverview* overviewForAnimVar(");
+    const auto byMonitor  = extractFunction(source, "COverview* overviewForMonitor(");
+    const auto byKey      = extractFunction(source, "COverview* overviewForMonitorKey(");
+    const auto byPoint    = extractFunction(source, "COverview* overviewForGlobalPoint(");
+    expect(byAnimVar.find("if (!OV)") < byAnimVar.find("OV->ownsAnimVar("), "animation-owner lookup skips null registry slots before dereference");
+    expect(byMonitor.find("if (!OV)") < byMonitor.find("OV->pMonitor"), "monitor lookup skips null registry slots before dereference");
+    expect(byKey.find("if (!OV)") < byKey.find("OV->pMonitor"), "monitor-key lookup skips null registry slots before dereference");
+    expect(byPoint.find("if (!OV)") < byPoint.find("OV->pMonitor"), "point lookup skips null registry slots before dereference");
+    expect(source.find("if (OV)\n            snapshot.push_back(OV.get());") != std::string::npos,
+           "safe registry snapshots never publish null overview pointers");
     expect(interactionSource.find("overviewRegistered(this)") != std::string::npos && interactionSource.find("activeOverview() != this") == std::string::npos,
            "settle timer liveness uses exact registry membership instead of active ownership");
 

--- a/tests/OverviewSourceTests.cpp
+++ b/tests/OverviewSourceTests.cpp
@@ -92,9 +92,9 @@ int main() {
            "drag/drop enable configuration is registered");
     expect(source.find("plugin:hyprexpo:drag_drop_enable") != std::string::npos,
            "drag/drop enable configuration has a compatibility default");
-    expect(source.find("if (**PDRAGDROPENABLE)\n                beginWindowDrag();") != std::string::npos,
+    expect(source.find("if (**PDRAGDROPENABLE && TARGET)\n                TARGET->beginWindowDrag();") != std::string::npos,
            "drag/drop enable configuration gates drag start");
-    expect(source.find("if (**PDRAGDROPENABLE && finishWindowDrag())") != std::string::npos,
+    expect(source.find("if (**PDRAGDROPENABLE && SOURCE)") != std::string::npos && source.find("SOURCE->finishWindowDrag()") != std::string::npos,
            "drag/drop enable configuration gates drag completion");
 
     const auto dispatchersSource = readFile("Dispatchers.cpp");

--- a/tests/OverviewSourceTests.cpp
+++ b/tests/OverviewSourceTests.cpp
@@ -194,6 +194,8 @@ int main() {
     expect(!resetDrag.empty(), "registry provides one centralized idempotent drag reset");
     expect(resetDrag.find("transitionOverviewDrag(") != std::string::npos && resetDrag.find("\"left_ptr\"") != std::string::npos && resetDrag.find("damageMonitor") != std::string::npos,
            "central drag reset clears pure state, restores left_ptr, and damages affected live monitors");
+    expect(resetDrag.find("liveOverviewMonitorKeys()") != std::string::npos,
+           "central reset always supplies current registry liveness when a monitor weak reference has expired");
     const auto destroyOne = extractFunction(source, "void destroyOverview(COverview* overview) {");
     const auto destroyAll = extractFunction(source, "void destroyAllOverviews() {");
     const auto moveOwnerPos   = destroyOne.find("auto OWNER = std::move(*IT);");

--- a/tests/RegistryTeardownTests.cpp
+++ b/tests/RegistryTeardownTests.cpp
@@ -1,0 +1,192 @@
+// The overview registry teardown hazard, reduced to plain C++ so it runs
+// without a compositor.
+//
+// ~COverview() is not passive: it resets the cursor override, Hyprland
+// re-sends the cursor shape, that damages the monitor, and the damage comes
+// straight back into the plugin through hkAddDamage -> overviewForMonitor(),
+// which walks g_overviews. So the registry must already be consistent before
+// any COverview destructor runs.
+//
+// Two teardown strategies do NOT give you that:
+//
+//   std::erase_if(g_overviews, ...) runs std::remove_if first, which
+//   move-assigns the unique_ptrs. unique_ptr's move-assignment releases the
+//   source, stores the new pointer, and only then deletes the old object. So
+//   the destructor runs while the vector still has its old size and holds a
+//   released (null) slot. The pre-fix overviewForMonitor() dereferenced that
+//   slot -- that is the reported SIGSEGV in
+//   CWeakPointer<CMonitor>::operator==.
+//
+//   g_overviews.clear() destroys the elements before it drops the size, so a
+//   destructor sees a fully populated registry of already-destroyed objects.
+//
+// The lookup below deliberately never dereferences a slot, so these cases are
+// safe to execute; it only reports what state the registry was in. That is
+// enough to pin the invariant.
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace {
+
+int failures = 0;
+
+void expect(bool condition, const std::string& label) {
+    if (condition)
+        return;
+
+    ++failures;
+    std::cerr << "FAIL: " << label << '\n';
+}
+
+struct Node;
+
+// Stands in for g_overviews.
+std::vector<std::unique_ptr<Node>> g_registry;
+
+// What the re-entrant lookup saw the last time a destructor triggered it.
+struct SObservation {
+    bool   ran          = false;
+    size_t reportedSize = 0;
+    int    nullSlots    = 0;
+    int    liveSlots    = 0;
+    bool   sawDyingNode = false;
+};
+
+SObservation g_observed;
+Node*        g_dying = nullptr;
+
+void reentrantLookup();
+
+struct Node {
+    explicit Node(int id_) : id(id_) {}
+
+    ~Node() {
+        // Stands in for unsetOverride() -> cursor re-send -> damage -> hook.
+        g_dying = this;
+        reentrantLookup();
+        g_dying = nullptr;
+    }
+
+    int id = 0;
+};
+
+// Stands in for overviewForMonitor(). Never dereferences a slot: inspecting
+// the slot state is all we need, and it keeps the hazard cases executable.
+void reentrantLookup() {
+    g_observed              = SObservation{};
+    g_observed.ran          = true;
+    g_observed.reportedSize = g_registry.size();
+
+    for (const auto& entry : g_registry) {
+        if (!entry) {
+            ++g_observed.nullSlots;
+            continue;
+        }
+        ++g_observed.liveSlots;
+        if (entry.get() == g_dying)
+            g_observed.sawDyingNode = true;
+    }
+}
+
+void seedRegistry(int count) {
+    g_registry.clear();
+    g_observed = SObservation{};
+    for (int i = 0; i < count; ++i)
+        g_registry.push_back(std::make_unique<Node>(i));
+    g_observed = SObservation{};
+}
+
+// The pre-fix destroyOverview().
+void destroyWithEraseIf(Node* node) {
+    std::erase_if(g_registry, [node](const auto& entry) { return entry.get() == node; });
+}
+
+// The shipped destroyOverview(): unregister the owner, then release it.
+void destroyDetachFirst(Node* node) {
+    const auto IT = std::find_if(g_registry.begin(), g_registry.end(), [node](const auto& entry) { return entry && entry.get() == node; });
+    if (IT == g_registry.end())
+        return;
+
+    auto OWNER = std::move(*IT);
+    g_registry.erase(IT);
+    OWNER.reset();
+}
+
+// The pre-fix destroyAllOverviews().
+void destroyAllWithClear() {
+    g_registry.clear();
+}
+
+// The shipped destroyAllOverviews().
+void destroyAllSwapFirst() {
+    std::vector<std::unique_ptr<Node>> OWNERS;
+    OWNERS.swap(g_registry);
+    OWNERS.clear();
+}
+
+} // namespace
+
+int main() {
+    // --- single teardown, the path that actually crashed --------------------
+    // Remove a middle element so remove_if has later elements to shift down;
+    // removing the last one never move-assigns and would hide the bug.
+    seedRegistry(4);
+    destroyWithEraseIf(g_registry[1].get());
+    expect(g_observed.ran, "erase_if runs the destructor re-entrantly");
+    expect(g_observed.nullSlots > 0, "erase_if lets the destructor observe a released registry slot");
+    expect(g_observed.reportedSize == 4, "erase_if has not shrunk the registry when the destructor runs");
+
+    seedRegistry(4);
+    destroyDetachFirst(g_registry[1].get());
+    expect(g_observed.ran, "detach-first still runs the destructor re-entrantly");
+    expect(g_observed.nullSlots == 0, "detach-first never exposes a released registry slot");
+    expect(!g_observed.sawDyingNode, "detach-first unregisters the owner before its destructor runs");
+    expect(g_observed.reportedSize == 3, "detach-first shrinks the registry before the destructor runs");
+    expect(g_registry.size() == 3, "detach-first leaves the surviving entries behind");
+    expect(g_registry[0]->id == 0 && g_registry[1]->id == 2 && g_registry[2]->id == 3, "detach-first preserves the order of the survivors");
+
+    // Removing the only entry must still unregister before destroying.
+    seedRegistry(1);
+    destroyDetachFirst(g_registry[0].get());
+    expect(g_observed.reportedSize == 0 && g_observed.nullSlots == 0, "detach-first empties the registry before the last owner is released");
+    expect(g_registry.empty(), "detach-first removes the last entry");
+
+    // Destroying something that is not registered must be a no-op.
+    seedRegistry(2);
+    auto stray = std::make_unique<Node>(99);
+    destroyDetachFirst(stray.get());
+    expect(g_registry.size() == 2, "detach-first ignores a node that is not in the registry");
+    stray.reset();
+
+    // --- bulk teardown ------------------------------------------------------
+    seedRegistry(3);
+    destroyAllWithClear();
+    expect(g_observed.ran, "clear() runs destructors re-entrantly");
+    // How much of the registry is still visible part-way through clear() is
+    // unspecified -- libstdc++ destroys the elements before it drops the size,
+    // and ~unique_ptr nulls its slot after running the deleter. Assert only
+    // that the registry is still reachable at all, which is the actual hazard;
+    // the exact counts are a libstdc++ characterisation, not a guarantee.
+    expect(g_observed.reportedSize > 0 || g_observed.sawDyingNode, "clear() can still expose the registry while destructors run");
+
+    seedRegistry(3);
+    destroyAllSwapFirst();
+    expect(g_observed.ran, "swap-first still runs destructors re-entrantly");
+    expect(g_observed.reportedSize == 0, "swap-first empties the registry before any destructor runs");
+    expect(g_observed.nullSlots == 0, "swap-first never exposes a released registry slot");
+    expect(g_registry.empty(), "swap-first leaves the registry empty");
+
+    if (failures > 0) {
+        std::cerr << "RegistryTeardownTests failed with " << failures << " error(s)\n";
+        return EXIT_FAILURE;
+    }
+
+    std::cout << "RegistryTeardownTests passed\n";
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
**Superseded by #114.** The release-compatible reconstruction preserves this PR's complete multi-monitor and interaction work, with contributor attribution, on the reverted release base. This contributor-owned branch remains unchanged at `602ab69`; the replacement passed tests and exact Hyprland v0.56.1/v0.56.2 builds. Recovery tracking: #113.

---

Resolves #97

## Summary

Append `all` to an expo command to open one overview per monitor:

```ini
bind = SUPER, g, hyprexpo:expo, toggle all
```

- Preserve the contributor foundation: usable multi-output nested harness, per-monitor overview registry, and all-monitor command parsing.
- Make `on all` / `enable all` fill missing monitor overviews; keep `toggle all` close semantics.
- Move keyboard focus across physical monitor boundaries using global tile geometry after local movement fails. Local wrap settings retain precedence.
- Apply selection only on the monitor that owns it, then dismiss every peer without changing peer workspaces.
- Move windows between workspace tiles on different monitors with one registry-owned drag session, target-local proxy rendering, exact target-monitor validation, and one idempotent cleanup path.
- Route pointer `select` / `bring` through the monitor under the cursor.
- Harden teardown against registry re-entry, expired monitors, settle-timer UAF, and stale framebuffer recapture.
- Update multi-monitor, keyboard, and dispatcher documentation; previous keyboard/drag limitations no longer apply.

## Contributor history

The original three commits remain intact and reviewable:

1. `409abcb` - nested development session support
2. `d36abe7` - per-monitor overview registry
3. `6b08706` - all-monitor dispatcher mode

Maintainer follow-ups are TDD RED/GREEN commits on top; no contributor commit was rewritten.

## Validation

- `make test`
- Hyprland 0.56.1 forced plugin build
- `npm --prefix docs run docs:build`
- `git diff --check`
- Independent code review: approved, zero findings at `7275582`
- Contributor ancestry and zero-merge guards pass
- Current-master merge tree: `bb1e46f1706289d6fb57988f1adf641aed5ad6ed`

## Runtime proof

- Fresh two-output session reran the former keyboard-close crash sequence: single `on`, expand `on all`, cross right, confirm. Workspace 11 changed to 10 on monitor 1; monitor 0 stayed on 1; all overviews closed cleanly.
- `toggle all` open/close preserved both monitor workspaces.
- Real press/move/release moved `hyprexpo-source` exactly once from workspace 1 / monitor 0 to workspace 10 / monitor 1; overview stayed open for continued interaction and cursor cleanup completed.
- Post-drop source and destination previews match a full close/reopen recapture pixel-for-pixel: AE=0 and RMSE=0 for both crops. Visual verdict: 97/100.
- Fresh single-output session passed `on all`, keyboard selection, toggle, cancel, submap restoration, clean config, and clean unload.

<!-- visual-proof:start -->
## Visual proof

Captured from PR head [`707012ac5f15b3090054faec26b08423a0356cc7`](https://github.com/sandwichfarm/hyprexpo/commit/707012ac5f15b3090054faec26b08423a0356cc7). Nested Hyprland 0.56.1; runtime/client ABI commit 5c9377c15f85c50648f35ca5a213754f95b93ca0.

This evidence shows simultaneous overviews on two monitors.

![Screenshot showing simultaneous HyprExpo workspace overviews open on two monitors](https://raw.githubusercontent.com/sandwichfarm/hyprexpo/4253cbbbdb971b3b0eb7bbd068a4ccff29217326/pr-visual-proofs/2026-09-02/pr-103-all-monitors.png)

[Watch the WebM proof](https://raw.githubusercontent.com/sandwichfarm/hyprexpo/4253cbbbdb971b3b0eb7bbd068a4ccff29217326/pr-visual-proofs/2026-09-02/pr-103-all-monitors.webm)
<!-- visual-proof:end -->
