### PR TITLE
Fix center-current grid bounds

### DIFF
--- a/HyprexpoLogic.cpp
+++ b/HyprexpoLogic.cpp
@@ -162,6 +162,27 @@ int gridColumnsToIncludeWorkspace(int configuredColumns, int firstWorkspaceID, i
     return cols;
 }
 
+std::size_t centeredWorkspaceBacktrack(std::size_t tileCount, int64_t activeWorkspaceID, std::optional<int64_t> lowestExistingID,
+                                       std::optional<int64_t> highestExistingID) {
+    if (tileCount == 0)
+        return 0;
+
+    const std::size_t centerTarget = tileCount / 2;
+    if (!lowestExistingID || !highestExistingID)
+        return centerTarget > 0 ? centerTarget - 1 : 0;
+    if (*lowestExistingID > *highestExistingID || activeWorkspaceID < *lowestExistingID || activeWorkspaceID > *highestExistingID)
+        return centerTarget;
+
+    const __int128 lastOffset      = static_cast<__int128>(tileCount - 1);
+    const __int128 roomBefore      = static_cast<__int128>(activeWorkspaceID) - static_cast<__int128>(*lowestExistingID);
+    const __int128 roomAfter       = static_cast<__int128>(*highestExistingID) - static_cast<__int128>(activeWorkspaceID);
+    const __int128 maxBacktrack    = std::min(lastOffset, roomBefore);
+    const __int128 minBacktrack    = std::max<__int128>(0, lastOffset - roomAfter);
+    const __int128 boundedTarget   = std::min(maxBacktrack, std::max(static_cast<__int128>(centerTarget), minBacktrack));
+
+    return static_cast<std::size_t>(boundedTarget);
+}
+
 int tileIndexFromPoint(double x, double y, double width, double height, int sideLength) {
     if (width <= 0 || height <= 0 || sideLength <= 0)
         return -1;

--- a/HyprexpoLogic.hpp
+++ b/HyprexpoLogic.hpp
@@ -107,6 +107,8 @@ int                      tileIndexAtPoint(double x, double y, int visibleCount, 
 
 int                      clampGridColumns(int columns);
 int                      gridColumnsToIncludeWorkspace(int configuredColumns, int firstWorkspaceID, int activeWorkspaceID, int maxColumns);
+std::size_t              centeredWorkspaceBacktrack(std::size_t tileCount, int64_t activeWorkspaceID, std::optional<int64_t> lowestExistingID,
+                                                    std::optional<int64_t> highestExistingID);
 int                      tileIndexFromPoint(double x, double y, double width, double height, int sideLength);
 int                      numberKeyToVisibleIndex(int number);
 ENumberKeyMode           numberKeyModeFromString(const std::string& mode);

--- a/Overview.cpp
+++ b/Overview.cpp
@@ -39,6 +39,7 @@
 #include <cctype>
 #include <chrono>
 #include <cmath>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -796,6 +797,19 @@ COverview::COverview(PHLWORKSPACE startedOn_, bool swipe_) : startedOn(startedOn
         int currentID = methodStartID;
         int firstID   = currentID;
 
+        std::optional<int64_t> lowestExistingID;
+        std::optional<int64_t> highestExistingID;
+        if (!skipEmpty) {
+            for (const auto& workspace : State::workspaceState()->workspacesCopy()) {
+                if (!workspace || workspace->m_isSpecialWorkspace || workspace->m_monitor != PMONITOR)
+                    continue;
+
+                lowestExistingID  = lowestExistingID ? std::min(*lowestExistingID, workspace->m_id) : workspace->m_id;
+                highestExistingID = highestExistingID ? std::max(*highestExistingID, workspace->m_id) : workspace->m_id;
+            }
+        }
+
+        const size_t backtrackTarget = Hyprexpo::centeredWorkspaceBacktrack(images.size(), methodStartID, lowestExistingID, highestExistingID);
         int backtracked = 0;
 
         // Initialize tiles to WORKSPACE_INVALID; cliking one of these results
@@ -806,7 +820,7 @@ COverview::COverview(PHLWORKSPACE startedOn_, bool swipe_) : startedOn(startedOn
         }
 
         // Scan through workspaces lower than methodStartID until we wrap; count how many
-        for (size_t i = 1; i < images.size() / 2; ++i) {
+        for (size_t i = 1; i <= backtrackTarget; ++i) {
             currentID = getWorkspaceIDNameFromString(selector + "-" + std::to_string(i)).id;
             if (currentID >= firstID)
                 break;

--- a/tests/HyprexpoLogicTests.cpp
+++ b/tests/HyprexpoLogicTests.cpp
@@ -169,6 +169,18 @@ int main() {
     expect(gridColumnsToIncludeWorkspace(3, 5, 4, 7) == 3, "first-anchor grid never shrinks for an active workspace before the anchor");
     expect(gridColumnsToIncludeWorkspace(3, 1, 1000, 7) == 7, "first-anchor grid is capped at the max columns as a best effort");
     expect(gridColumnsToIncludeWorkspace(5, 1, 4, 7) == 5, "first-anchor grid never shrinks below the configured columns");
+
+    expect(centeredWorkspaceBacktrack(9, 1, 1, 9) == 0, "center-current keeps the low workspace at the first tile");
+    expect(centeredWorkspaceBacktrack(9, 5, 1, 9) == 4, "center-current places the middle workspace at the center tile");
+    expect(centeredWorkspaceBacktrack(9, 9, 1, 9) == 8, "center-current slides the high workspace back inside the real bounds");
+    expect(centeredWorkspaceBacktrack(9, 11, 11, 19) == 0, "center-current supports a shifted range at its low workspace");
+    expect(centeredWorkspaceBacktrack(9, 15, 11, 19) == 4, "center-current supports a shifted range at its middle workspace");
+    expect(centeredWorkspaceBacktrack(9, 19, 11, 19) == 8, "center-current supports a shifted range at its high workspace");
+    expect(centeredWorkspaceBacktrack(9, 5, std::nullopt, std::nullopt) == 3, "skip-empty 3x3 traversal preserves its three predecessor queries");
+    expect(centeredWorkspaceBacktrack(0, 5, 1, 9) == 0, "center-current handles an empty tile set");
+    expect(centeredWorkspaceBacktrack(9, 5, 9, 1) == 4, "center-current ignores reversed bounds safely");
+    expect(centeredWorkspaceBacktrack(9, std::numeric_limits<int64_t>::max(), std::numeric_limits<int64_t>::min(), std::numeric_limits<int64_t>::max()) == 8,
+           "center-current handles the full signed workspace range without overflow");
     expect(HyprexpoConfig::SHOW_PINNED_WINDOWS_DEFAULT == 0, "pinned windows are hidden from previews by default");
     expect(std::string{HyprexpoConfig::NUMBER_KEY_MODE_DEFAULT} == "workspace", "raw number keys keep selecting workspace IDs by default");
     expect(numberKeyModeFromString("workspace") == ENumberKeyMode::Workspace, "workspace number-key mode parses");

--- a/tests/OverviewSourceTests.cpp
+++ b/tests/OverviewSourceTests.cpp
@@ -192,6 +192,30 @@ int main() {
     expect(overviewConstructor.find("for (int64_t id = minID; id <= maxID; ++id)") == std::string::npos,
            "dynamic workspace enumeration has no unbounded min-to-max fill loop");
 
+    const auto centerBranchStart = overviewConstructor.find("} else if (methodCenter) {");
+    const auto centerBranchEnd   = overviewConstructor.find("\n    } else {", centerBranchStart);
+    const auto centerBranch      = centerBranchStart == std::string::npos || centerBranchEnd == std::string::npos ? std::string{} :
+                                                                                                                    overviewConstructor.substr(centerBranchStart, centerBranchEnd - centerBranchStart);
+    expect(!centerBranch.empty(), "center-current traversal branch exists");
+
+    const auto boundsGatePos = centerBranch.find("if (!skipEmpty)");
+    const auto boundsScanPos = centerBranch.find("State::workspaceState()->workspacesCopy()");
+    const auto helperPos     = centerBranch.find("Hyprexpo::centeredWorkspaceBacktrack(");
+    expect(boundsGatePos != std::string::npos && boundsScanPos != std::string::npos && boundsGatePos < boundsScanPos,
+           "regular workspace bounds are collected only for consecutive traversal");
+    expect(boundsScanPos != std::string::npos && centerBranch.find("!workspace", boundsScanPos) != std::string::npos,
+           "center-current bounds ignore null workspace entries");
+    expect(boundsScanPos != std::string::npos && centerBranch.find("workspace->m_isSpecialWorkspace", boundsScanPos) != std::string::npos,
+           "center-current bounds exclude special workspaces");
+    expect(boundsScanPos != std::string::npos && centerBranch.find("workspace->m_monitor != PMONITOR", boundsScanPos) != std::string::npos,
+           "center-current bounds exclude workspaces owned by other monitors");
+    expect(helperPos != std::string::npos && boundsScanPos != std::string::npos && boundsScanPos < helperPos,
+           "center-current traversal uses the pure backtrack helper after collecting bounds");
+    expect(centerBranch.find("for (size_t i = 1; i <= backtrackTarget; ++i)") != std::string::npos,
+           "center-current lower scan includes the full helper target");
+    expect(centerBranch.find("if (currentID >= firstID)") != std::string::npos && centerBranch.find("if (i > 0 && currentID <= firstID)") != std::string::npos,
+           "skip-empty center traversal retains lower and forward wrap guards");
+
     const auto renderSource = readFile("OverviewRender.cpp");
     expect(!renderSource.empty(), "OverviewRender.cpp can be read from repo root");
     const auto closeOverview = extractFunction(renderSource, "void COverview::close(bool switchToSelection) {");


### PR DESCRIPTION
Keep centered grids within the monitor-local workspace bounds while preserving skip-empty predecessor counting.

Reconstructed on the release-compatible master after #109 was reverted; retains the complete original feature change and the newer base submap/cancel-gesture fixes. PR #112 pins remain unchanged.

Validation: `make test`, all 16 pin ancestry checks, clean feature diff/ancestry, and forced shared-object builds against exact Hyprland v0.56.1 (`5c9377c`) and v0.56.2 (`efb5099`), with separate matching headers/artifacts. Added and removed feature lines match the original PR. No new physical-input or nested runtime session was run for this reconstruction.

Original head: `5c6778a5aaaa3e95b70561e7dfc847ed0c12db94`. Preserved at `backup/release-recovery-113/pr104`. Recovery tracking: #113.

Resolves #102.
