### PR TITLE
Keep pinned windows from cancelling close animation

### DIFF
--- a/HyprexpoLogic.cpp
+++ b/HyprexpoLogic.cpp
@@ -191,6 +191,10 @@ ENumberKeyMode numberKeyModeFromString(const std::string& mode) {
     return ENumberKeyMode::Workspace;
 }
 
+bool shouldAbortOverviewCloseForWorkspaceMove(bool windowPinned, bool movedOnOverviewMonitor) {
+    return !windowPinned && movedOnOverviewMonitor;
+}
+
 SDropIntentGeometry computeDropIntentGeometry(const SDropIntentInput& input) {
     SDropIntentGeometry geometry;
 

--- a/HyprexpoLogic.hpp
+++ b/HyprexpoLogic.hpp
@@ -110,6 +110,7 @@ int                      gridColumnsToIncludeWorkspace(int configuredColumns, in
 int                      tileIndexFromPoint(double x, double y, double width, double height, int sideLength);
 int                      numberKeyToVisibleIndex(int number);
 ENumberKeyMode           numberKeyModeFromString(const std::string& mode);
+bool                     shouldAbortOverviewCloseForWorkspaceMove(bool windowPinned, bool movedOnOverviewMonitor);
 SDropIntentGeometry      computeDropIntentGeometry(const SDropIntentInput& input);
 
 SGestureSyncDecision     evaluateGestureSync(const SGestureConfig& config);

--- a/OverviewInteraction.cpp
+++ b/OverviewInteraction.cpp
@@ -575,7 +575,7 @@ void COverview::onWindowMoveToWorkspace(const PHLWINDOW& window, const PHLWORKSP
         return;
 
     const bool movedOnOverviewMonitor = window->m_monitor == monitor || (window->m_workspace && window->m_workspace->m_monitor == monitor) || (workspace && workspace->m_monitor == monitor);
-    if (!movedOnOverviewMonitor)
+    if (!Hyprexpo::shouldAbortOverviewCloseForWorkspaceMove(window->m_pinned, movedOnOverviewMonitor))
         return;
 
     externalWorkspaceMoveDuringClose = true;

--- a/tests/HyprexpoLogicTests.cpp
+++ b/tests/HyprexpoLogicTests.cpp
@@ -170,6 +170,10 @@ int main() {
     expect(gridColumnsToIncludeWorkspace(3, 1, 1000, 7) == 7, "first-anchor grid is capped at the max columns as a best effort");
     expect(gridColumnsToIncludeWorkspace(5, 1, 4, 7) == 5, "first-anchor grid never shrinks below the configured columns");
     expect(HyprexpoConfig::SHOW_PINNED_WINDOWS_DEFAULT == 0, "pinned windows are hidden from previews by default");
+    expect(!shouldAbortOverviewCloseForWorkspaceMove(true, true), "pinned moves on the overview monitor preserve the close animation");
+    expect(shouldAbortOverviewCloseForWorkspaceMove(false, true), "non-pinned moves on the overview monitor abort the close animation");
+    expect(!shouldAbortOverviewCloseForWorkspaceMove(false, false), "non-pinned moves outside the overview monitor are ignored");
+    expect(!shouldAbortOverviewCloseForWorkspaceMove(true, false), "pinned moves outside the overview monitor are ignored");
     expect(std::string{HyprexpoConfig::NUMBER_KEY_MODE_DEFAULT} == "workspace", "raw number keys keep selecting workspace IDs by default");
     expect(numberKeyModeFromString("workspace") == ENumberKeyMode::Workspace, "workspace number-key mode parses");
     expect(numberKeyModeFromString(" INDEX ") == ENumberKeyMode::Index, "index number-key mode is case-insensitive and trimmed");

--- a/tests/OverviewSourceTests.cpp
+++ b/tests/OverviewSourceTests.cpp
@@ -166,6 +166,20 @@ int main() {
     expect(numberSelection.find("number_key_mode") == std::string::npos && numberSelection.find("numberKeyToVisibleIndex") == std::string::npos,
            "kb_selectn semantics do not depend on the raw number-key mode");
 
+    const auto workspaceMoveHandler = extractFunction(interactionSource, "void COverview::onWindowMoveToWorkspace(");
+    expect(!workspaceMoveHandler.empty(), "workspace-move close handler exists");
+    const auto monitorRelevancePos = workspaceMoveHandler.find("const bool movedOnOverviewMonitor");
+    const auto classifierPos       = workspaceMoveHandler.find("Hyprexpo::shouldAbortOverviewCloseForWorkspaceMove(window->m_pinned, movedOnOverviewMonitor)");
+    const auto abortFlagPos        = workspaceMoveHandler.find("externalWorkspaceMoveDuringClose = true;");
+    const auto workspaceDamagePos  = workspaceMoveHandler.find("damage();", abortFlagPos);
+    const auto scheduleFramePos    = workspaceMoveHandler.find("monitor->scheduleFrame();", workspaceDamagePos);
+    expect(monitorRelevancePos != std::string::npos && classifierPos != std::string::npos && monitorRelevancePos < classifierPos,
+           "workspace-move handler classifies pin state after computing monitor relevance");
+    expect(classifierPos != std::string::npos && abortFlagPos != std::string::npos && classifierPos < abortFlagPos,
+           "workspace-move handler rejects pinned events before mutating close state");
+    expect(abortFlagPos != std::string::npos && workspaceDamagePos != std::string::npos && scheduleFramePos != std::string::npos && abortFlagPos < workspaceDamagePos && workspaceDamagePos < scheduleFramePos,
+           "accepted external moves retain flag, damage, and frame scheduling in order");
+
     const auto numberDispatcher = extractFunction(dispatchersSource, "static SDispatchResult onKbSelectNumberDispatcher(std::string arg) {");
     const auto indexDispatcher  = extractFunction(dispatchersSource, "static SDispatchResult onKbSelectIndexDispatcher(std::string arg) {");
     expect(numberDispatcher.find("g_pOverview->onKbSelectNumber(num)") != std::string::npos,


### PR DESCRIPTION
Keep pinned-window move notifications from cancelling the overview close zoom, while preserving cancellation for relevant ordinary-window moves.

Reconstructed on the release-compatible master after #109 was reverted; retains the complete original feature change and the newer base submap/cancel-gesture fixes. PR #112 pins remain unchanged.

Validation: `make test`, all 16 pin ancestry checks, clean feature diff/ancestry, and forced shared-object builds against exact Hyprland v0.56.1 (`5c9377c`) and v0.56.2 (`efb5099`), with separate matching headers/artifacts. Added and removed feature lines match the original PR. No new physical-input or nested runtime session was run for this reconstruction.

Original head: `ab5fd0a976021de6336831007e440b1bde8ee296`. Preserved at `backup/release-recovery-113/pr105`. Recovery tracking: #113.

Resolves #94.
