### PR TITLE
Add an origin-preserving cancel gesture

### DIFF
--- a/Dispatchers.cpp
+++ b/Dispatchers.cpp
@@ -517,11 +517,13 @@ static SDispatchResult registerExpoGesture(int fingerCount, const std::string& d
 
     std::expected<void, std::string> result;
     if (action == "expo")
-        result = g_pTrackpadGestures->addGesture(makeUnique<CExpoGesture>(), fingerCount, direction, modMask, deltaScale, disableInhibit);
+        result = g_pTrackpadGestures->addGesture(makeUnique<CExpoGesture>(EExpoGestureAction::Expo), fingerCount, direction, modMask, deltaScale, disableInhibit);
+    else if (action == "cancel")
+        result = g_pTrackpadGestures->addGesture(makeUnique<CExpoGesture>(EExpoGestureAction::Cancel), fingerCount, direction, modMask, deltaScale, disableInhibit);
     else if (action == "unset")
         result = g_pTrackpadGestures->removeGesture(fingerCount, direction, modMask, deltaScale, disableInhibit);
     else
-        return {.success = false, .error = std::format("invalid action '{}', expected expo|unset", action)};
+        return {.success = false, .error = std::format("invalid action '{}', expected expo|cancel|unset", action)};
 
     if (!result)
         return {.success = false, .error = result.error()};

--- a/ExpoGesture.cpp
+++ b/ExpoGesture.cpp
@@ -13,6 +13,14 @@ void CExpoGesture::begin(const ITrackpadGesture::STrackpadGestureBegin& e) {
     m_lastDelta   = 0.F;
     m_firstUpdate = true;
 
+    if (m_action == EExpoGestureAction::Cancel) {
+        if (!g_pOverview || g_pOverview->closeCommitted())
+            return;
+
+        g_pOverview->setClosing(true);
+        return;
+    }
+
     const auto monitor = State::monitorState()->query().vec(g_pInputManager->getMouseCoordsInternal()).run();
     if (!monitor || !monitor->m_activeWorkspace)
         return;
@@ -47,7 +55,7 @@ void CExpoGesture::end(const ITrackpadGesture::STrackpadGestureEnd& e) {
         return;
 
     g_pOverview->setClosing(false);
-    g_pOverview->onSwipeEnd();
+    g_pOverview->onSwipeEnd(m_action == EExpoGestureAction::Expo);
     if (g_pOverview)
         g_pOverview->resetSwipe();
 }

--- a/ExpoGesture.cpp
+++ b/ExpoGesture.cpp
@@ -17,7 +17,7 @@ void CExpoGesture::begin(const ITrackpadGesture::STrackpadGestureBegin& e) {
         if (!g_pOverview || g_pOverview->closeCommitted())
             return;
 
-        g_pOverview->setClosing(true);
+        g_pOverview->beginCancelSwipe();
         return;
     }
 

--- a/ExpoGesture.hpp
+++ b/ExpoGesture.hpp
@@ -2,9 +2,14 @@
 
 #include <hyprland/src/managers/input/trackpad/gestures/ITrackpadGesture.hpp>
 
+enum class EExpoGestureAction {
+    Expo,
+    Cancel,
+};
+
 class CExpoGesture : public ITrackpadGesture {
   public:
-    CExpoGesture()          = default;
+    explicit CExpoGesture(EExpoGestureAction action) : m_action(action) {}
     virtual ~CExpoGesture() = default;
 
     virtual void begin(const ITrackpadGesture::STrackpadGestureBegin& e);
@@ -12,6 +17,7 @@ class CExpoGesture : public ITrackpadGesture {
     virtual void end(const ITrackpadGesture::STrackpadGestureEnd& e);
 
   private:
-    float m_lastDelta   = 0.F;
-    bool  m_firstUpdate = false;
+    const EExpoGestureAction m_action;
+    float                    m_lastDelta   = 0.F;
+    bool                     m_firstUpdate = false;
 };

--- a/Overview.hpp
+++ b/Overview.hpp
@@ -29,6 +29,7 @@ class COverview {
     void onPreRender();
 
     void setClosing(bool closing);
+    void beginCancelSwipe();
     // True once close() has armed the teardown animation. Further gestures must
     // be ignored until the overview is destroyed, otherwise a second swipe
     // rewinds the in-flight close animation (the close "replays" from ~80%).

--- a/Overview.hpp
+++ b/Overview.hpp
@@ -40,7 +40,7 @@ class COverview {
 
     void resetSwipe();
     void onSwipeUpdate(double delta);
-    void onSwipeEnd();
+    void onSwipeEnd(bool switchToSelection);
 
     // close without a selection
     void          close(bool switchToSelection = true);

--- a/OverviewInteraction.cpp
+++ b/OverviewInteraction.cpp
@@ -560,6 +560,11 @@ void COverview::setClosing(bool closing_) {
     closing = closing_;
 }
 
+void COverview::beginCancelSwipe() {
+    closeOnID = openedID;
+    closing   = true;
+}
+
 void COverview::onWindowMoveToWorkspace(const PHLWINDOW& window, const PHLWORKSPACE& workspace) {
     if (!closing || externalWorkspaceMoveDuringClose || !window)
         return;

--- a/OverviewInteraction.cpp
+++ b/OverviewInteraction.cpp
@@ -617,7 +617,7 @@ void COverview::onSwipeUpdate(double delta) {
     pos->setValueAndWarp(lerp(POSMIN, POSMAX, PERC));
 }
 
-void COverview::onSwipeEnd() {
+void COverview::onSwipeEnd(bool switchToSelection) {
     if (m_closeCommitted)
         return;
 
@@ -634,12 +634,12 @@ void COverview::onSwipeEnd() {
     const auto SIZEMAX = zoomSizeForCurrentGrid(MON->m_size);
     const auto span    = SIZEMAX - SIZEMIN;
     if (std::abs(span.x) <= 1e-6) {
-        close();
+        close(switchToSelection);
         return;
     }
     const auto PERC    = (size->value() - SIZEMIN).x / span.x;
     if (PERC > 0.5) {
-        close();
+        close(switchToSelection);
         return;
     }
     *size = MON->m_size;

--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -111,7 +111,7 @@ Pinned windows, including browser Picture-in-Picture windows, stay pinned and vi
 
 ### Trackpad gesture
 
-`gesture_fingers` and `gesture_direction` register the same interactive, follow-your-finger overview gesture that [`hl.plugin.hyprexpo.gesture{}`](../guides/lua-gestures.md) provides, but from plain config. Hyprland selects either hyprlang or Lua for the whole config and a `.lua` cannot be sourced from a `.conf`, so hyprlang users need this to reach the gesture at all.
+`gesture_fingers` and `gesture_direction` register the interactive, follow-your-finger `expo` gesture from plain config. They remain expo-only; registering the `cancel` action requires [`hl.plugin.hyprexpo.gesture{}`](../guides/lua-gestures.md) in a Lua config. Hyprland selects either hyprlang or Lua for the whole config and a `.lua` cannot be sourced from a `.conf`, so hyprlang users need these keys to reach the expo gesture at all.
 
 ```ini
 plugin {

--- a/docs/guides/lua-gestures.md
+++ b/docs/guides/lua-gestures.md
@@ -103,7 +103,20 @@ hl.plugin.hyprexpo.gesture({
     direction = "up",
     action = "expo",
 })
+
+hl.plugin.hyprexpo.gesture({
+    fingers = 4,
+    direction = "down",
+    action = "cancel",
+})
 ```
+
+The `expo` action keeps the existing follow-your-finger behavior: it opens the
+overview when closed, and an expo close gesture selects the hovered workspace.
+The `cancel` action is inert while the overview is closed. While it is open, a
+cancel swipe starts an interactive close without selecting the hovered tile. A
+completed cancel swipe returns to the workspace where the overview opened; an
+incomplete swipe restores the still-open overview.
 
 `gesture` accepts this table shape:
 
@@ -111,10 +124,13 @@ hl.plugin.hyprexpo.gesture({
 | --- | --- | --- | --- |
 | `fingers` | integer | yes | number of fingers |
 | `direction` | string | yes | swipe direction |
-| `action` | string | no | `expo` or `unset`; defaults to `expo` |
+| `action` | string | no | `expo`, `cancel`, or `unset`; defaults to `expo` |
 | `mods` | string | no | modifier expression passed to Hyprland |
 | `scale` | number | no | gesture scale; defaults to `1.0` |
 | `disable_inhibit` | boolean | no | whether to bypass inhibit handling |
+
+Use `unset` with the same fingers, direction, modifiers, scale, and inhibit
+settings to remove a registered gesture.
 
 ## Argument Validation
 

--- a/docs/guides/lua-gestures.md
+++ b/docs/guides/lua-gestures.md
@@ -116,7 +116,9 @@ overview when closed, and an expo close gesture selects the hovered workspace.
 The `cancel` action is inert while the overview is closed. While it is open, a
 cancel swipe starts an interactive close without selecting the hovered tile. A
 completed cancel swipe returns to the workspace where the overview opened; an
-incomplete swipe restores the still-open overview.
+incomplete swipe restores the still-open overview. Each cancel swipe targets
+the opening workspace again, including after an incomplete expo close was
+previously aimed at another tile.
 
 `gesture` accepts this table shape:
 

--- a/docs/guides/runtime-smoke.md
+++ b/docs/guides/runtime-smoke.md
@@ -27,22 +27,26 @@ Nested test binds:
 8. Drag that window preview over another valid workspace tile and confirm a positional landing proxy appears inside the hovered target tile.
 9. Move the pointer within the target tile and between target tiles; confirm the landing proxy tracks the pointer position, preserves the original grab offset, and disappears when hovering the source or an invalid target.
 10. Release on a target workspace and confirm the window still moves through the existing safe workspace move behavior. This release is not yet a positional layout insertion.
-11. Exercise the Lua gesture registration path and complete or cancel a swipe.
-12. Open or create a Picture-in-Picture-like pinned window. In the nested session, one practical path is to focus a test window and run `hyprctl dispatch pin` from a terminal.
-13. With the default `plugin:hyprexpo:show_pinned_windows = 0`, open overview and confirm the pinned window is not rendered into every workspace preview tile.
-14. Set `plugin:hyprexpo:show_pinned_windows = 1`, reload or apply the keyword, reopen overview, and confirm pinned windows render in previews again for users who opt in.
-15. Set `plugin:hyprexpo:show_pinned_windows = 0` again, close overview, and confirm the pinned window is still visible and pinned in the normal Hyprland session.
-16. Unload or reload the plugin after closing overview and confirm no stale render pass callback crashes the session.
+11. In Lua config, register distinct `expo` and `cancel` gestures (for example, four-finger up and four-finger down). With the overview closed, begin the cancel gesture and confirm it remains closed.
+12. Complete the expo gesture and confirm its existing open/select behavior is unchanged.
+13. From the workspace where the overview opened, hover a different tile and make a partial cancel swipe. Confirm the animation returns to the same still-open overview and the origin workspace has not changed.
+14. Repeat with a completed cancel swipe. Confirm the overview closes onto the origin workspace rather than the hovered tile.
+15. Open and complete cancel once more to catch stale swipe state. Confirm the origin workspace is unchanged, then inspect the nested compositor log for crashes, assertions, API/hash mismatches, and stale-callback errors.
+16. Open or create a Picture-in-Picture-like pinned window. In the nested session, one practical path is to focus a test window and run `hyprctl dispatch pin` from a terminal.
+17. With the default `plugin:hyprexpo:show_pinned_windows = 0`, open overview and confirm the pinned window is not rendered into every workspace preview tile.
+18. Set `plugin:hyprexpo:show_pinned_windows = 1`, reload or apply the keyword, reopen overview, and confirm pinned windows render in previews again for users who opt in.
+19. Set `plugin:hyprexpo:show_pinned_windows = 0` again, close overview, and confirm the pinned window is still visible and pinned in the normal Hyprland session.
+20. Unload or reload the plugin after closing overview and confirm no stale render pass callback crashes the session.
 
-17. Enable `dynamic_grid = 1`, then test with 1, 2, 3, and 5 non-empty, non-special workspaces. Confirm the overview contains exactly those workspaces without padded empty tiles.
-18. Confirm every preview preserves the monitor aspect ratio. For 3 and 5 workspaces, confirm the partial final row is independently centered.
-19. Set `label_pos = top_right`, choose a visible `label_size`, and toggle `show_workspace_names`. Confirm every label remains inside its corresponding tile.
-20. Toggle `wallpaper_bg` and reopen the overview. Confirm the wallpaper changes only the background and does not move or resize tiles.
-21. Toggle `mru_sort` and confirm the current workspace moves to the first tile only when enabled. Toggle `fill_gaps` with non-contiguous workspace IDs and confirm missing IDs are added only when enabled.
-22. With only one active workspace, complete and cancel a swipe. Confirm the overview exits cleanly without a crash or invalid animation state.
-23. With `dynamic_grid = 1`, leave the current workspace empty and open a window on a neighboring workspace. Open and close with `hyprexpo:expo, toggle`; confirm the current workspace does not change.
-24. With `dynamic_grid = 1` and `fill_gaps = 1`, create distant workspace IDs (for example 1 and 5000). Open the overview; confirm it rejects gap expansion, remains responsive, and shows only the sparse workspaces.
-25. With `dynamic_grid = 1`, set `label_enable = 0`, then `label_show = never`, and set modern `border_color_current` / `border_color_hover` values. Confirm labels stay hidden and the modern border colors win over legacy highlight values.
+21. Enable `dynamic_grid = 1`, then test with 1, 2, 3, and 5 non-empty, non-special workspaces. Confirm the overview contains exactly those workspaces without padded empty tiles.
+22. Confirm every preview preserves the monitor aspect ratio. For 3 and 5 workspaces, confirm the partial final row is independently centered.
+23. Set `label_pos = top_right`, choose a visible `label_size`, and toggle `show_workspace_names`. Confirm every label remains inside its corresponding tile.
+24. Toggle `wallpaper_bg` and reopen the overview. Confirm the wallpaper changes only the background and does not move or resize tiles.
+25. Toggle `mru_sort` and confirm the current workspace moves to the first tile only when enabled. Toggle `fill_gaps` with non-contiguous workspace IDs and confirm missing IDs are added only when enabled.
+26. With only one active workspace, complete and cancel a swipe. Confirm the overview exits cleanly without a crash or invalid animation state.
+27. With `dynamic_grid = 1`, leave the current workspace empty and open a window on a neighboring workspace. Open and close with `hyprexpo:expo, toggle`; confirm the current workspace does not change.
+28. With `dynamic_grid = 1` and `fill_gaps = 1`, create distant workspace IDs (for example 1 and 5000). Open the overview; confirm it rejects gap expansion, remains responsive, and shows only the sparse workspaces.
+29. With `dynamic_grid = 1`, set `label_enable = 0`, then `label_show = never`, and set modern `border_color_current` / `border_color_hover` values. Confirm labels stay hidden and the modern border colors win over legacy highlight values.
 
 ::: warning
 The public site and docs should not claim full release readiness until this runtime smoke gate has been completed for the intended release artifact.

--- a/docs/guides/runtime-smoke.md
+++ b/docs/guides/runtime-smoke.md
@@ -31,7 +31,7 @@ Nested test binds:
 12. Complete the expo gesture and confirm its existing open/select behavior is unchanged.
 13. From the workspace where the overview opened, hover a different tile and make a partial cancel swipe. Confirm the animation returns to the same still-open overview and the origin workspace has not changed.
 14. Repeat with a completed cancel swipe. Confirm the overview closes onto the origin workspace rather than the hovered tile.
-15. Open and complete cancel once more to catch stale swipe state. Confirm the origin workspace is unchanged, then inspect the nested compositor log for crashes, assertions, API/hash mismatches, and stale-callback errors.
+15. Open from the origin workspace, hover another tile, begin an expo close, and release below the completion threshold so the overview restores. Without changing the hovered tile, complete cancel and confirm its animation retargets the origin and closes there. Repeat open/completed-cancel once more to catch stale swipe state, then inspect the nested compositor log for crashes, assertions, API/hash mismatches, and stale-callback errors.
 16. Open or create a Picture-in-Picture-like pinned window. In the nested session, one practical path is to focus a test window and run `hyprctl dispatch pin` from a terminal.
 17. With the default `plugin:hyprexpo:show_pinned_windows = 0`, open overview and confirm the pinned window is not rendered into every workspace preview tile.
 18. Set `plugin:hyprexpo:show_pinned_windows = 1`, reload or apply the keyword, reopen overview, and confirm pinned windows render in previews again for users who opt in.

--- a/tests/OverviewSourceTests.cpp
+++ b/tests/OverviewSourceTests.cpp
@@ -92,6 +92,10 @@ int main() {
 
     const auto dispatchersSource = readFile("Dispatchers.cpp");
     expect(!dispatchersSource.empty(), "Dispatchers.cpp can be read from repo root");
+    const auto gestureHeader = readFile("ExpoGesture.hpp");
+    expect(!gestureHeader.empty(), "ExpoGesture.hpp can be read from repo root");
+    const auto gestureSource = readFile("ExpoGesture.cpp");
+    expect(!gestureSource.empty(), "ExpoGesture.cpp can be read from repo root");
     const auto expoDispatcher = extractFunction(dispatchersSource, "static SDispatchResult onExpoDispatcher(std::string arg) {");
     expect(!expoDispatcher.empty(), "expo dispatcher function exists");
 
@@ -187,11 +191,78 @@ int main() {
     const auto gestureSync = extractFunction(dispatchersSource, "void syncExpoGestureFromConfig(");
     expect(!gestureSync.empty(), "syncExpoGestureFromConfig exists");
     expect(gestureSync.find("g_unloading || g_gestureRegistrationDisabled") != std::string::npos, "gesture sync bails out while the plugin is unloading");
+    expect(gestureSync.find("registerExpoGesture(FINGERS, DIR, \"expo\"") != std::string::npos,
+           "plain config synchronization remains expo-only");
 
     const auto gestureRegister = extractFunction(dispatchersSource, "static SDispatchResult registerExpoGesture(");
     expect(!gestureRegister.empty(), "registerExpoGesture definition exists");
     expect(gestureRegister.find("g_unloading || g_gestureRegistrationDisabled") != std::string::npos,
            "every gesture registration path, including the Lua helper, is fenced during unload");
+    expect(gestureRegister.find("action == \"expo\"") != std::string::npos &&
+               gestureRegister.find("makeUnique<CExpoGesture>(EExpoGestureAction::Expo)") != std::string::npos,
+           "Lua expo registration constructs an explicit expo gesture");
+    expect(gestureRegister.find("action == \"cancel\"") != std::string::npos &&
+               gestureRegister.find("makeUnique<CExpoGesture>(EExpoGestureAction::Cancel)") != std::string::npos,
+           "Lua cancel registration constructs an explicit cancel gesture");
+    expect(gestureRegister.find("expected expo|cancel|unset") != std::string::npos,
+           "invalid Lua gesture actions report the complete accepted set");
+
+    expect(gestureHeader.find("enum class EExpoGestureAction") != std::string::npos,
+           "gesture action modes use an explicit enum");
+    expect(gestureHeader.find("CExpoGesture(EExpoGestureAction action)") != std::string::npos,
+           "gesture construction requires an explicit action");
+    expect(gestureHeader.find("\n    CExpoGesture()") == std::string::npos,
+           "gesture construction cannot silently default an action");
+    expect(gestureHeader.find("const EExpoGestureAction m_action") != std::string::npos,
+           "each gesture retains an immutable action mode");
+
+    const auto gestureBegin = extractFunction(gestureSource, "void CExpoGesture::begin(");
+    expect(!gestureBegin.empty(), "gesture begin function exists");
+    const auto cancelBeginStart = gestureBegin.find("if (m_action == EExpoGestureAction::Cancel)");
+    const auto monitorQueryStart = gestureBegin.find("const auto monitor", cancelBeginStart);
+    const auto cancelBeginBlock = cancelBeginStart == std::string::npos || monitorQueryStart == std::string::npos ? std::string{} :
+                                                                                                                  gestureBegin.substr(cancelBeginStart, monitorQueryStart - cancelBeginStart);
+    expect(cancelBeginBlock.find("!g_pOverview || g_pOverview->closeCommitted()") != std::string::npos,
+           "cancel begin is inert without a mutable overview");
+    expect(cancelBeginBlock.find("g_pOverview->setClosing(true)") != std::string::npos,
+           "cancel begin starts interactive closing for an open overview");
+    expect(cancelBeginBlock.find("selectHoveredWorkspace") == std::string::npos && cancelBeginBlock.find("make_unique<COverview>") == std::string::npos,
+           "cancel begin neither selects a hovered workspace nor creates an overview");
+    const auto expoBeginBlock = monitorQueryStart == std::string::npos ? std::string{} : gestureBegin.substr(monitorQueryStart);
+    expect(expoBeginBlock.find("std::make_unique<COverview>(monitor->m_activeWorkspace, true)") != std::string::npos &&
+               expoBeginBlock.find("g_pOverview->selectHoveredWorkspace()") != std::string::npos &&
+               expoBeginBlock.find("g_pOverview->setClosing(true)") != std::string::npos,
+           "expo begin retains open and hovered-selection close behavior");
+
+    const auto gestureEnd = extractFunction(gestureSource, "void CExpoGesture::end(");
+    expect(!gestureEnd.empty(), "gesture end function exists");
+    expect(gestureEnd.find("g_pOverview->setClosing(false)") != std::string::npos,
+           "gesture end clears transient closing before threshold evaluation");
+    expect(gestureEnd.find("g_pOverview->onSwipeEnd(m_action == EExpoGestureAction::Expo)") != std::string::npos,
+           "gesture completion selects only for the expo action");
+    expect(gestureEnd.find("if (g_pOverview)\n        g_pOverview->resetSwipe()") != std::string::npos,
+           "gesture completion retains the post-close reset guard");
+
+    const auto swipeEnd = extractFunction(interactionSource, "void COverview::onSwipeEnd(");
+    expect(!swipeEnd.empty(), "overview swipe-end function exists");
+    expect(swipeEnd.find("void COverview::onSwipeEnd(bool switchToSelection)") != std::string::npos,
+           "overview swipe completion accepts the selection decision");
+    const auto degenerateSpanStart = swipeEnd.find("if (std::abs(span.x) <= 1e-6)");
+    const auto thresholdStart = swipeEnd.find("if (PERC > 0.5)", degenerateSpanStart);
+    const auto incompleteStart = swipeEnd.find("*size = MON->m_size", thresholdStart);
+    const auto degenerateSpanBlock = degenerateSpanStart == std::string::npos || thresholdStart == std::string::npos ? std::string{} :
+                                                                                                                       swipeEnd.substr(degenerateSpanStart, thresholdStart - degenerateSpanStart);
+    const auto thresholdBlock = thresholdStart == std::string::npos || incompleteStart == std::string::npos ? std::string{} :
+                                                                                                               swipeEnd.substr(thresholdStart, incompleteStart - thresholdStart);
+    const auto incompleteBlock = incompleteStart == std::string::npos ? std::string{} : swipeEnd.substr(incompleteStart);
+    expect(degenerateSpanBlock.find("close(switchToSelection)") != std::string::npos &&
+               thresholdBlock.find("close(switchToSelection)") != std::string::npos,
+           "completed swipe paths forward the action-specific selection choice");
+    expect(incompleteBlock.find("*pos  = {0, 0}") != std::string::npos &&
+               incompleteBlock.find("swipeWasCommenced = true") != std::string::npos &&
+               incompleteBlock.find("m_isSwiping       = false") != std::string::npos &&
+               incompleteBlock.find("close(") == std::string::npos,
+           "incomplete swipe still resets animation state and leaves the overview open");
 
     const auto exitFunction = extractFunction(mainSource, "APICALL EXPORT void PLUGIN_EXIT(");
     expect(!exitFunction.empty(), "PLUGIN_EXIT exists");

--- a/tests/OverviewSourceTests.cpp
+++ b/tests/OverviewSourceTests.cpp
@@ -235,8 +235,9 @@ int main() {
     const auto cancelSwipeBegin = extractFunction(interactionSource, "void COverview::beginCancelSwipe(");
     expect(!cancelSwipeBegin.empty(), "overview cancel-begin transition exists");
     const auto resetCancelTarget = cancelSwipeBegin.find("closeOnID = openedID");
-    const auto startCancelClose  = cancelSwipeBegin.find("closing = true", resetCancelTarget);
-    expect(resetCancelTarget != std::string::npos && startCancelClose != std::string::npos && resetCancelTarget < startCancelClose,
+    const auto startCancelClose  = cancelSwipeBegin.find("closing", resetCancelTarget);
+    const auto enableCancelClose = cancelSwipeBegin.find("= true", startCancelClose);
+    expect(resetCancelTarget != std::string::npos && startCancelClose != std::string::npos && enableCancelClose != std::string::npos && resetCancelTarget < startCancelClose,
            "cancel begin replaces any aborted expo target with the opening workspace before closing");
     const auto expoBeginBlock = monitorQueryStart == std::string::npos ? std::string{} : gestureBegin.substr(monitorQueryStart);
     expect(expoBeginBlock.find("std::make_unique<COverview>(monitor->m_activeWorkspace, true)") != std::string::npos &&

--- a/tests/OverviewSourceTests.cpp
+++ b/tests/OverviewSourceTests.cpp
@@ -96,6 +96,8 @@ int main() {
     expect(!gestureHeader.empty(), "ExpoGesture.hpp can be read from repo root");
     const auto gestureSource = readFile("ExpoGesture.cpp");
     expect(!gestureSource.empty(), "ExpoGesture.cpp can be read from repo root");
+    const auto overviewHeader = readFile("Overview.hpp");
+    expect(!overviewHeader.empty(), "Overview.hpp can be read from repo root");
     const auto expoDispatcher = extractFunction(dispatchersSource, "static SDispatchResult onExpoDispatcher(std::string arg) {");
     expect(!expoDispatcher.empty(), "expo dispatcher function exists");
 
@@ -224,10 +226,18 @@ int main() {
                                                                                                                   gestureBegin.substr(cancelBeginStart, monitorQueryStart - cancelBeginStart);
     expect(cancelBeginBlock.find("!g_pOverview || g_pOverview->closeCommitted()") != std::string::npos,
            "cancel begin is inert without a mutable overview");
-    expect(cancelBeginBlock.find("g_pOverview->setClosing(true)") != std::string::npos,
-           "cancel begin starts interactive closing for an open overview");
+    expect(cancelBeginBlock.find("g_pOverview->beginCancelSwipe()") != std::string::npos,
+           "cancel begin delegates target reset and interactive closing to the overview");
     expect(cancelBeginBlock.find("selectHoveredWorkspace") == std::string::npos && cancelBeginBlock.find("make_unique<COverview>") == std::string::npos,
            "cancel begin neither selects a hovered workspace nor creates an overview");
+    expect(overviewHeader.find("void beginCancelSwipe();") != std::string::npos,
+           "overview exposes an owned cancel-begin transition");
+    const auto cancelSwipeBegin = extractFunction(interactionSource, "void COverview::beginCancelSwipe(");
+    expect(!cancelSwipeBegin.empty(), "overview cancel-begin transition exists");
+    const auto resetCancelTarget = cancelSwipeBegin.find("closeOnID = openedID");
+    const auto startCancelClose  = cancelSwipeBegin.find("closing = true", resetCancelTarget);
+    expect(resetCancelTarget != std::string::npos && startCancelClose != std::string::npos && resetCancelTarget < startCancelClose,
+           "cancel begin replaces any aborted expo target with the opening workspace before closing");
     const auto expoBeginBlock = monitorQueryStart == std::string::npos ? std::string{} : gestureBegin.substr(monitorQueryStart);
     expect(expoBeginBlock.find("std::make_unique<COverview>(monitor->m_activeWorkspace, true)") != std::string::npos &&
                expoBeginBlock.find("g_pOverview->selectHoveredWorkspace()") != std::string::npos &&


### PR DESCRIPTION
Resolves #101

## Summary

- Add explicit `expo` and `cancel` modes to Lua-registered Hyprexpo gestures.
- Keep cancel inert while the overview is closed.
- Drive the existing 1:1 close animation while open, reset every cancel to the origin tile, and commit through `close(false)`.
- Preserve incomplete-swipe reopen behavior, existing expo selection behavior, plain-config expo registration, and prior crash/replay guards.
- Document Lua registration, config boundaries, and runtime smoke cases.

## Validation

- `make -B test`
- `make -B all`
- `git diff --check origin/master..HEAD`
- Independent code review: approved, zero findings after stale-target fix
- Nested Hyprland 0.56.1 Lua config loaded `v0.56.1+3-dev+210c259`
- Cancel gesture registration, unset/re-register, duplicate detection, and invalid-action error verified
- Direct Lua expo toggle/cancel stayed on origin workspace
- Config errors and plugin log checks clean

## Not tested

Physical touchpad begin/update/end and threshold animation. This host exposes no touchpad, and Hyprland provides no gesture injection dispatcher. The lifecycle is covered by source contracts and code review, but needs maintainer/user hardware smoke.