### PR TITLE
Chase Hyprland master keybind and window APIs (supersedes #109)

### DIFF
--- a/Dispatchers.cpp
+++ b/Dispatchers.cpp
@@ -12,10 +12,10 @@
 #include <hyprland/src/debug/log/Logger.hpp>
 #include <hyprland/src/desktop/state/FocusState.hpp>
 #include <hyprland/src/desktop/state/GlobalWindowController.hpp>
-#include <hyprland/src/desktop/view/Window.hpp>
+#include <hyprland/src/desktop/view/window/Window.hpp>
 #include <hyprland/src/helpers/Color.hpp>
 #include <hyprland/src/output/Monitor.hpp>
-#include <hyprland/src/managers/KeybindManager.hpp>
+#include <hyprland/src/keybinds/Resolver.hpp>
 #include <hyprland/src/managers/SeatManager.hpp>
 #include <hyprland/src/managers/input/InputManager.hpp>
 #include <hyprland/src/managers/input/trackpad/GestureTypes.hpp>
@@ -137,7 +137,7 @@ static PHLWINDOW windowToBringFromWorkspace(const PHLWORKSPACE& workspace) {
     const auto& windows = Desktop::windowState()->windows();
     for (auto it = windows.rbegin(); it != windows.rend(); ++it) {
         const auto& window = *it;
-        if (!window || window->m_workspace != workspace || !window->m_isMapped || window->isHidden())
+        if (!window || window->m_workspace != workspace || !window->mapped() || window->isHidden())
             continue;
 
         return window;
@@ -509,9 +509,9 @@ static SDispatchResult registerExpoGesture(int fingerCount, const std::string& d
     if (direction == TRACKPAD_GESTURE_DIR_NONE)
         return {.success = false, .error = std::format("invalid direction '{}'", directionName)};
 
-    uint32_t modMask = 0;
+    Input::ModifierMask modMask = Input::HL_MODIFIER_NONE;
     if (!mods.empty())
-        modMask = g_pKeybindManager->stringToModMask(mods);
+        modMask = Keybinds::modMaskFromString(mods);
 
     deltaScale = std::clamp(deltaScale, 0.1F, 10.F);
 

--- a/Overview.cpp
+++ b/Overview.cpp
@@ -14,7 +14,8 @@
 #include <hyprland/src/config/ConfigManager.hpp>
 #include <hyprland/src/config/shared/actions/ConfigActions.hpp>
 #include <hyprland/src/config/shared/animation/AnimationTree.hpp>
-#include <hyprland/src/desktop/view/Window.hpp>
+#include <hyprland/src/desktop/view/window/Window.hpp>
+#include <hyprland/src/desktop/view/window/WindowPresentation.hpp>
 #include <hyprland/src/layout/LayoutManager.hpp>
 #include <hyprland/src/layout/space/Space.hpp>
 #include <hyprland/src/animation/AnimationManager.hpp>
@@ -461,11 +462,11 @@ void normalizeMonitorWorkspaceRenderState(PHLMONITOR monitor) {
     }
 
     for (const auto& window : Desktop::windowState()->windows()) {
-        if (!window || !window->m_isMapped || window->isHidden() || window->m_pinned || !window->m_workspace || window->m_workspace->m_monitor != monitor)
+        if (!window || !window->mapped() || window->isHidden() || (window->m_state & Desktop::View::WINDOW_STATE_PINNED) || !window->m_workspace || window->m_workspace->m_monitor != monitor)
             continue;
 
-        window->alpha(Desktop::View::WINDOW_ALPHA_MOVE_FROM_WORKSPACE)->setValueAndWarp(1.F);
-        *window->alpha(Desktop::View::WINDOW_ALPHA_MOVE_FROM_WORKSPACE) = 1.F;
+        window->presentation().alpha(Desktop::View::WINDOW_ALPHA_MOVE_FROM_WORKSPACE)->setValueAndWarp(1.F);
+        *window->presentation().alpha(Desktop::View::WINDOW_ALPHA_MOVE_FROM_WORKSPACE) = 1.F;
     }
 }
 
@@ -480,16 +481,16 @@ std::vector<SPinnedWindowPreviewState> applyPinnedWindowPreviewState(bool showPi
         return states;
 
     for (const auto& window : Desktop::windowState()->windows()) {
-        if (!window || !window->m_isMapped || !window->m_pinned)
+        if (!window || !window->mapped() || !(window->m_state & Desktop::View::WINDOW_STATE_PINNED))
             continue;
 
         states.push_back({
-            .window = window,
+            .window    = window,
             .workspace = window->m_workspace,
-            .pinned = window->m_pinned,
+            .pinned    = true,
         });
 
-        window->m_pinned = false;
+        window->m_state &= ~Desktop::View::WINDOW_STATE_PINNED;
         window->m_workspace.reset();
     }
 
@@ -502,7 +503,8 @@ void restorePinnedWindowPreviewState(const std::vector<SPinnedWindowPreviewState
             continue;
 
         state.window->m_workspace = state.workspace;
-        state.window->m_pinned    = state.pinned;
+        if (state.pinned)
+            state.window->m_state |= Desktop::View::WINDOW_STATE_PINNED;
     }
 }
 
@@ -513,19 +515,19 @@ CPinnedWindowPreviewGuard::~CPinnedWindowPreviewGuard() {
 }
 
 bool windowVisibleOnWorkspace(const PHLWINDOW& window, const PHLWORKSPACE& workspace) {
-    return window && workspace && window->m_workspace == workspace && window->m_isMapped && !window->isHidden() && !window->m_pinned;
+    return window && workspace && window->m_workspace == workspace && window->mapped() && !window->isHidden() && !(window->m_state & Desktop::View::WINDOW_STATE_PINNED);
 }
 
 void settleWorkspaceMoveAnimation(const PHLWINDOW& window) {
     if (!window)
         return;
 
-    window->alpha(Desktop::View::WINDOW_ALPHA_MOVE_TO_WORKSPACE)->resetAllCallbacks();
-    window->alpha(Desktop::View::WINDOW_ALPHA_MOVE_TO_WORKSPACE)->setValueAndWarp(1.F);
-    *window->alpha(Desktop::View::WINDOW_ALPHA_MOVE_TO_WORKSPACE) = 1.F;
-    window->alpha(Desktop::View::WINDOW_ALPHA_MOVE_FROM_WORKSPACE)->setValueAndWarp(1.F);
-    *window->alpha(Desktop::View::WINDOW_ALPHA_MOVE_FROM_WORKSPACE) = 1.F;
-    window->m_monitorMovedFrom                                      = -1;
+    window->presentation().alpha(Desktop::View::WINDOW_ALPHA_MOVE_TO_WORKSPACE)->resetAllCallbacks();
+    window->presentation().alpha(Desktop::View::WINDOW_ALPHA_MOVE_TO_WORKSPACE)->setValueAndWarp(1.F);
+    *window->presentation().alpha(Desktop::View::WINDOW_ALPHA_MOVE_TO_WORKSPACE) = 1.F;
+    window->presentation().alpha(Desktop::View::WINDOW_ALPHA_MOVE_FROM_WORKSPACE)->setValueAndWarp(1.F);
+    *window->presentation().alpha(Desktop::View::WINDOW_ALPHA_MOVE_FROM_WORKSPACE) = 1.F;
+    window->presentation().resetMonitorMovedFrom();
 }
 
 void settleWorkspaceMoveAnimations() {
@@ -533,8 +535,8 @@ void settleWorkspaceMoveAnimations() {
         if (!window)
             continue;
 
-        const bool movingWorkspace = window->m_monitorMovedFrom != -1 || window->alpha(Desktop::View::WINDOW_ALPHA_MOVE_TO_WORKSPACE)->isBeingAnimated() ||
-            window->alpha(Desktop::View::WINDOW_ALPHA_MOVE_FROM_WORKSPACE)->isBeingAnimated();
+        const bool movingWorkspace = window->presentation().movingFromMonitor() || window->presentation().alpha(Desktop::View::WINDOW_ALPHA_MOVE_TO_WORKSPACE)->isBeingAnimated() ||
+            window->presentation().alpha(Desktop::View::WINDOW_ALPHA_MOVE_FROM_WORKSPACE)->isBeingAnimated();
         if (!movingWorkspace)
             continue;
 

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,6 @@
       type = "github";
       owner = "hyprwm";
       repo = "Hyprland";
-      ref = "v0.55.4";
     };
 
     nixpkgs.follows = "hyprland/nixpkgs";


### PR DESCRIPTION
Reopens review of the Hyprland master API update after #109 was accidentally merged and subsequently reverted during #113. **Supersedes #109.** This is a draft for tracking Hyprland master compatibility, targeting this repository's `master` branch.

The original contributor branch, `matt1432:chase-keybind`, and commit `fbdfba47cc7163578271ba7b342fd8674cd2e7af` are preserved unchanged, including the original author and commit hash.

The changes migrate dispatcher keybind/modifier handling and window rendering/pinned-state access to the upstream development APIs. The original patch also removes the Hyprland release reference in `flake.nix`.

Before this draft is ready, reconcile it with current `master`, review the flake change under #113's release-first compatibility policy, select an explicit Hyprland development revision, and verify the build and runtime against that revision.

Validation for reopening: verified that the branch contains the exact original commit from #109 and that the PR comparison changes only `Dispatchers.cpp`, `Overview.cpp`, and `flake.nix`. No new build or runtime validation was performed for this reopening.
