### PR TITLE
Allow explicit rows in fixed workspace grids

### DIFF
--- a/HyprexpoConfig.hpp
+++ b/HyprexpoConfig.hpp
@@ -21,6 +21,7 @@ inline constexpr int         WALLPAPER_BG_DEFAULT                = 0;
 inline constexpr std::size_t DYNAMIC_GRID_MAX_TILES              = 64;
 
 inline constexpr int         COLUMNS_DEFAULT                 = 3;
+inline constexpr int         ROWS_DEFAULT                    = 0;
 inline constexpr int         COLUMNS_MIN                     = 1;
 inline constexpr int         COLUMNS_MAX                     = 7;
 inline constexpr int         GAPS_IN_DEFAULT                 = 5;

--- a/HyprexpoLogic.cpp
+++ b/HyprexpoLogic.cpp
@@ -329,19 +329,25 @@ SOverviewDragTransition transitionOverviewDrag(const SOverviewDragState& state, 
     return {.next = state, .drop = std::nullopt, .cleanupMonitorKeys = {}, .accepted = false, .cleanup = false};
 }
 
-int clampGridColumns(int columns) {
-    return std::clamp(columns, HyprexpoConfig::COLUMNS_MIN, HyprexpoConfig::COLUMNS_MAX);
+int clampGridColumns(int64_t columns) {
+    return static_cast<int>(std::clamp<int64_t>(columns, HyprexpoConfig::COLUMNS_MIN, HyprexpoConfig::COLUMNS_MAX));
 }
 
-int gridColumnsToIncludeWorkspace(int configuredColumns, int firstWorkspaceID, int activeWorkspaceID, int maxColumns) {
+SGridShape computeFixedGridShape(int64_t columns, int64_t rows) {
+    const int cols = clampGridColumns(columns);
+    return {cols, rows > 0 ? clampGridColumns(rows) : cols};
+}
+
+int gridColumnsToIncludeWorkspace(int configuredColumns, int firstWorkspaceID, int activeWorkspaceID, int maxColumns, int fixedRows) {
     const int cap  = std::max(HyprexpoConfig::COLUMNS_MIN, maxColumns);
+    const int rows = fixedRows > 0 ? clampGridColumns(fixedRows) : 0;
     int       cols = std::clamp(configuredColumns, HyprexpoConfig::COLUMNS_MIN, cap);
 
     if (activeWorkspaceID <= firstWorkspaceID)
         return cols;
 
     const long long needed = static_cast<long long>(activeWorkspaceID) - firstWorkspaceID + 1;
-    while (static_cast<long long>(cols) * cols < needed && cols < cap)
+    while (static_cast<long long>(cols) * (rows > 0 ? rows : cols) < needed && cols < cap)
         ++cols;
 
     return cols;

--- a/HyprexpoLogic.hpp
+++ b/HyprexpoLogic.hpp
@@ -180,6 +180,7 @@ std::string lowerString(std::string value);
 std::vector<std::string> splitCommaList(const std::string& value);
 
 SGridShape               computeDynamicGridShape(int visibleCount);
+SGridShape               computeFixedGridShape(int64_t columns, int64_t rows);
 std::optional<std::vector<int64_t>> expandDynamicWorkspaceIDs(const std::vector<int64_t>& workspaceIDs, bool fillGaps, std::size_t maxExpandedWorkspaces);
 SSize                    aspectCorrectTileSize(double screenW, double screenH, int cols, int rows, double gap);
 STileLayout              computeTileLayout(int index, int visibleCount, SGridShape shape, SSize total, double gap, bool centerPartialRows);
@@ -188,8 +189,8 @@ std::optional<STileTarget> selectDirectionalTile(const SRect& source, EDirection
 std::optional<STileHit>    hitTestGlobalTile(const SPoint& point, const std::vector<SGlobalTile>& tiles);
 SOverviewDragTransition    transitionOverviewDrag(const SOverviewDragState& state, const SOverviewDragEvent& event, const std::vector<uint64_t>& liveMonitorKeys);
 
-int                      clampGridColumns(int columns);
-int                      gridColumnsToIncludeWorkspace(int configuredColumns, int firstWorkspaceID, int activeWorkspaceID, int maxColumns);
+int                      clampGridColumns(int64_t columns);
+int                      gridColumnsToIncludeWorkspace(int configuredColumns, int firstWorkspaceID, int activeWorkspaceID, int maxColumns, int fixedRows = 0);
 std::size_t              centeredWorkspaceBacktrack(std::size_t tileCount, int64_t activeWorkspaceID, std::optional<int64_t> lowestExistingID,
                                                     std::optional<int64_t> highestExistingID);
 int                      tileIndexFromPoint(double x, double y, double width, double height, int sideLength);

--- a/Overview.cpp
+++ b/Overview.cpp
@@ -126,6 +126,7 @@ static Config::FLOAT floatDefault(const std::string& name) {
 static Config::INTEGER intDefault(const std::string& name) {
     static const std::map<std::string, Config::INTEGER> DEFAULTS = {
         {"plugin:hyprexpo:columns", HyprexpoConfig::COLUMNS_DEFAULT},
+        {"plugin:hyprexpo:rows", HyprexpoConfig::ROWS_DEFAULT},
         {"plugin:hyprexpo:gaps_in", HyprexpoConfig::GAPS_IN_DEFAULT},
         {"plugin:hyprexpo:bg_col", HyprexpoConfig::BG_COL_DEFAULT},
         {"plugin:hyprexpo:gesture_distance", HyprexpoConfig::GESTURE_DISTANCE_DEFAULT},
@@ -1009,10 +1010,7 @@ static std::pair<bool, int> getWorkspaceMethodForMonitor(PHLMONITOR monitor) {
 }
 
 Hyprexpo::SGridShape COverview::currentGridShape() const {
-    if (dynamicGrid)
-        return gridShape;
-
-    return {SIDE_LENGTH, SIDE_LENGTH};
+    return gridShape;
 }
 
 double COverview::currentOuterInset() const {
@@ -1080,6 +1078,7 @@ COverview::COverview(PHLWORKSPACE startedOn_, PHLMONITOR monitor_, bool swipe_, 
     pMonitor            = PMONITOR;
 
     static auto* const* PCOLUMNS  = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:columns")->getDataStaticPtr();
+    static auto* const* PROWS     = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:rows")->getDataStaticPtr();
     static auto* const* PGAPS     = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:gaps_in")->getDataStaticPtr();
     static auto* const* PCOL      = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:bg_col")->getDataStaticPtr();
     static auto* const* PSKIP     = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:skip_empty")->getDataStaticPtr();
@@ -1094,8 +1093,7 @@ COverview::COverview(PHLWORKSPACE startedOn_, PHLMONITOR monitor_, bool swipe_, 
     static auto* const* PDRAGDROPENABLE = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprexpo:drag_drop_enable")->getDataStaticPtr();
 
     createdAt            = std::chrono::steady_clock::now();
-    SIDE_LENGTH          = Hyprexpo::clampGridColumns(**PCOLUMNS);
-    gridShape            = {SIDE_LENGTH, SIDE_LENGTH};
+    gridShape            = Hyprexpo::computeFixedGridShape(**PCOLUMNS, **PROWS);
     GAP_WIDTH            = std::max<Hyprlang::INT>(0, **PGAPS);
     BG_COLOR             = **PCOL;
     showWorkspaceNumbers = **PSHOWNUM;
@@ -1114,11 +1112,12 @@ COverview::COverview(PHLWORKSPACE startedOn_, PHLMONITOR monitor_, bool swipe_, 
     emptyTilesSelectable = skipEmpty;
 
     if (!methodCenter && !skipEmpty && maxWorkspace <= 0 && startedOn) {
-        SIDE_LENGTH = Hyprexpo::gridColumnsToIncludeWorkspace(SIDE_LENGTH, methodStartID, (int)startedOn->m_id, HyprexpoConfig::COLUMNS_MAX);
-        gridShape   = {SIDE_LENGTH, SIDE_LENGTH};
+        const int columns = Hyprexpo::gridColumnsToIncludeWorkspace(gridShape.cols, methodStartID, (int)startedOn->m_id,
+                                                                   HyprexpoConfig::COLUMNS_MAX, **PROWS > 0 ? gridShape.rows : 0);
+        gridShape = Hyprexpo::computeFixedGridShape(columns, **PROWS);
     }
 
-    images.resize(SIDE_LENGTH * SIDE_LENGTH);
+    images.resize(gridShape.cols * gridShape.rows);
 
     const bool anchorSelector = !methodCenter || (!skipEmpty && maxWorkspace > 0 && methodStartID != startedOn->m_id);
     if (anchorSelector) {
@@ -1192,7 +1191,7 @@ COverview::COverview(PHLWORKSPACE startedOn_, PHLMONITOR monitor_, bool swipe_, 
         // Scan through workspaces higher than methodStartID. If using "m"
         // (skip_empty), stop when we wrap, leaving the rest of the workspace
         // ID's set to WORKSPACE_INVALID
-        for (size_t i = 1; i < (size_t)(SIDE_LENGTH * SIDE_LENGTH); ++i) {
+        for (size_t i = 1; i < images.size(); ++i) {
             auto& image = images[i];
             currentID   = workspaceIDForMonitor(PMONITOR, selector + "+" + std::to_string(i));
             if (currentID <= methodStartID)
@@ -1247,7 +1246,6 @@ COverview::COverview(PHLWORKSPACE startedOn_, PHLMONITOR monitor_, bool swipe_, 
         }
 
         gridShape = Hyprexpo::computeDynamicGridShape((int)visibleWorkspaceIDs.size());
-        SIDE_LENGTH = gridShape.cols;
         images.resize(visibleWorkspaceIDs.size());
         for (size_t i = 0; i < visibleWorkspaceIDs.size(); ++i)
             images[i].workspaceID = visibleWorkspaceIDs[i];
@@ -1255,8 +1253,8 @@ COverview::COverview(PHLWORKSPACE startedOn_, PHLMONITOR monitor_, bool swipe_, 
 
     Render::GL::g_pHyprOpenGL->makeEGLCurrent();
 
-    Vector2D tileSize = pMonitor->m_size / SIDE_LENGTH;
-    CBox     monbox{0, 0, tileSize.x * 2, tileSize.y * 2};
+    const auto tileSize = Hyprexpo::aspectCorrectTileSize(pMonitor->m_size.x, pMonitor->m_size.y, gridShape.cols, gridShape.rows, 0.0);
+    CBox       monbox{0, 0, tileSize.w * 2, tileSize.h * 2};
 
     if (!ENABLE_LOWRES)
         monbox = {{0, 0}, pMonitor->m_pixelSize};
@@ -1296,9 +1294,6 @@ COverview::COverview(PHLWORKSPACE startedOn_, PHLMONITOR monitor_, bool swipe_, 
     PMONITOR->m_activeWorkspace        = startedOn;
     startedOn->m_visible               = true;
     Animation::Workspace::startAnimation(startedOn, Animation::Workspace::ANIMATION_TYPE_IN, true, true);
-
-    // zoom on the current workspace.
-    // const auto& TILE = images[std::clamp(currentid, 0, SIDE_LENGTH * SIDE_LENGTH)];
 
     const auto initSize = zoomSizeForCurrentGrid(pMonitor->m_size);
     Animation::mgr()->createAnimation(initSize, size, Config::animationTree()->getAnimationPropertyConfig("windowsMove"), AVARDAMAGE_NONE);

--- a/Overview.hpp
+++ b/Overview.hpp
@@ -137,7 +137,6 @@ class COverview final : public IOverviewSession {
     void       enterSubmapIfEnabled();
     void       resetSubmapIfNeeded();
 
-    int        SIDE_LENGTH = 3;
     bool       dynamicGrid = false;
     bool       emptyTilesSelectable = false;
     Hyprexpo::SGridShape gridShape{3, 3};

--- a/PluginConfig.cpp
+++ b/PluginConfig.cpp
@@ -44,6 +44,7 @@ void registerHyprexpoConfigValues() {
     addConfigValue(makeShared<Config::Values::CIntValue>("plugin:hyprexpo:wallpaper_bg", "draw the monitor wallpaper behind overview tiles", HyprexpoConfig::WALLPAPER_BG_DEFAULT));
 
     addConfigValue(makeShared<Config::Values::CIntValue>("plugin:hyprexpo:columns", "columns", HyprexpoConfig::COLUMNS_DEFAULT));
+    addConfigValue(makeShared<Config::Values::CIntValue>("plugin:hyprexpo:rows", "fixed grid rows (0 follows columns)", HyprexpoConfig::ROWS_DEFAULT));
     addConfigValue(makeShared<Config::Values::CIntValue>("plugin:hyprexpo:gaps_in", "inner gaps", HyprexpoConfig::GAPS_IN_DEFAULT));
     addConfigValue(makeShared<Config::Values::CColorValue>("plugin:hyprexpo:bg_col", "background color", HyprexpoConfig::BG_COL_DEFAULT));
     addConfigValue(makeShared<Config::Values::CStringValue>("plugin:hyprexpo:workspace_method", "workspace method", HyprexpoConfig::WORKSPACE_METHOD_DEFAULT));

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Add the plugin block to your Hyprland config:
 plugin {
     hyprexpo {
         columns = 3
+        rows = 0 # Follow columns; use a positive value for a rectangular fixed grid.
         gaps_in = 5
         gaps_out = 0
         bg_col = rgb(111111)
@@ -153,6 +154,7 @@ hl.config({
     plugin = {
         hyprexpo = {
             columns = 3,
+            rows = 0, -- Follow columns; positive values set fixed-grid rows.
             gaps_in = 5,
             gaps_out = 0,
             bg_col = "rgb(111111)",
@@ -167,6 +169,12 @@ hl.config({
 ```
 
 `drag_drop_enable` defaults to `1`. Set it to `0` to keep workspace clicks from moving windows when the pointer shifts during a click.
+
+For ten fixed-grid slots, use `columns = 5`, `rows = 2`, `dynamic_grid = 0`,
+and `skip_empty = 0`. Empty workspaces remain selectable and can receive dragged
+windows. `rows = 0` (the default) keeps the existing square grid; positive rows
+are clamped to `1..7`. Dynamic grids and native scrolling overviews size themselves
+as before and ignore `rows`.
 
 Add a dispatcher binding:
 

--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -94,6 +94,7 @@ plugin {
 | key | type | description | default |
 | --- | --- | --- | --- |
 | `plugin:hyprexpo:columns` | int | desktops per row, clamped to `1..7` | `3` |
+| `plugin:hyprexpo:rows` | int | fixed-grid rows, positive values clamped to `1..7`; `0` or negative values follow columns | `0` |
 | `plugin:hyprexpo:gaps_in` | int | spacing between tiles in pixels | `5` |
 | `plugin:hyprexpo:gaps_out` | int | outer margin around the grid in pixels | `0` |
 | `plugin:hyprexpo:bg_col` | color | grid background color | `0xFF111111` |
@@ -108,6 +109,31 @@ plugin {
 | `plugin:hyprexpo:show_pinned_windows` | bool int | render pinned/PiP windows in workspace preview thumbnails; default `0` hides them from previews only | `0` |
 | `plugin:hyprexpo:scrolling_thumbnail_budget` | int | scrolling thumbnail budget multiplier `m`, clamped to `1..16`; total capture pixels are bounded by `m * W * H` for monitor size `W x H` | `4` |
 | `plugin:hyprexpo:scrolling_input_debug` | bool int | enable deterministic input and loaded native mutation acceptance dispatchers; leave disabled outside disposable testing | `0` |
+
+### Rectangular fixed grids
+
+Set positive `rows` to choose the height independently of `columns`. For example,
+this makes a five-column, two-row grid with ten slots:
+
+```lua
+hl.config({plugin = {hyprexpo = {
+    columns = 5,
+    rows = 2,
+    dynamic_grid = 0,
+    skip_empty = 0,
+}}})
+```
+
+Workspace previews retain their aspect ratio and the grid is centered with
+letterboxing as needed. Empty and not-yet-created workspaces remain available
+as selection and drag/drop targets. A workspace cap may leave non-selectable
+padding inside the configured rectangle; it does not shrink the grid.
+
+The default `rows = 0` inherits the column count, preserving existing square-grid
+behavior. It does **not** derive rows from workspace count. `rows` has no effect
+on `dynamic_grid = 1` or native scrolling-layout overviews. The existing
+[first-anchor growth](../guides/multi-monitor) can increase columns when uncapped,
+but explicit rows stay fixed.
 
 Pinned windows, including browser Picture-in-Picture windows, stay pinned and visible in normal Hyprland. By default HyprExpo hides them only while capturing workspace preview thumbnails so they do not appear on every tile. Set `show_pinned_windows = 1` to opt in to the old preview behavior.
 
@@ -289,7 +315,7 @@ Then bind `hyprexpo:kb_select` to those tokens in the overview submap.
 
 ## Safe Failure Behavior
 
-Invalid `columns`, workspace methods, label tokens, border colors, drag/drop
+Invalid `columns`, `rows`, workspace methods, label tokens, border colors, drag/drop
 border colors, gradient values, and bool-int options are expected to fail
 safely. The plugin should log invalid values or use a fallback instead of
 crashing Hyprland during render.

--- a/docs/guides/multi-monitor.md
+++ b/docs/guides/multi-monitor.md
@@ -51,6 +51,12 @@ grows — never below the configured `columns` — and is capped at the maximum 
 columns. This applies to plain sequential grids (not `skip_empty` or
 `max_workspace`, which keep their explicit bounds).
 
+With `rows = 0` (the default), growth keeps the legacy square grid. With explicit
+positive `rows`, only columns grow: `columns = 3`, `rows = 2`, `first 1` grows to
+four columns and two rows when workspace 7 is active. Rows are never silently
+increased. At the seven-column limit this remains best effort, so a one-row grid
+cannot include an active workspace more than seven slots from its first anchor.
+
 ## Opening on Every Monitor
 
 By default the overview opens only on the monitor under the cursor. Append `all`

--- a/tests/HyprexpoLogicTests.cpp
+++ b/tests/HyprexpoLogicTests.cpp
@@ -157,6 +157,43 @@ void checkGeometryForMonitor(const Hyprexpo::SSize& total) {
     }
 }
 
+void checkFixedGridGeometryForMonitor(const Hyprexpo::SSize& total) {
+    constexpr double gap = 24.0;
+    for (const auto shape : std::vector<Hyprexpo::SGridShape>{{5, 2}, {2, 5}, {1, 5}, {5, 1}, {3, 2}, {2, 3}, {7, 7}}) {
+        const int count = shape.cols * shape.rows;
+        const auto layouts = layoutsFor(count, shape, total, gap, false);
+        const auto& first = layouts.front().box;
+        const auto& last = layouts.back().box;
+        expect(near(first.x, total.w - last.x - last.w) && near(first.y, total.h - last.y - last.h),
+               "fixed rectangle is letterboxed symmetrically");
+        const double zoom = std::max(shape.cols, shape.rows);
+        for (int i = 0; i < count; ++i) {
+            const auto& layout = layouts[i];
+            const auto& box = layout.box;
+            expect(layout.row == i / shape.cols && layout.col == i % shape.cols, "fixed rectangle keeps row-major tile indices");
+            expect(box.x >= 0.0 && box.y >= 0.0 && box.x + box.w <= total.w + 0.001 && box.y + box.h <= total.h + 0.001,
+                   "every fixed tile fits the monitor");
+            expect(near(box.w / box.h, total.w / total.h), "fixed tiles preserve workspace aspect ratio");
+            expect(Hyprexpo::tileIndexAtPoint(box.x + box.w / 2, box.y + box.h / 2, count, shape, total, gap, false) == i,
+                   "every rectangular tile is hit-testable including the last slot");
+            const auto zoomed = Hyprexpo::computeTileLayout(i, count, shape, {total.w * zoom, total.h * zoom}, 0.0, false);
+            expect(near(zoomed.box.w, total.w) && near(zoomed.box.h, total.h), "rectangular zoom endpoints retain full workspace size");
+        }
+        if (shape.cols > 1)
+            expect(Hyprexpo::tileIndexAtPoint(first.x + first.w + gap / 2, first.y + first.h / 2, count, shape, total, gap, false) == -1,
+                   "fixed-grid column gaps are not selectable");
+        if (shape.rows > 1)
+            expect(Hyprexpo::tileIndexAtPoint(first.x + first.w / 2, first.y + first.h + gap / 2, count, shape, total, gap, false) == -1,
+                   "fixed-grid row gaps are not selectable");
+        if (first.x > 0.0)
+            expect(Hyprexpo::tileIndexAtPoint(first.x / 2, first.y + first.h / 2, count, shape, total, gap, false) == -1,
+                   "horizontal letterboxing is not a workspace target");
+        if (first.y > 0.0)
+            expect(Hyprexpo::tileIndexAtPoint(first.x + first.w / 2, first.y / 2, count, shape, total, gap, false) == -1,
+                   "vertical letterboxing is not a workspace target");
+    }
+}
+
 Hyprexpo::Scrolling::STapeSpec scrollingTape(Hyprexpo::Scrolling::EDirection direction) {
     using namespace Hyprexpo::Scrolling;
     return {
@@ -732,6 +769,20 @@ int main() {
     expect(clampGridColumns(3) == 3, "columns keep valid value");
     expect(clampGridColumns(99) == 7, "columns clamp upper bound");
 
+    const auto wideFixed = computeFixedGridShape(5, 2);
+    expect(wideFixed.cols == 5 && wideFixed.rows == 2 && wideFixed.cols * wideFixed.rows == 10,
+           "explicit five-column two-row fixed grid contains ten slots");
+    const auto tallFixed = computeFixedGridShape(2, 5);
+    expect(tallFixed.cols == 2 && tallFixed.rows == 5, "explicit rows can exceed columns");
+    const auto defaultFixed = computeFixedGridShape(3, 0);
+    expect(defaultFixed.cols == 3 && defaultFixed.rows == 3, "unset rows preserve the legacy square grid");
+    const auto negativeRows = computeFixedGridShape(4, std::numeric_limits<int64_t>::min());
+    expect(negativeRows.cols == 4 && negativeRows.rows == 4, "nonpositive rows use the configured column count");
+    const auto oversizedFixed = computeFixedGridShape(std::numeric_limits<int64_t>::max(), std::numeric_limits<int64_t>::max());
+    expect(oversizedFixed.cols == 7 && oversizedFixed.rows == 7, "64-bit grid settings clamp before narrowing or allocation");
+    const auto minimumFixed = computeFixedGridShape(std::numeric_limits<int64_t>::min(), 1);
+    expect(minimumFixed.cols == 1 && minimumFixed.rows == 1, "minimum column setting remains a valid bounded grid");
+
     expect(gridColumnsToIncludeWorkspace(3, 1, 9, 7) == 3, "first-anchor grid keeps columns when active workspace fits");
     expect(gridColumnsToIncludeWorkspace(3, 1, 10, 7) == 4, "first-anchor grid grows to include an active workspace just past the grid");
     expect(gridColumnsToIncludeWorkspace(3, 1, 16, 7) == 4, "first-anchor grid grows to exactly fill the last tile");
@@ -740,6 +791,14 @@ int main() {
     expect(gridColumnsToIncludeWorkspace(3, 5, 4, 7) == 3, "first-anchor grid never shrinks for an active workspace before the anchor");
     expect(gridColumnsToIncludeWorkspace(3, 1, 1000, 7) == 7, "first-anchor grid is capped at the max columns as a best effort");
     expect(gridColumnsToIncludeWorkspace(5, 1, 4, 7) == 5, "first-anchor grid never shrinks below the configured columns");
+
+    expect(gridColumnsToIncludeWorkspace(5, 1, 10, 7, 2) == 5, "five-by-two grid keeps its shape when the active workspace fits");
+    expect(gridColumnsToIncludeWorkspace(3, 1, 7, 7, 2) == 4, "rectangular first-anchor growth uses the explicit row count");
+    expect(gridColumnsToIncludeWorkspace(5, 1, 11, 7, 2) == 6, "rectangular growth adds only the needed column");
+    expect(gridColumnsToIncludeWorkspace(2, 6, 15, 7, 5) == 2, "tall fixed grid accounts for a non-one first anchor");
+    expect(gridColumnsToIncludeWorkspace(2, 6, 16, 7, 5) == 3, "tall grid grows columns without changing rows");
+    expect(gridColumnsToIncludeWorkspace(3, 1, 1000, 7, 1) == 7, "single-row growth remains bounded");
+    expect(gridColumnsToIncludeWorkspace(5, 1, 2, 7, 2) == 5, "rectangular growth never shrinks the configured width");
 
     expect(centeredWorkspaceBacktrack(9, 1, 1, 9) == 0, "center-current keeps the low workspace at the first tile");
     expect(centeredWorkspaceBacktrack(9, 5, 1, 9) == 4, "center-current places the middle workspace at the center tile");
@@ -923,6 +982,9 @@ int main() {
     checkGeometryForMonitor(makeSize(1600, 900));
     checkGeometryForMonitor(makeSize(900, 1600));
     checkGeometryForMonitor(makeSize(2560, 1080));
+    checkFixedGridGeometryForMonitor(makeSize(1600, 900));
+    checkFixedGridGeometryForMonitor(makeSize(900, 1600));
+    checkFixedGridGeometryForMonitor(makeSize(1280, 720.5));
     checkScrollingTapeDirections();
     checkScrollingSceneAndInputMath();
     checkScrollingDropIntents();

--- a/tests/OverviewSourceTests.cpp
+++ b/tests/OverviewSourceTests.cpp
@@ -370,6 +370,15 @@ int main() {
            "release cannot restore the cursor outside centralized reset");
 
     const auto overviewConstructor = extractFunction(source, "COverview::COverview(");
+    expectContains(configSource, "\"plugin:hyprexpo:rows\"", "explicit fixed rows are registered as configuration");
+    expectContains(source, "{\"plugin:hyprexpo:rows\", HyprexpoConfig::ROWS_DEFAULT}", "row fallback uses the shared default");
+    expectContains(overviewConstructor, "Hyprexpo::computeFixedGridShape(**PCOLUMNS, **PROWS)", "fixed grids resolve both configured dimensions");
+    expectContains(overviewConstructor, "images.resize(gridShape.cols * gridShape.rows)", "fixed grids allocate rectangular capacity including empty slots");
+    expectContains(overviewConstructor, "**PROWS > 0 ? gridShape.rows : 0", "first-anchor growth distinguishes explicit from inherited rows");
+    expectAbsent(overviewConstructor, "SIDE_LENGTH", "construction and captures no longer square a rectangle");
+    const auto currentShape = extractFunction(source, "Hyprexpo::SGridShape COverview::currentGridShape(");
+    expectContains(currentShape, "return gridShape;", "every geometry consumer sees the resolved grid shape");
+    expectAbsent(currentShape, "SIDE_LENGTH", "fixed geometry does not replace resolved rows with columns");
     expect(!overviewConstructor.empty(), "overview constructor exists");
     const auto gapExpansionPos = overviewConstructor.find("Hyprexpo::expandDynamicWorkspaceIDs(");
     const auto dynamicResizePos = overviewConstructor.find("images.resize(visibleWorkspaceIDs.size())");


### PR DESCRIPTION
Resolves #111.

Adds the explicit `rows` alternative for fixed workspace grids:

```lua
hl.config({plugin = {hyprexpo = {
    columns = 5,
    rows = 2,
    dynamic_grid = 0,
    skip_empty = 0,
}}})
```

This provides ten fixed slots without hiding empty or unopened workspaces.
`rows = 0` (the default) follows columns and preserves the existing square grid;
it is not workspace-count-driven automatic sizing. Positive rows are clamped to
1–7. Uncapped first-anchor growth can increase columns while explicit rows stay
fixed. Dynamic grids and native scrolling retain their existing sizing.

The implementation reuses the existing aspect-correct layout, hit testing,
navigation and zoom helpers, and removes the duplicate square-only `SIDE_LENGTH`
state. Fixed allocation and traversal now use the resolved rectangular shape.

Validation at `6ea806014d8f9a6105bac19f8542f6548f6d93fa`:

- Test-first shape/default/int64-bound and first-anchor growth contracts; full
  Make suites and ASan/UBSan pass. New geometry tests cover landscape, portrait,
  fractional sizes, letterboxing, gaps, hit tests and zoom endpoints.
- Separate exact Hyprland 0.56.1 and 0.56.2 builds and disposable runtime checks
  pass for 5×2, 2×5, 1×5, 5×1, 1×1 and default 3×3 grids on both outputs.
- Runtime keyboard navigation, landscape/portrait last-slot pointer selection,
  synthetic cancel-swipe endpoints, bounded growth and capped padding pass.
- Actual window drag into an uncreated tenth slot creates the correct workspace;
  cross-output drag reaches the portrait output's tenth slot. Dynamic layout is
  identical with rows=1 and rows=7.
- Documentation build, all16 pin checks and independent code/architecture reviews
  pass. Screenshot layout review passes.

The published v0.56.2 tag, release pins, master and the installed desktop plugin
are unchanged. Build this PR revision explicitly for testing; the current release
pins intentionally continue selecting the previously released source. Physical
touchpad input was not exercised; swipe endpoints use the production adapter's
callback sequence in a separate test-only probe.
