### PR TITLE
Update HyprPM description for hyprexpo

### DIFF
--- a/hyprpm.toml
+++ b/hyprpm.toml
@@ -21,7 +21,7 @@ commit_pins = [
 ]
 
 [hyprexpo]
-description = "hyprexpo+ — keyboard selection, labels, gaps, and Hyprland-style borders"
+description = "Exposé-style workspace and window overviews for Hyprland"
 authors = ["sandwich"]
 output = "hyprexpo.so"
 build = [


### PR DESCRIPTION
Replace the old `hyprexpo+` feature-list description with a description of the
current hyprexpo project:

> Exposé-style workspace and window overviews for Hyprland

Only `[hyprexpo].description` changes in `hyprpm.toml`. Repository/plugin names,
authors, build/output settings and all release pins are unchanged. This PR is
independent of the rectangular-grid work in #118.

Validation: parsed the TOML and compared it with master to confirm the description
is the only changed value; all 16 pin ancestry checks and `git diff --check` pass.
No build or runtime behavior changes.
