### PR TITLE
Restore the original demo video below the README introduction

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 HyprExpo is a maintained Hyprland plugin for expose-style workspace overview with keyboard selection, drag-drop window movement, labels, configurable gaps and borders, multi-monitor placement, and Lua gestures.
 
+https://github.com/user-attachments/assets/861baa26-46b6-4fa8-8d37-65cbb9ecbed4
+
 Native Hyprland scrolling-layout workspaces open a separate window-level
 scrolling overview. It preserves the full offscreen tape, supports pointer,
 touch, keyboard, panning, and positional window moves, and reuses grid captures


### PR DESCRIPTION
Restore the original HyprExpo demonstration video directly below the README heading and short description. The attachment was removed in the site update merged as #27; this uses the same original GitHub attachment URL.

Only the video URL and a separating blank line are added. The rest of the README is byte-for-byte unchanged.

Verified the URL against the historical README, the live attachment response (`206`, `video/mp4`, valid MP4 signature), its exact placement, and `git diff --check`.
