### PR TITLE
Guard HyprPM registrations and releases against temporary revisions

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -44,8 +44,8 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: Verify target contract and negative cases
-        run: python3 -m unittest discover -s tests -p 'test_ci_*.py' -v
+      - name: Verify tooling contracts and negative cases
+        run: make test-tooling
       - name: Compile and run all standalone regression suites
         run: make -B test
       - name: Verify every historical release pin is reachable

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,45 @@
+# Contributing
+
+Follow the [branch policy](docs/reference/branch-policy.md) and validate against
+the Hyprland revisions affected by your change.
+
+## Local Installation Contract
+
+These rules apply to maintainers, contributors, and coding agents.
+
+- Test PR builds with `make dev-reload` or `./scripts/run-nested.sh`. Keep the
+  checkout and built artifact available for the test session.
+- Do not write a PR commit or temporary branch into the desktop's hyprpm
+  `repository.rev`, or set that override to keep a test build installed. A
+  squash merge and branch deletion can make the original commit unavailable
+  to `hyprpm update`, even when it still exists in your local Git database.
+- From a checkout, register a managed installation through
+  `./scripts/hyprpm-add.sh <repository-url> [revision]`. Released Hyprland
+  normally uses no revision argument so hyprpm can select `commit_pins`.
+  The wrapper validates an explicit revision before invoking hyprpm.
+- Run `make check-hyprpm-state` before any manual managed replacement.
+  `make install` and `scripts/dev-link.sh` enforce this check themselves.
+  Do not bypass a failed check by editing `rev` to another test hash.
+- Keep supported branch and release-tag history available upstream. Persistent
+  hashes must remain reachable from that history; temporary PR refs are not
+  retention anchors. Follow the [recovery procedure](docs/troubleshooting.md#hyprpm-cannot-check-out-a-saved-revision)
+  when a saved override is already stale.
+- Back up the existing state and artifact before intentional replacements;
+  never overwrite the inode of a loaded shared object. Verify the matching
+  ABI, loaded plugin, and config errors after loading.
+
+The guard uses Git and Python 3.11+ standard-library tooling. Unpinned and
+unmanaged destinations pass without network access. Explicit revisions require
+a fresh upstream clone; failed verification stops the operation without
+changing the plugin or saved state. This verifies revision retention, not ABI
+compatibility, and does not intercept direct hyprpm commands or manual edits.
+
+## Guard Regression Tests
+
+Run `make test-tooling` for the Git/installer fixtures and `make test` for the
+standalone C++ suites. Tooling tests use disposable repositories and fake plugin
+artifacts, never the running desktop or a real publication remote. Both suites
+are required by compatibility CI.
+
+The release commands must stop if `check-commit-pins.sh` fails. Never suppress
+that failure or publish a PR commit merely because the local object exists.

--- a/Makefile
+++ b/Makefile
@@ -63,9 +63,12 @@ dev-reload: dev-build
 dev-nested:
 	./scripts/run-nested.sh
 
-install: $(TARGET)
+check-hyprpm-state:
+	@python3 scripts/check-hyprpm-state.py "$(INSTALL_DIR)/state.toml"
+
+install: check-hyprpm-state $(TARGET)
 	@echo "Installing for $(INSTALL_USER) into $(INSTALL_DIR)/$(INSTALL_NAME)"
-	install -Dm755 $(TARGET) $(INSTALL_DIR)/$(INSTALL_NAME)
+	install -Dm755 "$(TARGET)" "$(INSTALL_DIR)/$(INSTALL_NAME)"
 
 clean:
 	rm -f ./$(TARGET) ./$(TEST_TARGET) ./$(SOURCE_TEST_TARGET) ./$(REGISTRY_TEST_TARGET) ./$(INPUT_ORACLE_TARGET)
@@ -74,6 +77,9 @@ test: $(TEST_TARGET) $(SOURCE_TEST_TARGET) $(REGISTRY_TEST_TARGET)
 	./$(TEST_TARGET)
 	./$(SOURCE_TEST_TARGET)
 	./$(REGISTRY_TEST_TARGET)
+
+test-tooling:
+	python3 -m unittest discover -s tests -p 'test_*.py' -v
 
 $(TEST_TARGET): src/HyprexpoLogic.cpp src/HyprexpoLogic.hpp src/HyprexpoConfig.hpp src/ScrollingOverviewLogic.cpp src/ScrollingOverviewLogic.hpp src/ScrollingInputState.cpp src/ScrollingInputState.hpp src/ScrollingRequestId.hpp src/ScrollingMutationTransaction.cpp src/ScrollingMutationTransaction.hpp tests/HyprexpoLogicTests.cpp
 	$(CXX) -std=c++2b -Wall -Wextra -Werror src/HyprexpoLogic.cpp src/ScrollingOverviewLogic.cpp src/ScrollingInputState.cpp src/ScrollingMutationTransaction.cpp tests/HyprexpoLogicTests.cpp -o $@
@@ -104,7 +110,8 @@ endif
 SET_VERSION := $(if $(VERSION_ARG),$(VERSION_ARG),$(v))
 
 version:
-	@if [ -z '$(SET_VERSION)' ]; then \
+	@set -e; \
+	if [ -z '$(SET_VERSION)' ]; then \
 		printf '%s\n' '$(VERSION)'; \
 	else \
 		printf '%s' '$(SET_VERSION)' | grep -Eq '$(VERSION_REGEX)' \
@@ -119,7 +126,8 @@ version:
 	fi
 
 tag:
-	@v='$(VERSION_BASE)'; \
+	@set -e; \
+	v='$(VERSION_BASE)'; \
 	printf '%s' "$$v" | grep -Eq '$(VERSION_REGEX)' \
 		|| { echo "error: VERSION file '$$v' must look like v1.2.3 or v1.2.3+4"; exit 1; }; \
 	if [ -n "$$(git status --porcelain -- $(VERSION_FILE))" ]; then \
@@ -133,7 +141,8 @@ tag:
 	echo "created tag $$v. next: make publish"
 
 publish:
-	@v='$(VERSION_BASE)'; \
+	@set -e; \
+	v='$(VERSION_BASE)'; \
 	if ! git rev-parse -q --verify "refs/tags/$$v" >/dev/null; then \
 		echo "error: tag $$v does not exist; run 'make tag' first"; exit 1; fi; \
 	./scripts/check-commit-pins.sh "$$v"; \
@@ -159,4 +168,4 @@ check-version:
 		|| { echo "::error::VERSION ($$file_ver) does not match tag ($$tag_ver)"; exit 1; }; \
 	echo "version aligned: $$file_ver"
 
-.PHONY: all clean install test dev-build dev-load dev-reload dev-nested version tag publish check-pins check-version
+.PHONY: all clean install test test-tooling dev-build dev-load dev-reload dev-nested version tag publish check-pins check-version check-hyprpm-state

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -12,6 +12,18 @@ hyprpm reload
 
 The plugin repository is named `hyprexpo` in `hyprpm.toml`, and the built output is `hyprexpo.so`.
 
+When registering from a source checkout, use the guarded wrapper:
+
+```bash
+./scripts/hyprpm-add.sh https://github.com/sandwichfarm/hyprexpo
+```
+
+It also accepts a revision argument for the [development track](../guides/development-installation.md).
+Before invoking hyprpm, an explicit revision is checked in a fresh clone against
+maintained branch or release-tag history. A temporary PR branch or a PR-only
+commit is rejected. A locally available commit is not sufficient: squash merges
+can leave it unavailable to a future normal clone.
+
 ## Build From Source
 
 Build dependencies are a C++23 compiler, `pkg-config`, Hyprland development headers, and these pkg-config packages:
@@ -72,6 +84,15 @@ make install
 hyprpm reload
 ```
 
+`make install` and `scripts/dev-link.sh` check the saved `repository.rev` before
+changing a managed destination. The preflight uses Git and Python 3.11+ and
+requires network access only for an explicit revision. Run it independently
+with `make check-hyprpm-state` (`INSTALL_USER` and `INSTALL_DIR` select the same
+destination as `make install`). Failed or unreadable state stops replacement;
+see [saved-revision recovery](../troubleshooting.md#hyprpm-cannot-check-out-a-saved-revision).
+These commands never persist a test revision. Use the development load commands
+above for PR testing.
+
 If the hyprpm artifact path is root-owned, keep the privilege at the command
 line and preserve the target user explicitly:
 
@@ -83,8 +104,9 @@ hyprpm reload
 Equivalent manual install:
 
 ```bash
+make check-hyprpm-state &&
 install -Dm755 hyprexpo.so \
-    /var/cache/hyprpm/$USER/hyprexpo/hyprexpo.so
+    "/var/cache/hyprpm/$USER/hyprexpo/hyprexpo.so"
 hyprpm reload
 ```
 

--- a/docs/guides/development-installation.md
+++ b/docs/guides/development-installation.md
@@ -11,22 +11,22 @@ flake lock and the running compositor's `hyprctl version` output against the
 [validation receipt](../reference/workflow-validation.md). Test in a disposable
 compositor before changing a desktop.
 
-While [PR #122](https://github.com/sandwichfarm/hyprexpo/pull/122) is unmerged,
-its implementation is on `integration/chase-validation`. For candidate testing,
-use `origin/integration/chase-validation` with hyprpm or that candidate's full
-commit in the Nix URL. Commands below using `hyprland-git` assume that branch
-contains the validated candidate and matching lock; branch creation alone is
-insufficient.
+Commands below using `hyprland-git` assume that branch contains the validated
+candidate and matching lock; branch creation alone is insufficient. Test an
+unmerged candidate from its checkout in a disposable compositor. Do not save
+its PR hash or temporary branch in a desktop's hyprpm registration: a later
+squash merge or branch deletion can break updates.
 
 ## hyprpm Revision Selection
 
 Hyprpm accepts an optional Git revision after the repository URL. Its
 implementation clones the repository and resets to that revision. For a
-non-default branch, use its remote-tracking ref in the fresh clone:
+non-default branch, use its remote-tracking ref in the fresh clone. From a
+HyprExpo checkout, use the guarded registration wrapper:
 
 ```sh
 hyprpm update
-hyprpm add https://github.com/sandwichfarm/hyprexpo origin/hyprland-git
+./scripts/hyprpm-add.sh https://github.com/sandwichfarm/hyprexpo origin/hyprland-git
 hyprpm enable hyprexpo
 hyprpm reload
 ```
@@ -36,11 +36,17 @@ chase track; do not use it on released Hyprland to bypass a failed compatibility
 check. A bare `hyprland-git` name does not resolve in a fresh clone where only
 `master` exists locally. `origin/hyprland-git` does.
 
-For an immutable plugin candidate, use its full commit hash in place of
-`origin/hyprland-git`. Keep the corresponding compositor revision and dependency
-environment together. The same mechanism can validate an unmerged candidate
-using its published `origin/<candidate-branch>` ref; this does not establish
-support for a different published branch tip.
+For an immutable plugin candidate already retained by maintained history, use
+its full commit hash in place of `origin/hyprland-git`. The guard accepts hashes
+reachable from `master`, `hyprland-git`, declared `release/<version>` branches,
+or versioned release tags in a fresh clone. Temporary branch names and commits
+reachable only through PR history are rejected before registration. Keep the
+corresponding compositor revision and dependency environment together.
+
+For unmerged PR tests, use `make dev-reload` or `./scripts/run-nested.sh` in the
+test checkout without changing managed state. Direct revision-specific hyprpm
+tests belong in a disposable environment whose registration is discarded with
+the test. They do not establish a persistent installation or future availability.
 
 Hyprpm cannot add the same repository twice. To change the selected revision,
 first disable and remove the existing registration, then add the intended
@@ -149,7 +155,7 @@ session. Preserve the old consumer lock and system generation for rollback.
 
 | Symptom | Check and recovery |
 | --- | --- |
-| Git revision cannot be checked out | Use `origin/hyprland-git` or a full commit reachable from the repository; verify it in a fresh clone. |
+| Git revision cannot be checked out | Check the saved override and follow [saved-revision recovery](../troubleshooting.md#hyprpm-cannot-check-out-a-saved-revision). Verify any replacement against maintained history in a fresh clone. |
 | Missing or changed C++ APIs | Compare the source revision with the exact compositor target. Select a compatible candidate before retrying. |
 | Header or plugin ABI mismatch | Confirm the running session matches the installed compositor, then regenerate headers/rebuild with its dependency environment. Restart into the intended compositor when disk and running versions differ. |
 | Nix input follows the system but build fails | Check source compatibility and the complete lock, not only the top-level Hyprland input. Retain the failing build log. |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,5 +1,46 @@
 # Troubleshooting
 
+## hyprpm Cannot Check Out a Saved Revision
+
+If `hyprpm update` prints `Plugin has revision set, resetting` followed by
+`Could not parse object`, inspect `repository.rev` in
+`/var/cache/hyprpm/$USER/hyprexpo/state.toml`. An explicit revision overrides
+the repository's compatibility pins. A PR commit can disappear from normal
+clones after a squash merge and deletion of its temporary branch; retaining
+the object in a developer checkout does not make the installation updateable.
+
+From a source checkout, run `make check-hyprpm-state`. The check makes no changes.
+It accepts unpinned state offline, and verifies explicit revisions using a fresh
+clone. Failed network access also refuses replacement instead of assuming the
+revision is safe. It cannot establish ABI compatibility or guarantee that an
+upstream maintainer will preserve the accepted refs in the future.
+
+To restore normal pin selection on a **supported released Hyprland**, first
+back up the installed state and binary, then re-register without a revision:
+
+```bash
+backup_root="${XDG_STATE_HOME:-$HOME/.local/state}/hyprexpo"
+mkdir -p "$backup_root" &&
+backup_dir="$(mktemp -d "$backup_root/revision-recovery.XXXXXX")" &&
+cp -a "/var/cache/hyprpm/$USER/hyprexpo" "$backup_dir/" &&
+hyprpm remove hyprexpo &&
+./scripts/hyprpm-add.sh https://github.com/sandwichfarm/hyprexpo &&
+hyprpm enable hyprexpo &&
+hyprpm reload &&
+hyprctl reload
+```
+
+Keep the backup until loading succeeds. Run hyprpm as your normal user and
+authenticate its sudo prompt in your terminal. If a command fails, stop and
+retain the output and backup. Do not delete the entire cache or replace `rev`
+with another temporary PR hash. Development-track installations must retain
+their matching compositor and use the [development recovery procedure](./guides/development-installation.md#troubleshooting-and-rollback).
+
+Verify `hyprctl version`, `hyprctl plugin list`, and `hyprctl configerrors` after
+recovery. A failed install can unload the plugin and cause `unknown config key
+'plugin.hyprexpo.…'` errors until it is loaded again. Finish loading and reload
+the config before treating these as removed options.
+
 ## Plugin Load Fails With API or Hash Mismatch
 
 Rebuild HyprExpo against the same Hyprland revision that is running, then reload the plugin.

--- a/scripts/check-hyprpm-state.py
+++ b/scripts/check-hyprpm-state.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Reject hyprpm registrations and replacements tied to temporary history."""
+
+import argparse
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+import tempfile
+import tomllib
+
+
+RELEASE_TAG = r"v[0-9]+\.[0-9]+\.[0-9]+(?:\+[0-9]+)?"
+RETAINED_BRANCH = r"(?:master|hyprland-git|release/[0-9]+(?:\.[0-9]+)*)"
+
+
+def retained_ref(ref):
+    return bool(
+        re.fullmatch(r"refs/remotes/origin/" + RETAINED_BRANCH, ref)
+        or re.fullmatch(r"refs/tags/" + RELEASE_TAG, ref)
+    )
+
+
+def check_state(state):
+    try:
+        with state.open("rb") as stream:
+            data = tomllib.load(stream)
+    except FileNotFoundError:
+        if state.is_symlink():
+            raise ValueError("state.toml is a dangling symlink")
+        return "no managed state at this destination"
+
+    return check_repository(data.get("repository"))
+
+
+def check_repository(repository):
+    if not isinstance(repository, dict):
+        raise ValueError("state.toml has no repository table")
+    rev = repository.get("rev", "")
+    if not isinstance(rev, str):
+        raise ValueError("repository.rev must be a string")
+    if not rev:
+        return "no explicit revision override; hyprpm can select compatibility pins"
+
+    # A temporary branch can disappear even when its current commit is on master.
+    if not (
+        re.fullmatch(r"[0-9a-fA-F]{40}", rev)
+        or rev in ("master", "refs/heads/master")
+        or retained_ref(rev)
+        or retained_ref("refs/remotes/" + rev)
+        or re.fullmatch(RELEASE_TAG, rev)
+    ):
+        raise ValueError("repository.rev names temporary or unsupported history: " + rev)
+
+    url = repository.get("url")
+    if not isinstance(url, str) or not url.strip():
+        raise ValueError("an explicit revision requires repository.url")
+
+    # Do not inherit another checkout's objects, refs, or working tree. In
+    # particular, an old PR object in a local clone must not make this pass.
+    environment = os.environ.copy()
+    for name in (
+        "GIT_DIR", "GIT_COMMON_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE",
+        "GIT_OBJECT_DIRECTORY", "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+        "GIT_SHALLOW_FILE", "GIT_NAMESPACE",
+    ):
+        environment.pop(name, None)
+    environment["GIT_TERMINAL_PROMPT"] = "0"
+
+    def git(*args):
+        try:
+            return subprocess.run(
+                ["git", *args], capture_output=True, text=True,
+                env=environment, timeout=60,
+            )
+        except subprocess.TimeoutExpired:
+            # TimeoutExpired includes the command, which may contain URL credentials.
+            raise ValueError("Git verification timed out; installation refused") from None
+
+    with tempfile.TemporaryDirectory(prefix="hyprexpo-revision-check-") as directory:
+        clone = str(Path(directory) / "repo")
+        # --no-local is essential for local URLs: copying the object directory
+        # would retain unreachable commits which a normal remote clone omits.
+        # Empty templates prevent injected local refs and alternate object stores.
+        result = git("clone", "--quiet", "--no-checkout", "--no-local", "--template=", "--", url, clone)
+        if result.returncode:
+            raise ValueError("cannot verify repository.url with a fresh clone; installation refused")
+        result = git("-C", clone, "rev-parse", "--verify", "--end-of-options", rev + "^{commit}")
+        if result.returncode:
+            raise ValueError("saved revision is unavailable in a fresh clone: " + rev)
+        commit = result.stdout.strip()
+        result = git("-C", clone, "for-each-ref", "--format=%(refname)", "refs/remotes/origin/", "refs/tags/")
+        if result.returncode:
+            raise ValueError("cannot enumerate retained upstream history")
+        for ref in result.stdout.splitlines():
+            if not retained_ref(ref):
+                continue
+            result = git("-C", clone, "merge-base", "--is-ancestor", commit, ref + "^{commit}")
+            if result.returncode == 0:
+                return f"saved revision {rev} is retained by {ref}"
+            if result.returncode != 1:
+                raise ValueError("cannot verify retained upstream history: " + ref)
+        raise ValueError("saved revision is not retained by a release tag or maintained branch: " + rev)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("state", nargs="?", type=Path, help="state.toml beside the managed destination (do not resolve the .so symlink)")
+    parser.add_argument("--url", help="repository URL for a proposed registration")
+    parser.add_argument("--revision", help="proposed revision, or an empty string for compatibility pins")
+    args = parser.parse_args()
+    proposal = args.url is not None or args.revision is not None
+    if proposal and (args.state is not None or args.url is None or args.revision is None):
+        parser.error("use either a state path or both --url and --revision")
+    if not proposal and args.state is None:
+        parser.error("a state path or both --url and --revision are required")
+    try:
+        if proposal:
+            if not args.url.strip():
+                raise ValueError("repository URL must not be empty")
+            message = check_repository({"url": args.url, "rev": args.revision})
+        else:
+            message = check_state(args.state)
+    except (OSError, ValueError, subprocess.SubprocessError) as error:
+        location = "proposed registration" if proposal else str(args.state)
+        print(f"error: unsafe hyprpm state at {location}: {error}", file=sys.stderr)
+        print(
+            "No plugin or state was changed by this check. Use make dev-reload or a nested session for PR testing.\n"
+            "For recovery, see docs/troubleshooting.md; do not replace the saved revision with another PR hash.",
+            file=sys.stderr,
+        )
+        return 1
+    print("hyprpm state verified: " + message)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/dev-link.sh
+++ b/scripts/dev-link.sh
@@ -167,7 +167,7 @@ if [[ -z "$target_so" || $do_list -eq 1 || $do_interactive -eq 1 ]]; then
   filtered=()
   for c in "${candidates[@]}"; do
     ca="$(readlink -f "$c" 2>/dev/null || true)"
-    [[ -n "$ca" && "$ca" != "$local_abs" ]] && filtered+=("$ca")
+    [[ -n "$ca" && "$ca" != "$local_abs" ]] && filtered+=("$c")
   done
 
   if (( do_list )); then
@@ -206,6 +206,7 @@ fi
 
 msg "Target: $target_so"
 ensure_writable_target "$target_so"
+python3 "$script_dir/check-hyprpm-state.py" "$(dirname "$target_so")/state.toml"
 
 local_abs="$(readlink -f "$local_so")"
 target_abs="$(readlink -f "$target_so" 2>/dev/null || true)"

--- a/scripts/hyprpm-add.sh
+++ b/scripts/hyprpm-add.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Validate a proposed persistent revision before hyprpm writes its registration.
+set -euo pipefail
+
+if (( $# < 1 || $# > 2 )); then
+    echo "usage: $0 <repository-url> [revision]" >&2
+    exit 2
+fi
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+python3 "$script_dir/check-hyprpm-state.py" --url="$1" --revision="${2:-}"
+exec hyprpm add "$@"

--- a/tests/test_hyprpm_release_guards.py
+++ b/tests/test_hyprpm_release_guards.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Exercise the actual release recipes against disposable, offline Git repos."""
+
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class ReleaseGuardsTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory(prefix="hyprexpo-release-test-")
+        self.addCleanup(self.temporary.cleanup)
+        self.directory = Path(self.temporary.name)
+        self.repo = self.directory / "repo"
+        self.remote = self.directory / "remote.git"
+        self.repo.mkdir()
+        self.env = {
+            key: value for key, value in os.environ.items()
+            if not key.startswith("GIT_")
+            and key not in {"MAKEFLAGS", "MFLAGS", "MAKEOVERRIDES", "MAKEFILES"}
+        }
+        self.env.update({
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_CONFIG_GLOBAL": os.devnull,
+            "GIT_TERMINAL_PROMPT": "0",
+            "GIT_ALLOW_PROTOCOL": "file",
+            "LC_ALL": "C",
+        })
+        self.git("init", "--initial-branch=master")
+        self.git("config", "user.name", "Release fixture")
+        self.git("config", "user.email", "fixture@example.invalid")
+        self.git("config", "commit.gpgsign", "false")
+        self.git("config", "tag.gpgsign", "false")
+        for relative in ("Makefile", "scripts/version.sh", "scripts/check-commit-pins.sh"):
+            destination = self.repo / relative
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(ROOT / relative, destination)
+        (self.repo / "VERSION").write_text("v1.2.3\n")
+        self.git("add", ".")
+        self.git("commit", "-m", "Provide the initial release fixture")
+        self.pin = self.git("rev-parse", "HEAD").stdout.strip()
+        self.set_pin(self.pin)
+        self.git("init", "--bare", "--initial-branch=master", str(self.remote))
+        self.git("remote", "add", "origin", str(self.remote))
+        self.git("push", "-u", "origin", "master")
+
+    def run_command(self, *args, check=True):
+        result = subprocess.run(
+            args, cwd=self.repo, env=self.env, text=True,
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT, timeout=20,
+        )
+        if check:
+            self.assertEqual(result.returncode, 0, result.stdout)
+        return result
+
+    def git(self, *args, **kwargs):
+        return self.run_command("git", *args, **kwargs)
+
+    def make(self, *args):
+        return self.run_command("make", "--no-print-directory", *args, check=False)
+
+    def set_pin(self, pin):
+        (self.repo / "hyprpm.toml").write_text(
+            '[repository]\nname = "fixture"\ncommit_pins = [\n'
+            f'    ["{"a" * 40}", "{pin}"],\n]\n'
+        )
+        self.git("add", "hyprpm.toml")
+        self.git("commit", "-m", "Select the fixture plugin revision")
+
+    def stage_unrelated_change(self):
+        (self.repo / "unrelated.txt").write_text("Keep this staged change.\n")
+        self.git("add", "unrelated.txt")
+
+    def snapshot(self):
+        return {
+            "version": (self.repo / "VERSION").read_bytes(),
+            "head": self.git("rev-parse", "HEAD").stdout,
+            "index": self.git("write-tree").stdout,
+            "tags": self.git("for-each-ref", "refs/tags").stdout,
+            "remote_refs": self.git("--git-dir", str(self.remote), "for-each-ref").stdout,
+        }
+
+    def assert_rejected_without_changes(self, *args):
+        self.stage_unrelated_change()
+        before = self.snapshot()
+        result = self.make(*args)
+        # Check side effects even if a later echo incorrectly hides the error.
+        self.assertEqual(self.snapshot(), before, result.stdout)
+        self.assertNotEqual(result.returncode, 0, result.stdout)
+        self.assertIn("hyprpm plugin pins must be fetchable", result.stdout)
+        self.assertNotIn("next: make", result.stdout)
+        self.assertNotIn("pushed branch + tag", result.stdout)
+
+    def make_unlanded_pin(self):
+        # The object exists locally, but this unmerged PR commit is not in HEAD.
+        tree = self.git("rev-parse", "HEAD^{tree}").stdout.strip()
+        unlanded = self.git("commit-tree", tree, "-p", "HEAD", "-m", "Unmerged PR").stdout.strip()
+        self.set_pin(unlanded)
+
+    def test_version_rejects_unlanded_pin_before_mutation(self):
+        self.make_unlanded_pin()
+        self.assert_rejected_without_changes("version", "v1.2.3+1")
+
+    def test_tag_rejects_unlanded_pin_before_mutation(self):
+        self.make_unlanded_pin()
+        self.assert_rejected_without_changes("tag")
+
+    def test_publish_rejects_unlanded_pin_before_either_push(self):
+        self.make_unlanded_pin()
+        self.git("tag", "-a", "v1.2.3", "-m", "Invalid release fixture")
+        self.assert_rejected_without_changes("publish")
+
+    def test_version_rejects_unavailable_pin_before_mutation(self):
+        self.set_pin("0" * 40)
+        self.assert_rejected_without_changes("version", "v=v1.2.3+1")
+
+    def test_tag_rejects_unavailable_pin_before_mutation(self):
+        self.set_pin("0" * 40)
+        self.assert_rejected_without_changes("tag")
+
+    def test_publish_rejects_unavailable_pin_before_either_push(self):
+        self.set_pin("0" * 40)
+        self.git("tag", "-a", "v1.2.3", "-m", "Invalid release fixture")
+        self.assert_rejected_without_changes("publish")
+
+    def test_valid_version_tag_publish_flow(self):
+        self.stage_unrelated_change()
+        old_head = self.git("rev-parse", "HEAD").stdout.strip()
+        result = self.make("version", "v1.2.3+1")
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertEqual((self.repo / "VERSION").read_text(), "v1.2.3+1\n")
+        self.assertEqual(self.git("rev-parse", "HEAD^").stdout.strip(), old_head)
+        self.assertEqual(self.git("diff", "--cached", "--name-only").stdout, "unrelated.txt\n")
+        self.assertEqual(self.git("diff", "HEAD^", "HEAD", "--name-only").stdout, "VERSION\n")
+        result = self.make("tag")
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertEqual(self.git("cat-file", "-t", "v1.2.3+1").stdout, "tag\n")
+        self.assertEqual(self.git("rev-parse", "v1.2.3+1^{commit}").stdout,
+                         self.git("rev-parse", "HEAD").stdout)
+        result = self.make("publish")
+        self.assertEqual(result.returncode, 0, result.stdout)
+        for ref in ("refs/heads/master", "refs/tags/v1.2.3+1"):
+            self.assertEqual(self.git("--git-dir", str(self.remote), "rev-parse", ref).stdout,
+                             self.git("rev-parse", ref).stdout)
+
+    def test_rejected_branch_push_does_not_push_tag(self):
+        result = self.make("version", "v1.2.3+1")
+        self.assertEqual(result.returncode, 0, result.stdout)
+        result = self.make("tag")
+        self.assertEqual(result.returncode, 0, result.stdout)
+        hook = self.remote / "hooks" / "update"
+        hook.write_text('#!/bin/sh\ncase "$1" in refs/heads/*) exit 1;; esac\n')
+        hook.chmod(0o755)
+        before = self.snapshot()
+        result = self.make("publish")
+        self.assertEqual(self.snapshot(), before, result.stdout)
+        self.assertNotEqual(result.returncode, 0, result.stdout)
+        self.assertIn("hook declined", result.stdout)
+        self.assertNotIn("pushed branch + tag", result.stdout)
+        # Prove this remote would accept the tag if the recipe tried its second push.
+        self.git("push", "origin", "v1.2.3+1")
+        self.assertEqual(self.git("--git-dir", str(self.remote), "rev-parse", "refs/tags/v1.2.3+1").stdout,
+                         self.git("rev-parse", "refs/tags/v1.2.3+1").stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_hyprpm_state.py
+++ b/tests/test_hyprpm_state.py
@@ -1,0 +1,475 @@
+#!/usr/bin/env python3
+"""Exercise installed-state validation and install boundaries using real Git repos."""
+
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+GUARD = ROOT / "scripts/check-hyprpm-state.py"
+
+
+class HyprpmStateTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory(prefix="hyprexpo-state-test-")
+        self.addCleanup(self.temporary.cleanup)
+        self.directory = Path(self.temporary.name)
+        self.repo = self.directory / "caller"
+        self.remote = self.directory / "remote.git"
+        self.install_dir = self.directory / "installed"
+        self.repo.mkdir()
+        self.install_dir.mkdir()
+        self.state = self.install_dir / "state.toml"
+        self.env = {
+            key: value for key, value in os.environ.items()
+            if not key.startswith("GIT_")
+            and key not in {"MAKEFLAGS", "MFLAGS", "MAKEOVERRIDES", "MAKEFILES"}
+        }
+        self.env.update({
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_CONFIG_GLOBAL": os.devnull,
+            "GIT_TERMINAL_PROMPT": "0",
+            "GIT_ALLOW_PROTOCOL": "file",
+            "LC_ALL": "C",
+            "XDG_CACHE_HOME": str(self.directory / "cache"),
+            "XDG_DATA_HOME": str(self.directory / "data"),
+        })
+        self.git("init", "--initial-branch=master")
+        self.git("config", "user.name", "State fixture")
+        self.git("config", "user.email", "fixture@example.invalid")
+        self.git("config", "commit.gpgsign", "false")
+        self.git("config", "tag.gpgsign", "false")
+        (self.repo / "payload").write_text("Fixture tree.\n")
+        self.git("add", ".")
+        self.git("commit", "-m", "Provide the retained master history")
+        self.master = self.git("rev-parse", "HEAD").stdout.strip()
+        self.tree = self.git("rev-parse", "HEAD^{tree}").stdout.strip()
+        self.git("init", "--bare", "--initial-branch=master", str(self.remote))
+        self.git("remote", "add", "origin", str(self.remote))
+        self.git("push", "-u", "origin", "master")
+
+    def command(self, *args, check=True, env=None):
+        result = subprocess.run(
+            args, cwd=self.repo, env=env or self.env, text=True,
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT, timeout=20,
+        )
+        if check:
+            self.assertEqual(result.returncode, 0, result.stdout)
+        return result
+
+    def git(self, *args, **kwargs):
+        return self.command("git", *args, **kwargs)
+
+    def commit(self, message, parent=None):
+        args = ["commit-tree", self.tree, "-m", message]
+        if parent:
+            args.extend(["-p", parent])
+        return self.git(*args).stdout.strip()
+
+    def publish_branch(self, name, commit):
+        self.git("push", "origin", f"{commit}:refs/heads/{name}")
+
+    def set_revision(self, revision, url=None):
+        self.state.write_text(
+            "[repository]\n"
+            f"url = {json.dumps(str(self.remote) if url is None else url)}\n"
+            f"rev = {json.dumps(revision)}\n"
+        )
+
+    def snapshot(self, path):
+        if not path.exists() and not path.is_symlink():
+            return None
+        info = path.lstat()
+        contents = os.readlink(path) if path.is_symlink() else path.read_bytes()
+        return (info.st_ino, info.st_mode, info.st_size, info.st_mtime_ns, contents)
+
+    def guard(self, expected, env=None):
+        before = self.snapshot(self.state)
+        result = self.command(sys.executable, str(GUARD), str(self.state), check=False, env=env)
+        self.assertEqual(self.snapshot(self.state), before, result.stdout)
+        self.assertEqual(result.returncode, expected, result.stdout)
+        return result
+
+    def test_absent_state_passes_without_git(self):
+        self.guard(0, env={**self.env, "PATH": str(self.directory / "no-programs")})
+
+    def test_unpinned_state_passes_without_git_or_remote(self):
+        states = (
+            "[repository]\n",
+            '[repository]\nurl = "https://unreachable.invalid/repo.git"\n',
+            '[repository]\nrev = ""\nurl = "https://unreachable.invalid/repo.git"\n',
+        )
+        for contents in states:
+            with self.subTest(contents=contents):
+                self.state.write_text(contents)
+                self.guard(0, env={**self.env, "PATH": str(self.directory / "no-programs")})
+
+    def test_malformed_toml_and_invalid_utf8_are_rejected(self):
+        for contents in (b"[repository\n", b"[repository]\nrev = \xff\n"):
+            with self.subTest(contents=contents):
+                self.state.write_bytes(contents)
+                self.guard(1)
+
+    def test_missing_or_invalid_repository_table_is_rejected(self):
+        for contents in ("", "enabled = true\n", 'repository = "invalid"\n'):
+            with self.subTest(contents=contents):
+                self.state.write_text(contents)
+                self.guard(1)
+
+    def test_non_string_revisions_are_rejected(self):
+        for value in ("123", "true", "[]", "{}"):
+            with self.subTest(value=value):
+                self.state.write_text(f"[repository]\nrev = {value}\n")
+                self.guard(1)
+
+    @unittest.skipIf(os.geteuid() == 0, "Root can read permission-denied fixtures")
+    def test_unreadable_state_is_rejected_without_changing_permissions(self):
+        self.set_revision("master")
+        self.state.chmod(0)
+        before = self.state.stat()
+        try:
+            result = self.command(sys.executable, str(GUARD), str(self.state), check=False)
+            after = self.state.stat()
+            self.assertEqual(result.returncode, 1, result.stdout)
+            self.assertEqual((after.st_ino, after.st_mode, after.st_mtime_ns),
+                             (before.st_ino, before.st_mode, before.st_mtime_ns))
+        finally:
+            self.state.chmod(0o600)
+
+    def test_state_directory_is_rejected(self):
+        self.state.mkdir()
+        result = self.command(sys.executable, str(GUARD), str(self.state), check=False)
+        self.assertEqual(result.returncode, 1, result.stdout)
+        self.assertTrue(self.state.is_dir())
+
+    def test_missing_or_invalid_repository_url_is_rejected(self):
+        for url_line in ("", 'url = ""\n', "url = 42\n"):
+            with self.subTest(url_line=url_line):
+                self.state.write_text('[repository]\nrev = "master"\n' + url_line)
+                self.guard(1)
+
+    def test_unavailable_remote_fails_closed(self):
+        self.set_revision("master", str(self.directory / "missing.git"))
+        self.guard(1)
+
+    def test_transport_failure_fails_closed(self):
+        # The transport allowlist rejects HTTPS immediately without using the network.
+        self.set_revision(self.master, "https://unreachable.invalid/repo.git")
+        self.guard(1)
+
+    def test_master_names_resolve_from_fresh_remote(self):
+        for revision in ("master", "origin/master", "refs/heads/master",
+                         "refs/remotes/origin/master"):
+            with self.subTest(revision=revision):
+                self.set_revision(revision)
+                self.guard(0)
+
+    def test_retained_development_and_maintenance_names(self):
+        for branch in ("hyprland-git", "release/0.56"):
+            retained = self.commit(f"Independent {branch} history")
+            self.publish_branch(branch, retained)
+            for revision in (f"origin/{branch}", f"refs/remotes/origin/{branch}"):
+                with self.subTest(revision=revision):
+                    self.set_revision(revision)
+                    self.guard(0)
+
+    def test_commit_hashes_in_each_retained_history(self):
+        for branch in ("master", "hyprland-git", "release/0.56"):
+            ancestor = self.master if branch == "master" else self.commit(f"Base for {branch}")
+            tip = self.commit(f"Advance {branch}", parent=ancestor)
+            self.publish_branch(branch, tip)
+            for revision in (ancestor, tip):
+                with self.subTest(branch=branch, revision=revision):
+                    self.set_revision(revision)
+                    self.guard(0)
+
+    def test_lightweight_and_annotated_version_tags_retain_history(self):
+        for name, annotated in (("v1.2.3", False), ("v1.2.3+4", True)):
+            ancestor = self.commit(f"Independent history for {name}")
+            tip = self.commit(f"Release {name}", parent=ancestor)
+            args = ["tag", name, tip]
+            if annotated:
+                args.extend(["-a", "-m", f"Release {name}"])
+            self.git(*args)
+            self.git("push", "origin", f"refs/tags/{name}")
+            for revision in (name, f"refs/tags/{name}", ancestor, tip):
+                with self.subTest(revision=revision):
+                    self.set_revision(revision)
+                    self.guard(0)
+
+    def test_temporary_names_are_rejected_even_when_pointing_to_master(self):
+        for branch in ("temporary-fix", "release/temporary"):
+            self.publish_branch(branch, self.master)
+            for revision in (branch, f"origin/{branch}", f"refs/heads/{branch}",
+                             f"refs/remotes/origin/{branch}"):
+                with self.subTest(revision=revision):
+                    self.set_revision(revision)
+                    self.guard(1)
+
+    def test_arbitrary_revision_expressions_are_rejected(self):
+        for revision in ("HEAD", "master~0", "master^{commit}", "master@{0}",
+                         self.master[:12], "--all", " ", "refs/remotes/origin/HEAD"):
+            with self.subTest(revision=revision):
+                self.set_revision(revision)
+                self.guard(1)
+
+    def test_nonversion_tags_do_not_authorize_temporary_history(self):
+        temporary = self.commit("Only a development tag retains this commit")
+        self.git("tag", "snapshot", temporary)
+        self.git("push", "origin", "refs/tags/snapshot")
+        for revision in ("snapshot", "refs/tags/snapshot", temporary):
+            with self.subTest(revision=revision):
+                self.set_revision(revision)
+                self.guard(1)
+
+    def test_temporary_branch_only_hash_is_rejected_even_when_fetchable(self):
+        temporary = self.commit("Unmerged temporary change", parent=self.master)
+        self.publish_branch("temporary-fix", temporary)
+        probe = self.directory / "probe.git"
+        self.git("clone", "--bare", "--no-local", str(self.remote), str(probe))
+        self.git("--git-dir", str(probe), "cat-file", "-e", temporary)
+        self.set_revision(temporary)
+        self.guard(1)
+
+    def test_deleted_pr_hash_is_rejected_despite_local_remote_objects(self):
+        deleted = self.commit("Deleted PR change", parent=self.master)
+        self.publish_branch("deleted-pr", deleted)
+        self.git("push", "origin", "--delete", "deleted-pr")
+        self.git("cat-file", "-e", deleted)
+        self.git("--git-dir", str(self.remote), "cat-file", "-e", deleted)
+        probe = self.directory / "probe.git"
+        self.git("clone", "--bare", "--no-local", str(self.remote), str(probe))
+        result = self.git("--git-dir", str(probe), "cat-file", "-e", deleted, check=False)
+        self.assertNotEqual(result.returncode, 0, result.stdout)
+        self.set_revision(deleted)
+        self.guard(1)
+
+    def test_unavailable_hash_is_rejected(self):
+        self.set_revision("0" * 40)
+        self.guard(1)
+
+    def test_caller_refs_do_not_authorize_or_override_remote_revisions(self):
+        local_only = self.commit("Caller has its own retained-looking refs")
+        self.git("update-ref", "refs/remotes/origin/master", local_only)
+        self.git("tag", "v9.9.9", local_only)
+        for revision in (local_only, "v9.9.9"):
+            with self.subTest(revision=revision):
+                self.set_revision(revision)
+                self.guard(1)
+        self.set_revision("origin/master")
+        self.guard(0)
+
+    def test_clone_templates_cannot_inject_local_only_release_history(self):
+        local_only = self.commit("Unpublished orphan injected by a Git template")
+        missing = self.git("--git-dir", str(self.remote), "cat-file", "-e", local_only, check=False)
+        self.assertNotEqual(missing.returncode, 0, missing.stdout)
+        template = self.directory / "template"
+        (template / "refs/tags").mkdir(parents=True)
+        (template / "refs/tags/v9.9.9").write_text(local_only + "\n")
+        (template / "objects/info").mkdir(parents=True)
+        (template / "objects/info/alternates").write_text(str(self.repo / ".git/objects") + "\n")
+        config = self.directory / "template.gitconfig"
+        config.write_text(f"[init]\n\ttemplateDir = {template}\n")
+        environments = {
+            "environment": {**self.env, "GIT_TEMPLATE_DIR": str(template)},
+            "configuration": {**self.env, "GIT_CONFIG_GLOBAL": str(config)},
+        }
+        self.set_revision(local_only)
+        for source, environment in environments.items():
+            with self.subTest(source=source):
+                # Prove an ordinary fresh clone inherits the forged tag and objects.
+                probe = self.directory / f"template-probe-{source}"
+                self.git("clone", "--no-local", "--no-checkout", str(self.remote), str(probe),
+                         env=environment)
+                injected = self.git("-C", str(probe), "rev-parse", "v9.9.9^{commit}")
+                self.assertEqual(injected.stdout.strip(), local_only)
+                self.guard(1, env=environment)
+
+    def prepare_install(self):
+        for relative in ("Makefile", "scripts/version.sh", "scripts/check-hyprpm-state.py",
+                         "scripts/dev-link.sh"):
+            destination = self.repo / relative
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(ROOT / relative, destination)
+        (self.repo / "VERSION").write_text("v1.2.3\n")
+        self.new_binary = self.directory / "new-hyprexpo.so"
+        self.new_binary.write_bytes(b"new plugin fixture\n")
+        self.old_binary = self.install_dir / "hyprexpo.so"
+        self.old_binary.write_bytes(b"installed plugin fixture\n")
+        self.backup = self.install_dir / "hyprexpo.so.bak"
+        self.backup.write_bytes(b"existing backup fixture\n")
+        self.env["HYPREXPO_DEV_SO"] = str(self.new_binary)
+
+    def make(self, goal):
+        return self.command(
+            "make", "--no-print-directory", "-j4", goal,
+            f"TARGET={self.new_binary}", f"INSTALL_DIR={self.install_dir}",
+            "INSTALL_USER=fixture", "SRC=", "HEADERS=", "CXX=false", "INCLUDES=", "LIBS=",
+            check=False,
+        )
+
+    def install_snapshot(self):
+        return {str(path): self.snapshot(path) for path in
+                (self.state, self.new_binary, self.old_binary, self.backup)}
+
+    def test_make_check_target_and_install_reject_without_mutation(self):
+        self.prepare_install()
+        self.set_revision("0" * 40)
+        for goal in ("check-hyprpm-state", "install"):
+            with self.subTest(goal=goal):
+                before = self.install_snapshot()
+                result = self.make(goal)
+                self.assertEqual(self.install_snapshot(), before, result.stdout)
+                self.assertNotEqual(result.returncode, 0, result.stdout)
+                self.assertNotIn("No rule to make target", result.stdout)
+
+    def test_make_install_accepts_retained_revision(self):
+        self.prepare_install()
+        self.set_revision(self.master)
+        state_before = self.snapshot(self.state)
+        result = self.make("install")
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertEqual(self.old_binary.read_bytes(), self.new_binary.read_bytes())
+        self.assertEqual(self.snapshot(self.state), state_before)
+
+    def test_make_install_accepts_absent_and_unpinned_state(self):
+        self.prepare_install()
+        for contents in (None, '[repository]\nrev = ""\nurl = "missing"\n'):
+            with self.subTest(contents=contents):
+                if contents is not None:
+                    self.state.write_text(contents)
+                before = self.snapshot(self.state)
+                result = self.make("install")
+                self.assertEqual(result.returncode, 0, result.stdout)
+                self.assertEqual(self.old_binary.read_bytes(), self.new_binary.read_bytes())
+                self.assertEqual(self.snapshot(self.state), before)
+
+    @unittest.skipIf(os.geteuid() == 0, "dev-link intentionally rejects root")
+    def test_dev_link_rejects_before_replacing_explicit_symlink_or_backup(self):
+        self.prepare_install()
+        previous_binary = self.directory / "previous.so"
+        previous_binary.write_bytes(b"previous symlink destination\n")
+        self.old_binary.unlink()
+        self.old_binary.symlink_to(previous_binary)
+        self.set_revision("0" * 40)
+        before = self.install_snapshot()
+        previous_before = self.snapshot(previous_binary)
+        result = self.command("bash", "scripts/dev-link.sh", "-t", str(self.old_binary), check=False)
+        self.assertEqual(self.install_snapshot(), before, result.stdout)
+        self.assertEqual(self.snapshot(previous_binary), previous_before, result.stdout)
+        self.assertNotEqual(result.returncode, 0, result.stdout)
+
+    @unittest.skipIf(os.geteuid() == 0, "dev-link intentionally rejects root")
+    def test_dev_link_accepts_retained_revision_and_preserves_state(self):
+        self.prepare_install()
+        self.set_revision("origin/master")
+        original = self.old_binary.read_bytes()
+        state_before = self.snapshot(self.state)
+        result = self.command("bash", "scripts/dev-link.sh", "-t", str(self.old_binary), check=False)
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertTrue(self.old_binary.is_symlink())
+        self.assertEqual(self.old_binary.resolve(), self.new_binary)
+        self.assertEqual(self.backup.read_bytes(), original)
+        self.assertEqual(self.snapshot(self.state), state_before)
+
+    @unittest.skipIf(os.geteuid() == 0, "dev-link intentionally rejects root")
+    def test_dev_link_restore_remains_available_for_rejected_state(self):
+        self.prepare_install()
+        self.old_binary.unlink()
+        self.old_binary.symlink_to(self.new_binary)
+        self.new_binary.unlink()
+        self.set_revision("0" * 40)
+        state_before = self.snapshot(self.state)
+        backup = self.backup.read_bytes()
+        result = self.command("bash", "scripts/dev-link.sh", "--restore", "-t",
+                              str(self.old_binary), check=False)
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertFalse(self.old_binary.is_symlink())
+        self.assertEqual(self.old_binary.read_bytes(), backup)
+        self.assertFalse(self.backup.exists())
+        self.assertEqual(self.snapshot(self.state), state_before)
+
+    def prepare_manager(self):
+        executable_dir = self.directory / "bin"
+        executable_dir.mkdir()
+        executable = executable_dir / "hyprpm"
+        executable.write_text(
+            '#!/bin/sh\n'
+            'printf "%s\\0" "$@" > "$HYPREXPO_MANAGER_LOG"\n'
+            'exit "${HYPREXPO_MANAGER_STATUS:-0}"\n'
+        )
+        executable.chmod(0o755)
+        self.manager_log = self.directory / "manager-arguments"
+        self.env["HYPREXPO_MANAGER_LOG"] = str(self.manager_log)
+        self.env["PATH"] = str(executable_dir) + os.pathsep + self.env["PATH"]
+        self.set_revision("master")
+
+    def add_repository(self, *args):
+        before = self.snapshot(self.state)
+        result = self.command("bash", str(ROOT / "scripts/hyprpm-add.sh"), *args, check=False)
+        self.assertEqual(self.snapshot(self.state), before, result.stdout)
+        return result
+
+    def test_add_wrapper_rejects_temporary_branches_and_hashes_before_manager(self):
+        self.prepare_manager()
+        temporary = self.commit("Unmerged candidate still exists upstream", parent=self.master)
+        self.publish_branch("candidate-pr", temporary)
+        for revision in ("candidate-pr", "origin/candidate-pr", temporary):
+            with self.subTest(revision=revision):
+                result = self.add_repository(str(self.remote), revision)
+                self.assertNotEqual(result.returncode, 0, result.stdout)
+                self.assertFalse(self.manager_log.exists(), result.stdout)
+        self.git("push", "origin", "--delete", "candidate-pr")
+        for revision in (temporary, "0" * 40):
+            with self.subTest(deleted_or_unavailable=revision):
+                result = self.add_repository(str(self.remote), revision)
+                self.assertNotEqual(result.returncode, 0, result.stdout)
+                self.assertFalse(self.manager_log.exists(), result.stdout)
+
+    def test_add_wrapper_rejects_temporary_name_even_when_master_is_retained(self):
+        self.prepare_manager()
+        self.publish_branch("candidate-pr", self.master)
+        result = self.add_repository(str(self.remote), "origin/candidate-pr")
+        self.assertNotEqual(result.returncode, 0, result.stdout)
+        self.assertFalse(self.manager_log.exists(), result.stdout)
+
+    def test_add_wrapper_retained_and_unpinned_inputs_keep_original_arguments(self):
+        self.prepare_manager()
+        development = self.commit("Retained development history")
+        self.publish_branch("hyprland-git", development)
+        inputs = (
+            (str(self.remote),),
+            (str(self.remote), ""),
+            (str(self.remote), self.master),
+            (str(self.remote), "origin/hyprland-git"),
+        )
+        for args in inputs:
+            with self.subTest(args=args):
+                result = self.add_repository(*args)
+                self.assertEqual(result.returncode, 0, result.stdout)
+                self.assertEqual(self.manager_log.read_bytes().split(b"\0")[:-1],
+                                 [b"add", *[arg.encode() for arg in args]])
+                self.manager_log.unlink()
+
+    def test_add_wrapper_transport_failure_never_invokes_manager(self):
+        self.prepare_manager()
+        result = self.add_repository("https://unreachable.invalid/repo.git", self.master)
+        self.assertNotEqual(result.returncode, 0, result.stdout)
+        self.assertFalse(self.manager_log.exists(), result.stdout)
+
+    def test_add_wrapper_preserves_manager_failure_status(self):
+        self.prepare_manager()
+        self.env["HYPREXPO_MANAGER_STATUS"] = "7"
+        result = self.add_repository(str(self.remote))
+        self.assertEqual(result.returncode, 7, result.stdout)
+        self.assertTrue(self.manager_log.exists(), result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A PR #116 test installation saved its pre-squash commit in hyprpm's `repository.rev`. After the temporary branch disappeared, `hyprpm update` could no longer check out that commit and failed before reading the normal compatibility pins.

This adds guards at registration, managed replacement, and release publication:

- `scripts/hyprpm-add.sh` validates a proposed revision before invoking hyprpm. A fresh clone must resolve it through maintained branch or release-tag history. Temporary branches, PR-only hashes, local object stores, and injected Git templates cannot satisfy the check.
- `make install` and `scripts/dev-link.sh` validate existing destination state before replacing files. Unpinned installations remain usable offline; supported release/development pins remain accepted. Recovery remains available.
- `make version`, `make tag`, and `make publish` stop after a failed pin check or push. Previously their command chains could continue and mutate commits, tags, or remote refs after failure.
- The contributor contract and installation/recovery guides prohibit saving desktop test pins and route contributors through the guarded entry points. `make test-tooling` now runs in the required compatibility regression job.

Validation: 45 Python tooling tests, all three standalone C++ suites, all 16 historical pins, Python/shell syntax, and the complete site/docs build pass. Negative fixtures reproduce the old install/release mutations and verify that rejection preserves plugin files, state, index, commits, tags, and remote refs. The actual PR116 backup is rejected while the repaired local state and published release pin pass without changing live files. Independent review is clean after adding template-injection regressions.

The guards cover repository-provided entry points; direct hyprpm commands and manual state edits remain outside that boundary. Source-retention checks still require maintained upstream refs and do not establish compositor ABI compatibility. Privileged registration is delegated to hyprpm and tested with isolated side effects.
