### PR TITLE
Turn Hyprland probe drift into bounded compatibility work

### DIFF
--- a/.codex/skills/hyprexpo-chase/SKILL.md
+++ b/.codex/skills/hyprexpo-chase/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: hyprexpo-chase
+description: Observe Hyprland upstream, prepare one bounded development compatibility candidate, or prepare a release packet without publishing.
+---
+
+# HyprExpo chase
+
+Run `python3 scripts/watch-hyprland.py --format markdown` first. Read the
+report and [chasing Hyprland](../../../docs/guides/chasing-hyprland.md) before
+changing source, branches, or CI state.
+
+## Modes
+
+- `observe`: Read-only. Report exact target, upstream tip, release candidates,
+  probe evidence, duplicate candidates, and missing information.
+- `chase`: One exact upstream commit and one owned candidate branch. Work only
+  in an isolated checkout. Keep `hyprland-git` protected until reviewed merge.
+- `release`: Prepare a local packet and promotion PR for one exact upstream
+  release. Do not create tags, releases, or prereleases.
+- `status`: Report current observer output and existing candidate state.
+
+## Required rules
+
+- Existing Actions are read-only observers. One designated manual runner owns
+  candidate writes. Do not run concurrent repair agents across machines.
+- Preserve pins, managed-installation guards, contributor history, and live
+  desktop state. Test PR artifacts with disposable sessions or `make dev-reload`;
+  never save a temporary revision to managed hyprpm state.
+- Bind all evidence to exact plugin tree, upstream commit, lock, and test scope.
+  A compile or old artifact is not runtime acceptance for a new target.
+- Use at most three repair hypotheses and two hours of active work. On failure,
+  leave a resumable draft with diagnosis and missing gates.
+- Release preparation is not publication. Follow the existing promotion guide
+  and require explicit authorization before tags, assets, or release changes.
+
+Hermes is not a first-version runner. It may reuse this procedure only after a
+separate identity, credential, writer-lock, scheduler, and pilot validation.

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -27,6 +27,8 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       matrix: ${{ steps.resolve.outputs.matrix }}
+      contract: ${{ steps.resolve.outputs.contract }}
+      gate: ${{ steps.resolve.outputs.gate }}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
@@ -34,7 +36,25 @@ jobs:
       - id: resolve
         env:
           TARGET_BRANCH: ${{ github.base_ref || inputs.target_branch || github.ref_name }}
-        run: echo "matrix=$(python3 scripts/ci-targets.py matrix "$TARGET_BRANCH")" >> "$GITHUB_OUTPUT"
+          PR_NUMBER: ${{ github.event.pull_request.number || 0 }}
+          PR_DRAFT: ${{ github.event.pull_request.draft || false }}
+          PR_HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          PR_HEAD: ${{ github.head_ref || github.ref_name }}
+        run: |
+          descriptor=$(python3 scripts/ci-targets.py contract \
+            --repository "$GITHUB_REPOSITORY" --number "$PR_NUMBER" \
+            --base "$TARGET_BRANCH" --head-repository "$PR_HEAD_REPOSITORY" \
+            --head "$PR_HEAD" --draft "$PR_DRAFT")
+          CONTRACT="$descriptor" python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import json
+          import os
+          import subprocess
+          descriptor = json.loads(os.environ["CONTRACT"])
+          matrix = subprocess.check_output(["python3", "scripts/ci-targets.py", "matrix", descriptor["track"]], text=True).strip()
+          print(f"contract={descriptor['track']}")
+          print(f"gate={descriptor['gate']}")
+          print(f"matrix={matrix}")
+          PY
 
   regressions:
     name: Regression tests
@@ -72,7 +92,7 @@ jobs:
       - name: Build exact source and record dependency / generated-header provenance
         env:
           UPSTREAM_REV: ${{ matrix.rev }}
-          CI_TARGET_BRANCH: ${{ github.base_ref || inputs.target_branch || github.ref_name }}
+          CI_TARGET_BRANCH: ${{ needs.targets.outputs.contract }}
           EVIDENCE_DIR: ${{ runner.temp }}/evidence-${{ matrix.name }}
         run: ./scripts/ci-build.sh "$UPSTREAM_REV" "$EVIDENCE_DIR"
       - name: Preserve artifacts and failure logs
@@ -86,7 +106,7 @@ jobs:
   gate:
     # Never emit a skipped opposite-track gate: GitHub accepts skipped checks
     # for protection, including another workflow run on the same commit.
-    name: ${{ (github.base_ref || inputs.target_branch || github.ref_name) == 'master' && 'Release gate' || 'Development gate' }}
+    name: ${{ needs.targets.outputs.gate }}
     if: always()
     needs: [targets, regressions, build]
     runs-on: ubuntu-24.04

--- a/.github/workflows/upstream-tip.yml
+++ b/.github/workflows/upstream-tip.yml
@@ -7,13 +7,36 @@ on:
 
 permissions:
   contents: read
+  actions: read
+  pull-requests: read
 
 concurrency:
   group: upstream-tip-probe
   cancel-in-progress: false
 
 jobs:
+  observe:
+    name: Observe upstream state
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Record actionable upstream state
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python3 scripts/watch-hyprland.py --format markdown | tee upstream-observation.md
+      - name: Preserve observation
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: upstream-observation-${{ github.run_id }}-${{ github.run_attempt }}
+          path: upstream-observation.md
+          if-no-files-found: warn
+
   probe:
+    needs: observe
     name: Advisory upstream tip
     runs-on: ubuntu-24.04
     timeout-minutes: 120

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,10 @@
 Follow the [branch policy](docs/reference/branch-policy.md) and validate against
 the Hyprland revisions affected by your change.
 
+For periodic development compatibility work, follow
+[chasing Hyprland](docs/guides/chasing-hyprland.md). It keeps upstream
+observation, candidate repair, and release preparation separate.
+
 ## Local Installation Contract
 
 These rules apply to maintainers, contributors, and coding agents.

--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ For more options, see the [configuration options](https://hyprexpo.lol/docs/conf
 
 ## Next Steps
 
+- [Chasing Hyprland](https://hyprexpo.lol/docs/guides/chasing-hyprland/)
 - [Repository layout and development-branch reconciliation](docs/reference/repository-layout.md)
 
 - [Installation details](https://hyprexpo.lol/docs/getting-started/installation/)

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -43,6 +43,7 @@ export default defineConfig({
           { text: "Migration", link: "/guides/migration" },
           { text: "Runtime Smoke", link: "/guides/runtime-smoke" },
           { text: "Release Promotion", link: "/guides/release-promotion" },
+          { text: "Chasing Hyprland", link: "/guides/chasing-hyprland" },
           { text: "Development Installation", link: "/guides/development-installation" },
         ],
       },

--- a/docs/guides/chasing-hyprland.md
+++ b/docs/guides/chasing-hyprland.md
@@ -1,0 +1,72 @@
+# Chasing Hyprland
+
+HyprExpo supports released Hyprland targets on `master` and one exact development
+target on `hyprland-git`. This procedure observes upstream changes, prepares
+reviewable compatibility work, and prepares release packets. It does not publish
+or merge by itself.
+
+## Observe
+
+Run from an up-to-date checkout with GitHub CLI access:
+
+```sh
+python3 scripts/watch-hyprland.py --format markdown
+```
+
+The report is read-only. It records the development pin, upstream `main`,
+release candidates, current probe evidence, and existing candidates. A failed
+observation is incomplete evidence, never proof that no work exists.
+
+The scheduled upstream-tip workflow runs this same observation before its
+expensive build. Scheduled GitHub workflows are best effort and run from the
+default branch; a delayed or missed schedule is not a compatibility result.
+
+## Prepare one development target
+
+Only the designated manual runner writes candidates. Actions observe. Do not run
+another writer from Hermes or a second host until a shared writer lease exists.
+
+1. Save the observer report. If a matching candidate or live job exists, inspect
+   it and stop; do not duplicate it.
+2. Create an isolated branch from current `hyprland-git` using the exact upstream
+   commit from the report. Do not use the desktop checkout.
+3. Update the development target, `flake.nix`, and resolved lock together.
+   Preserve release targets and hyprpm pins.
+4. Diagnose the exact build failure against the captured upstream source. Keep
+   existing behavior tests meaningful; do not fake headers, change the target,
+   disable sandboxing, or suppress features to obtain a build.
+5. Run tooling, C++ suites, relevant input tests, documentation build, exact
+   build, and affected disposable runtime proof. Record hardware gaps.
+6. Push one owned candidate PR into `hyprland-git`. Keep incomplete work draft
+   and include exact source/tree/lock/probe/runtime evidence plus the next gate.
+
+The standing tracking PR uses the development contract only while it remains the
+configured same-repository draft tracker. It is not a release-promotion PR.
+
+## Prepare a released target
+
+Run observation first. A new stable release is a separate work item identified
+by release ID, tag, and peeled tag commit. Old unsupported releases, drafts,
+prereleases, malformed tags, and a tag that moved need explicit review.
+
+Choose a compatible historical candidate if `hyprland-git` has moved beyond the
+release. Create a local packet and a reviewable promotion PR containing exact
+upstream/plugin/tree/lock identities, support decisions, artifacts, runtime
+receipt, pin ancestry, notes, and remaining gates. Follow the
+[release promotion guide](./release-promotion.md).
+
+Do not create a tag, GitHub Release, or prerelease packet in public state. The
+current stable publisher accepts broad `v*` tags; release-candidate publication
+requires separate version, trigger, collision, provenance, and authorization
+work first.
+
+## Resuming and Hermes
+
+Bound one repair attempt to three hypotheses and two hours of active work. Keep
+a receipt when a target remains broken. Before continuing, re-observe refs and
+job handles; upstream may have moved or another contributor may own the work.
+
+Hermes is optional later. It must use this procedure as approved context, have
+separate read-only observation and constrained candidate-write credentials, an
+isolated workspace, persistent receipts, single-writer ownership, capped jobs,
+and a tested disable path. It must not receive stable-release publisher access.

--- a/docs/guides/release-promotion.md
+++ b/docs/guides/release-promotion.md
@@ -5,6 +5,8 @@ Hyprland development track. It stops at a reviewable, validated promotion PR;
 merging, tagging, and publishing require the maintainer's release decision.
 See the [branch policy](../reference/branch-policy.md) for contribution flow and
 [compatibility reference](../reference/compatibility.md) for current targets.
+Use [chasing Hyprland](./chasing-hyprland.md) to discover and prepare a target;
+this guide remains the promotion and publication gate.
 
 ## Select Immutable Inputs
 

--- a/scripts/ci-targets.py
+++ b/scripts/ci-targets.py
@@ -12,9 +12,10 @@ ROOT = Path(__file__).resolve().parents[1]
 
 def targets(path=ROOT / "scripts/hyprland-targets.json"):
     data = json.loads(path.read_text())
-    if set(data) != {"release", "development"}:
-        raise ValueError("target file must contain release and development")
-    for track, rows in data.items():
+    if set(data) != {"release", "development", "tracker"}:
+        raise ValueError("target file must contain release, development and tracker")
+    for track in ("release", "development"):
+        rows = data[track]
         if not rows or (track == "development" and len(rows) != 1):
             raise ValueError(f"invalid number of {track} targets")
         names = set()
@@ -30,6 +31,9 @@ def targets(path=ROOT / "scripts/hyprland-targets.json"):
                 raise ValueError("duplicate target")
             names.add(row["name"])
             revisions.add(row["rev"])
+    tracker = data["tracker"]
+    if set(tracker) != {"repository", "number", "base", "head"} or not isinstance(tracker["number"], int):
+        raise ValueError("tracker contract is invalid")
     return data
 
 
@@ -38,6 +42,21 @@ def track_for_branch(branch):
     if branch not in mapping:
         raise ValueError(f"unrecognized target branch: {branch}")
     return mapping[branch]
+
+
+def contract(repository, number, base, head_repository, head, draft):
+    tracker = targets()["tracker"]
+    if (
+        draft
+        and repository == tracker["repository"]
+        and head_repository == tracker["repository"]
+        and number == tracker["number"]
+        and base == tracker["base"]
+        and head == tracker["head"]
+    ):
+        return {"track": "hyprland-git", "gate": "Tracking gate", "kind": "tracking"}
+    track = track_for_branch(base)
+    return {"track": track, "gate": "Release gate" if track == "release" else "Development gate", "kind": "promotion_or_development"}
 
 
 def verify_lock(metadata, expected):
@@ -64,11 +83,20 @@ def main():
     branch_lock = commands.add_parser("verify-branch-lock")
     branch_lock.add_argument("metadata", type=Path)
     branch_lock.add_argument("branch", choices=["master", "hyprland-git"])
+    contract_command = commands.add_parser("contract")
+    contract_command.add_argument("--repository", required=True)
+    contract_command.add_argument("--number", type=int, default=0)
+    contract_command.add_argument("--base", required=True)
+    contract_command.add_argument("--head-repository", required=True)
+    contract_command.add_argument("--head", required=True)
+    contract_command.add_argument("--draft", choices=["true", "false"], default="false")
     args = parser.parse_args()
     if args.command == "matrix":
         print(json.dumps({"include": targets()[track_for_branch(args.branch)]}))
     elif args.command == "verify-lock":
         verify_lock(json.loads(args.metadata.read_text()), args.rev)
+    elif args.command == "contract":
+        print(json.dumps(contract(args.repository, args.number, args.base, args.head_repository, args.head, args.draft == "true")))
     else:
         metadata = json.loads(args.metadata.read_text())
         locks = metadata["locks"]

--- a/scripts/ci-targets.py
+++ b/scripts/ci-targets.py
@@ -55,8 +55,8 @@ def contract(repository, number, base, head_repository, head, draft):
         and head == tracker["head"]
     ):
         return {"track": "hyprland-git", "gate": "Tracking gate", "kind": "tracking"}
-    track = track_for_branch(base)
-    return {"track": track, "gate": "Release gate" if track == "release" else "Development gate", "kind": "promotion_or_development"}
+    track_for_branch(base)
+    return {"track": base, "gate": "Release gate" if base == "master" else "Development gate", "kind": "promotion_or_development"}
 
 
 def verify_lock(metadata, expected):

--- a/scripts/hyprland-targets.json
+++ b/scripts/hyprland-targets.json
@@ -5,5 +5,11 @@
   ],
   "development": [
     {"name": "hyprland-git", "rev": "34eb03bd8da01024596c367fba66485a8c9b8ca7"}
-  ]
+  ],
+  "tracker": {
+    "repository": "sandwichfarm/hyprexpo",
+    "number": 123,
+    "base": "master",
+    "head": "hyprland-git"
+  }
 }

--- a/scripts/prepare-hyprland-release.py
+++ b/scripts/prepare-hyprland-release.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Create a local, non-publishing release preparation packet from an observation."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("observation", type=Path)
+    parser.add_argument("--tag", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    report = json.loads(args.observation.read_text())
+    matches = [release for release in report.get("eligible_releases", []) if release.get("tag") == args.tag]
+    if len(matches) != 1:
+        print(f"release {args.tag!r} is not one unique eligible observation target", file=sys.stderr)
+        return 2
+    release = matches[0]
+    packet = {
+        "schema_version": 1,
+        "status": "prepared_not_published",
+        "release": release,
+        "plugin_base": report["plugin_base"],
+        "development_target": report["development_target"],
+        "release_targets": report["release_targets"],
+        "required_gates": [
+            "exact upstream tag/peeled commit",
+            "compatible plugin candidate/tree and lock",
+            "proposed support and maintenance decision",
+            "exact build/rebuild provenance",
+            "disposable runtime receipt",
+            "pin ancestry and final integrated-tree validation",
+            "explicit maintainer release approval",
+        ],
+        "publication": "forbidden by this preparation command",
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(packet, indent=2, sort_keys=True) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/watch-hyprland.py
+++ b/scripts/watch-hyprland.py
@@ -81,6 +81,7 @@ def discover_live() -> dict[str, Any]:
     development = json_command("gh", "api", f"repos/{REPOSITORY}/git/ref/heads/hyprland-git")["object"]["sha"]
     upstream = json_command("gh", "api", f"repos/{UPSTREAM}/commits/main")
     releases = paginated_json("gh", "api", f"repos/{UPSTREAM}/releases?per_page=100")
+    tags = paginated_json("gh", "api", f"repos/{UPSTREAM}/tags?per_page=100")
     prs = json_command("gh", "pr", "list", "-R", REPOSITORY, "--state", "open", "--json", "number,title,headRefName,baseRefName,isDraft")
     runs = json_command("gh", "run", "list", "-R", REPOSITORY, "--workflow", "upstream-tip.yml", "--limit", "10", "--json", "databaseId,status,conclusion,headSha,createdAt,event")
     return {
@@ -89,6 +90,7 @@ def discover_live() -> dict[str, Any]:
         "upstream_main": upstream["sha"],
         "upstream_main_date": upstream["commit"]["committer"]["date"],
         "releases": releases,
+        "tags": {tag["name"]: tag["commit"]["sha"] for tag in tags if isinstance(tag.get("name"), str) and isinstance(tag.get("commit"), dict) and isinstance(tag["commit"].get("sha"), str)},
         "open_prs": prs,
         "probe_runs": runs,
         "contract": load_branch_contract(development),
@@ -99,14 +101,16 @@ def stable_releases(releases: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return [release for release in releases if not release.get("draft") and not release.get("prerelease") and semantic_version(release.get("tag_name", ""))]
 
 
-def release_candidates(releases: list[dict[str, Any]], supported: set[str]) -> list[dict[str, Any]]:
+def release_candidates(releases: list[dict[str, Any]], tags: dict[str, str], supported: set[str]) -> list[dict[str, Any]]:
     supported_versions = [semantic_version(tag) for tag in supported if semantic_version(tag)]
     floor = max(supported_versions) if supported_versions else None
     candidates = []
     for release in stable_releases(releases):
         version = semantic_version(release["tag_name"])
         if release["tag_name"] not in supported and (floor is None or version > floor):
-            candidates.append(release)
+            candidate = dict(release)
+            candidate["tag_commit"] = tags.get(release["tag_name"])
+            candidates.append(candidate)
     return candidates
 
 
@@ -126,7 +130,7 @@ def observe(data: dict[str, Any]) -> dict[str, Any]:
     if latest_probe and latest_probe.get("status") == "completed" and latest_probe.get("conclusion") != "success":
         failures.append("probe_failed")
     supported = {row.get("name") for row in contract.get("release_targets", [])}
-    eligible = release_candidates(data.get("releases", []), supported)
+    eligible = release_candidates(data.get("releases", []), data.get("tags", {}), supported)
     if candidates:
         status = "candidate_active"
     elif failures:
@@ -152,7 +156,7 @@ def observe(data: dict[str, Any]) -> dict[str, Any]:
         "failure_stages": failures,
         "candidate_prs": candidates,
         "eligible_releases": [
-            {"id": release.get("id"), "tag": release["tag_name"], "target": release.get("target_commitish"), "published_at": release.get("published_at")}
+            {"id": release.get("id"), "tag": release["tag_name"], "tag_commit": release.get("tag_commit"), "target": release.get("target_commitish"), "published_at": release.get("published_at")}
             for release in eligible
         ],
         "release_targets": contract.get("release_targets", []),

--- a/scripts/watch-hyprland.py
+++ b/scripts/watch-hyprland.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Report actionable Hyprland upstream changes without changing repository state."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_VERSION = 1
+REPOSITORY = "sandwichfarm/hyprexpo"
+UPSTREAM = "hyprwm/Hyprland"
+SEMVER = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
+
+
+class ObservationError(RuntimeError):
+    pass
+
+
+def command(*args: str) -> str:
+    result = subprocess.run(args, cwd=ROOT, text=True, capture_output=True)
+    if result.returncode:
+        raise ObservationError(f"{' '.join(args[:3])}: {result.stderr.strip() or result.stdout.strip()}")
+    return result.stdout
+
+
+def json_command(*args: str) -> Any:
+    try:
+        return json.loads(command(*args))
+    except json.JSONDecodeError as error:
+        raise ObservationError(f"invalid JSON from {' '.join(args[:3])}") from error
+
+
+def paginated_json(*args: str) -> list[dict[str, Any]]:
+    pages = json_command(*args, "--paginate", "--slurp")
+    if not isinstance(pages, list) or any(not isinstance(page, list) for page in pages):
+        raise ObservationError("paginated API response is incomplete")
+    return [item for page in pages for item in page]
+
+
+def semantic_version(tag: str) -> tuple[int, int, int] | None:
+    match = SEMVER.fullmatch(tag)
+    return tuple(map(int, match.groups())) if match else None
+
+
+def lock_revision(lock: dict[str, Any]) -> str | None:
+    try:
+        root = lock["nodes"][lock["root"]]
+        node = lock["nodes"][root["inputs"]["hyprland"]]
+        return node["locked"]["rev"]
+    except (KeyError, TypeError):
+        return None
+
+
+def load_branch_contract(branch_sha: str) -> dict[str, Any]:
+    targets = json.loads(command("git", "show", f"{branch_sha}:scripts/hyprland-targets.json"))
+    lock = json.loads(command("git", "show", f"{branch_sha}:flake.lock"))
+    development = targets.get("development", [])
+    if len(development) != 1 or not isinstance(development[0].get("rev"), str):
+        raise ObservationError("development target contract is invalid")
+    revision = development[0]["rev"]
+    locked = lock_revision(lock)
+    return {
+        "development_revision": revision,
+        "lock_revision": locked,
+        "lock_matches_target": locked == revision,
+        "release_targets": targets.get("release", []),
+    }
+
+
+def discover_live() -> dict[str, Any]:
+    command("git", "fetch", "--quiet", "origin", "master", "hyprland-git")
+    master = json_command("gh", "api", f"repos/{REPOSITORY}/git/ref/heads/master")["object"]["sha"]
+    development = json_command("gh", "api", f"repos/{REPOSITORY}/git/ref/heads/hyprland-git")["object"]["sha"]
+    upstream = json_command("gh", "api", f"repos/{UPSTREAM}/commits/main")
+    releases = paginated_json("gh", "api", f"repos/{UPSTREAM}/releases?per_page=100")
+    prs = json_command("gh", "pr", "list", "-R", REPOSITORY, "--state", "open", "--json", "number,title,headRefName,baseRefName,isDraft")
+    runs = json_command("gh", "run", "list", "-R", REPOSITORY, "--workflow", "upstream-tip.yml", "--limit", "10", "--json", "databaseId,status,conclusion,headSha,createdAt,event")
+    return {
+        "master": master,
+        "development_branch": development,
+        "upstream_main": upstream["sha"],
+        "upstream_main_date": upstream["commit"]["committer"]["date"],
+        "releases": releases,
+        "open_prs": prs,
+        "probe_runs": runs,
+        "contract": load_branch_contract(development),
+    }
+
+
+def stable_releases(releases: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [release for release in releases if not release.get("draft") and not release.get("prerelease") and semantic_version(release.get("tag_name", ""))]
+
+
+def release_candidates(releases: list[dict[str, Any]], supported: set[str]) -> list[dict[str, Any]]:
+    supported_versions = [semantic_version(tag) for tag in supported if semantic_version(tag)]
+    floor = max(supported_versions) if supported_versions else None
+    candidates = []
+    for release in stable_releases(releases):
+        version = semantic_version(release["tag_name"])
+        if release["tag_name"] not in supported and (floor is None or version > floor):
+            candidates.append(release)
+    return candidates
+
+
+def observe(data: dict[str, Any]) -> dict[str, Any]:
+    contract = data["contract"]
+    target = contract["development_revision"]
+    main = data["upstream_main"]
+    candidate_prefix = f"chase/hyprland-{main}"
+    candidates = [pr for pr in data.get("open_prs", []) if pr.get("headRefName") == candidate_prefix and pr.get("baseRefName") == "hyprland-git"]
+    probe_runs = data.get("probe_runs", [])
+    latest_probe = probe_runs[0] if probe_runs else None
+    failures: list[str] = []
+    if not contract["lock_matches_target"]:
+        failures.append("development_lock_mismatch")
+    if latest_probe and latest_probe.get("status") != "completed":
+        failures.append("probe_incomplete")
+    if latest_probe and latest_probe.get("status") == "completed" and latest_probe.get("conclusion") != "success":
+        failures.append("probe_failed")
+    supported = {row.get("name") for row in contract.get("release_targets", [])}
+    eligible = release_candidates(data.get("releases", []), supported)
+    if failures:
+        status = "incomplete" if "probe_incomplete" in failures else "needs_diagnosis"
+    elif main == target:
+        status = "up_to_date"
+    elif candidates:
+        status = "candidate_active"
+    else:
+        status = "new_upstream_target"
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "observed_at": datetime.now(timezone.utc).isoformat(),
+        "repository": REPOSITORY,
+        "status": status,
+        "master": data["master"],
+        "development_branch": data["development_branch"],
+        "plugin_base": data["development_branch"],
+        "development_target": target,
+        "development_lock": contract["lock_revision"],
+        "upstream_main": main,
+        "upstream_main_date": data.get("upstream_main_date"),
+        "lock_matches_target": contract["lock_matches_target"],
+        "latest_probe": latest_probe,
+        "failure_stages": failures,
+        "candidate_prs": candidates,
+        "eligible_releases": [
+            {"id": release.get("id"), "tag": release["tag_name"], "target": release.get("target_commitish"), "published_at": release.get("published_at")}
+            for release in eligible
+        ],
+        "release_targets": contract.get("release_targets", []),
+        "next_action": (
+            "inspect failed probe evidence before repair" if failures else
+            "reuse active candidate" if candidates else
+            "prepare one development candidate" if main != target else
+            "no development repair required"
+        ),
+    }
+
+
+def markdown(report: dict[str, Any]) -> str:
+    lines = [
+        "# Hyprland chase observation",
+        "",
+        f"Status: **{report['status']}**",
+        f"Development target: `{report['development_target']}`",
+        f"Observed upstream main: `{report['upstream_main']}`",
+        f"Plugin base: `{report['plugin_base']}`",
+        f"Next action: {report['next_action']}",
+        "",
+    ]
+    if report["failure_stages"]:
+        lines.extend(["## Evidence gaps", "", *[f"- `{stage}`" for stage in report["failure_stages"]], ""])
+    if report["candidate_prs"]:
+        lines.extend(["## Existing candidates", "", *[f"- #{pr['number']} {pr['title']}" for pr in report["candidate_prs"]], ""])
+    if report["eligible_releases"]:
+        lines.extend(["## New released targets", "", *[f"- `{release['tag']}` (release ID `{release['id']}`)" for release in report["eligible_releases"]], ""])
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--format", choices=("json", "markdown"), default="json")
+    parser.add_argument("--fixture", type=Path, help="Read deterministic observation input instead of live services")
+    args = parser.parse_args()
+    try:
+        data = json.loads(args.fixture.read_text()) if args.fixture else discover_live()
+        report = observe(data)
+    except (OSError, ObservationError, KeyError, TypeError, json.JSONDecodeError) as error:
+        print(json.dumps({"schema_version": SCHEMA_VERSION, "status": "incomplete", "error": str(error)}))
+        return 2
+    print(markdown(report) if args.format == "markdown" else json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/watch-hyprland.py
+++ b/scripts/watch-hyprland.py
@@ -127,12 +127,12 @@ def observe(data: dict[str, Any]) -> dict[str, Any]:
         failures.append("probe_failed")
     supported = {row.get("name") for row in contract.get("release_targets", [])}
     eligible = release_candidates(data.get("releases", []), supported)
-    if failures:
+    if candidates:
+        status = "candidate_active"
+    elif failures:
         status = "incomplete" if "probe_incomplete" in failures else "needs_diagnosis"
     elif main == target:
         status = "up_to_date"
-    elif candidates:
-        status = "candidate_active"
     else:
         status = "new_upstream_target"
     return {
@@ -157,8 +157,8 @@ def observe(data: dict[str, Any]) -> dict[str, Any]:
         ],
         "release_targets": contract.get("release_targets", []),
         "next_action": (
+            "reuse active candidate and inspect its receipt" if candidates else
             "inspect failed probe evidence before repair" if failures else
-            "reuse active candidate" if candidates else
             "prepare one development candidate" if main != target else
             "no development repair required"
         ),

--- a/tests/test_ci_targets.py
+++ b/tests/test_ci_targets.py
@@ -20,6 +20,18 @@ class TargetContractTests(unittest.TestCase):
     def test_current_contract_has_exact_commits(self):
         ci.targets()
 
+    def test_only_configured_same_repository_draft_tracker_uses_development_contract(self):
+        result = ci.contract("sandwichfarm/hyprexpo", 123, "master", "sandwichfarm/hyprexpo", "hyprland-git", True)
+        self.assertEqual(result, {"track": "hyprland-git", "gate": "Tracking gate", "kind": "tracking"})
+        cases = (
+            (124, "master", "sandwichfarm/hyprexpo", "hyprland-git", True),
+            (123, "hyprland-git", "sandwichfarm/hyprexpo", "hyprland-git", True),
+            (123, "master", "fork/hyprexpo", "hyprland-git", True),
+            (123, "master", "sandwichfarm/hyprexpo", "hyprland-git", False),
+        )
+        for number, base, repository, head, draft in cases:
+            self.assertEqual(ci.contract("sandwichfarm/hyprexpo", number, base, repository, head, draft)["kind"], "promotion_or_development")
+
     def test_reject_moving_ref_or_empty_matrix(self):
         for change in ("moving", "empty", "duplicate"):
             data = ci.targets()

--- a/tests/test_prepare_hyprland_release.py
+++ b/tests/test_prepare_hyprland_release.py
@@ -1,0 +1,40 @@
+import json
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PREPARE = ROOT / "scripts/prepare-hyprland-release.py"
+
+
+class ReleasePacketTests(unittest.TestCase):
+    def observation(self, releases):
+        return {"plugin_base": "p" * 40, "development_target": "d" * 40, "release_targets": [{"name": "v0.56.2"}], "eligible_releases": releases}
+
+    def test_packet_is_local_and_non_publishing(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "observation.json"
+            output = root / "packet.json"
+            source.write_text(json.dumps(self.observation([{"id": 2, "tag": "v0.57.0", "target": "t" * 40}])))
+            result = subprocess.run(["python3", str(PREPARE), str(source), "--tag", "v0.57.0", "--output", str(output)], text=True, capture_output=True)
+            self.assertEqual(result.returncode, 0)
+            packet = json.loads(output.read_text())
+            self.assertEqual(packet["status"], "prepared_not_published")
+            self.assertEqual(packet["publication"], "forbidden by this preparation command")
+            self.assertIn("pin ancestry and final integrated-tree validation", packet["required_gates"])
+
+    def test_unknown_or_ambiguous_release_fails_closed(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "observation.json"
+            source.write_text(json.dumps(self.observation([{"tag": "v0.57.0"}, {"tag": "v0.57.0"}])))
+            result = subprocess.run(["python3", str(PREPARE), str(source), "--tag", "v0.57.0", "--output", str(root / "packet.json")], text=True, capture_output=True)
+            self.assertEqual(result.returncode, 2)
+            self.assertFalse((root / "packet.json").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_watch_hyprland.py
+++ b/tests/test_watch_hyprland.py
@@ -57,6 +57,12 @@ class WatchHyprlandTests(unittest.TestCase):
         self.assertEqual(report["status"], "candidate_active")
         self.assertEqual(report["candidate_prs"][0]["number"], 7)
 
+    def test_existing_candidate_wins_over_prior_failed_probe(self):
+        main = "b" * 40
+        report = json.loads(run(fixture(probe="failure", prs=[{"number": 7, "title": "chase", "headRefName": f"chase/hyprland-{main}", "baseRefName": "hyprland-git", "isDraft": True}])).stdout)
+        self.assertEqual(report["status"], "candidate_active")
+        self.assertIn("probe_failed", report["failure_stages"])
+
     def test_failed_probe_requires_diagnosis(self):
         result = run(fixture(probe="failure"))
         report = json.loads(result.stdout)

--- a/tests/test_watch_hyprland.py
+++ b/tests/test_watch_hyprland.py
@@ -9,7 +9,7 @@ ROOT = Path(__file__).resolve().parents[1]
 WATCHER = ROOT / "scripts/watch-hyprland.py"
 
 
-def fixture(main="b" * 40, target="a" * 40, lock=None, probe="success", releases=None, prs=None):
+def fixture(main="b" * 40, target="a" * 40, lock=None, probe="success", releases=None, tags=None, prs=None):
     return {
         "master": "m" * 40,
         "development_branch": "d" * 40,
@@ -22,6 +22,7 @@ def fixture(main="b" * 40, target="a" * 40, lock=None, probe="success", releases
             "release_targets": [{"name": "v0.56.2", "rev": "r" * 40}],
         },
         "releases": [] if releases is None else releases,
+        "tags": {} if tags is None else tags,
         "open_prs": [] if prs is None else prs,
         "probe_runs": [{"databaseId": 1, "status": "completed", "conclusion": probe, "headSha": "m" * 40, "createdAt": "2026-09-10T00:00:00Z"}],
     }
@@ -82,8 +83,8 @@ class WatchHyprlandTests(unittest.TestCase):
             {"id": 3, "tag_name": "v0.58.0", "draft": True, "prerelease": False},
             {"id": 4, "tag_name": "v0.59.0-rc.1", "draft": False, "prerelease": True},
         ]
-        report = json.loads(run(fixture(releases=releases)).stdout)
-        self.assertEqual(report["eligible_releases"], [{"id": 2, "tag": "v0.57.0", "target": "z" * 40, "published_at": None}])
+        report = json.loads(run(fixture(releases=releases, tags={"v0.57.0": "p" * 40})).stdout)
+        self.assertEqual(report["eligible_releases"], [{"id": 2, "tag": "v0.57.0", "tag_commit": "p" * 40, "target": "z" * 40, "published_at": None}])
 
     def test_older_unsupported_releases_are_not_new_work(self):
         releases = [{"id": 1, "tag_name": "v0.55.4", "draft": False, "prerelease": False}]

--- a/tests/test_watch_hyprland.py
+++ b/tests/test_watch_hyprland.py
@@ -1,0 +1,95 @@
+import json
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WATCHER = ROOT / "scripts/watch-hyprland.py"
+
+
+def fixture(main="b" * 40, target="a" * 40, lock=None, probe="success", releases=None, prs=None):
+    return {
+        "master": "m" * 40,
+        "development_branch": "d" * 40,
+        "upstream_main": main,
+        "upstream_main_date": "2026-09-10T00:00:00Z",
+        "contract": {
+            "development_revision": target,
+            "lock_revision": target if lock is None else lock,
+            "lock_matches_target": lock is None or lock == target,
+            "release_targets": [{"name": "v0.56.2", "rev": "r" * 40}],
+        },
+        "releases": [] if releases is None else releases,
+        "open_prs": [] if prs is None else prs,
+        "probe_runs": [{"databaseId": 1, "status": "completed", "conclusion": probe, "headSha": "m" * 40, "createdAt": "2026-09-10T00:00:00Z"}],
+    }
+
+
+def run(data, form="json"):
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as handle:
+        json.dump(data, handle)
+        path = handle.name
+    result = subprocess.run(["python3", str(WATCHER), "--fixture", path, "--format", form], text=True, capture_output=True)
+    Path(path).unlink()
+    return result
+
+
+class WatchHyprlandTests(unittest.TestCase):
+    def test_up_to_date_has_no_candidate_work(self):
+        result = run(fixture(main="a" * 40))
+        report = json.loads(result.stdout)
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(report["status"], "up_to_date")
+        self.assertEqual(report["eligible_releases"], [])
+
+    def test_new_target_requests_one_candidate(self):
+        result = run(fixture())
+        report = json.loads(result.stdout)
+        self.assertEqual(report["status"], "new_upstream_target")
+        self.assertEqual(report["next_action"], "prepare one development candidate")
+
+    def test_existing_exact_candidate_deduplicates(self):
+        main = "b" * 40
+        result = run(fixture(prs=[{"number": 7, "title": "chase", "headRefName": f"chase/hyprland-{main}", "baseRefName": "hyprland-git", "isDraft": True}]))
+        report = json.loads(result.stdout)
+        self.assertEqual(report["status"], "candidate_active")
+        self.assertEqual(report["candidate_prs"][0]["number"], 7)
+
+    def test_failed_probe_requires_diagnosis(self):
+        result = run(fixture(probe="failure"))
+        report = json.loads(result.stdout)
+        self.assertEqual(report["status"], "needs_diagnosis")
+        self.assertIn("probe_failed", report["failure_stages"])
+
+    def test_lock_mismatch_is_never_compatible(self):
+        result = run(fixture(lock="c" * 40))
+        report = json.loads(result.stdout)
+        self.assertEqual(report["status"], "needs_diagnosis")
+        self.assertIn("development_lock_mismatch", report["failure_stages"])
+
+    def test_new_stable_release_is_reported_but_drafts_are_ignored(self):
+        releases = [
+            {"id": 1, "tag_name": "v0.56.2", "draft": False, "prerelease": False},
+            {"id": 2, "tag_name": "v0.57.0", "draft": False, "prerelease": False, "target_commitish": "z" * 40},
+            {"id": 3, "tag_name": "v0.58.0", "draft": True, "prerelease": False},
+            {"id": 4, "tag_name": "v0.59.0-rc.1", "draft": False, "prerelease": True},
+        ]
+        report = json.loads(run(fixture(releases=releases)).stdout)
+        self.assertEqual(report["eligible_releases"], [{"id": 2, "tag": "v0.57.0", "target": "z" * 40, "published_at": None}])
+
+    def test_older_unsupported_releases_are_not_new_work(self):
+        releases = [{"id": 1, "tag_name": "v0.55.4", "draft": False, "prerelease": False}]
+        report = json.loads(run(fixture(main="a" * 40, releases=releases)).stdout)
+        self.assertEqual(report["eligible_releases"], [])
+
+    def test_markdown_exposes_failure_and_release_work(self):
+        result = run(fixture(probe="failure", releases=[{"id": 2, "tag_name": "v0.57.0", "draft": False, "prerelease": False}]), "markdown")
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("probe_failed", result.stdout)
+        self.assertIn("v0.57.0", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The upstream-tip probe finds incompatibilities but previously left a maintainer to reconstruct target identity, release status, and next action. This adds a read-only observer, bounded chase procedure, release packet generator, and meaningful tracking PR CI routing.

The observer reported today's real state: upstream `599ff9042…` is newer than development pin `34eb03bd…`; scheduled probe #34462165645 failed on changed workspace/monitor APIs. The supervised repair pilot is tracked separately as a draft candidate; no compatibility claim is made here.

Changes:
- `scripts/watch-hyprland.py` reports exact branch/lock/upstream/release/probe/candidate state in JSON or Markdown.
- `scripts/prepare-hyprland-release.py` emits a local non-publishing packet only for one observed eligible release.
- Repo skill and docs define observe/chase/release/status, single writer ownership, bounded repair, consumer safeguards, and later Hermes activation requirements.
- Configured same-repository draft tracker #123 uses development matrix + `Tracking gate`; normal promotion/development PRs keep release/development gate behavior.
- Daily workflow uploads read-only observation before its existing probe, including on probe failure.

Validation: 56 tooling tests, all C++ suites, 39 input cases, diagnostic source contract, live observer pilot, docs build, YAML parse, shell syntax, and diff checks passed. Hosted workflow behavior remains pending this PR.
