### PR TITLE
Draft: diagnose Hyprland 599ff9042 workspace API breakage

### DIFF
--- a/.codex/skills/hyprexpo-chase/SKILL.md
+++ b/.codex/skills/hyprexpo-chase/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: hyprexpo-chase
+description: Observe Hyprland upstream, prepare one bounded development compatibility candidate, or prepare a release packet without publishing.
+---
+
+# HyprExpo chase
+
+Run `python3 scripts/watch-hyprland.py --format markdown` first. Read the
+report and [chasing Hyprland](../../../docs/guides/chasing-hyprland.md) before
+changing source, branches, or CI state.
+
+## Modes
+
+- `observe`: Read-only. Report exact target, upstream tip, release candidates,
+  probe evidence, duplicate candidates, and missing information.
+- `chase`: One exact upstream commit and one owned candidate branch. Work only
+  in an isolated checkout. Keep `hyprland-git` protected until reviewed merge.
+- `release`: Prepare a local packet and promotion PR for one exact upstream
+  release. Do not create tags, releases, or prereleases.
+- `status`: Report current observer output and existing candidate state.
+
+## Required rules
+
+- Existing Actions are read-only observers. One designated manual runner owns
+  candidate writes. Do not run concurrent repair agents across machines.
+- Preserve pins, managed-installation guards, contributor history, and live
+  desktop state. Test PR artifacts with disposable sessions or `make dev-reload`;
+  never save a temporary revision to managed hyprpm state.
+- Bind all evidence to exact plugin tree, upstream commit, lock, and test scope.
+  A compile or old artifact is not runtime acceptance for a new target.
+- Use at most three repair hypotheses and two hours of active work. On failure,
+  leave a resumable draft with diagnosis and missing gates.
+- Release preparation is not publication. Follow the existing promotion guide
+  and require explicit authorization before tags, assets, or release changes.
+
+Hermes is not a first-version runner. It may reuse this procedure only after a
+separate identity, credential, writer-lock, scheduler, and pilot validation.

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -44,8 +44,8 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: Verify target contract and negative cases
-        run: python3 -m unittest discover -s tests -p 'test_ci_*.py' -v
+      - name: Verify tooling contracts and negative cases
+        run: make test-tooling
       - name: Compile and run all standalone regression suites
         run: make -B test
       - name: Verify every historical release pin is reachable

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -27,6 +27,8 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       matrix: ${{ steps.resolve.outputs.matrix }}
+      contract: ${{ steps.resolve.outputs.contract }}
+      gate: ${{ steps.resolve.outputs.gate }}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
@@ -34,7 +36,25 @@ jobs:
       - id: resolve
         env:
           TARGET_BRANCH: ${{ github.base_ref || inputs.target_branch || github.ref_name }}
-        run: echo "matrix=$(python3 scripts/ci-targets.py matrix "$TARGET_BRANCH")" >> "$GITHUB_OUTPUT"
+          PR_NUMBER: ${{ github.event.pull_request.number || 0 }}
+          PR_DRAFT: ${{ github.event.pull_request.draft || false }}
+          PR_HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          PR_HEAD: ${{ github.head_ref || github.ref_name }}
+        run: |
+          descriptor=$(python3 scripts/ci-targets.py contract \
+            --repository "$GITHUB_REPOSITORY" --number "$PR_NUMBER" \
+            --base "$TARGET_BRANCH" --head-repository "$PR_HEAD_REPOSITORY" \
+            --head "$PR_HEAD" --draft "$PR_DRAFT")
+          CONTRACT="$descriptor" python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import json
+          import os
+          import subprocess
+          descriptor = json.loads(os.environ["CONTRACT"])
+          matrix = subprocess.check_output(["python3", "scripts/ci-targets.py", "matrix", descriptor["track"]], text=True).strip()
+          print(f"contract={descriptor['track']}")
+          print(f"gate={descriptor['gate']}")
+          print(f"matrix={matrix}")
+          PY
 
   regressions:
     name: Regression tests
@@ -72,7 +92,7 @@ jobs:
       - name: Build exact source and record dependency / generated-header provenance
         env:
           UPSTREAM_REV: ${{ matrix.rev }}
-          CI_TARGET_BRANCH: ${{ github.base_ref || inputs.target_branch || github.ref_name }}
+          CI_TARGET_BRANCH: ${{ needs.targets.outputs.contract }}
           EVIDENCE_DIR: ${{ runner.temp }}/evidence-${{ matrix.name }}
         run: ./scripts/ci-build.sh "$UPSTREAM_REV" "$EVIDENCE_DIR"
       - name: Preserve artifacts and failure logs
@@ -86,7 +106,7 @@ jobs:
   gate:
     # Never emit a skipped opposite-track gate: GitHub accepts skipped checks
     # for protection, including another workflow run on the same commit.
-    name: ${{ (github.base_ref || inputs.target_branch || github.ref_name) == 'master' && 'Release gate' || 'Development gate' }}
+    name: ${{ needs.targets.outputs.gate }}
     if: always()
     needs: [targets, regressions, build]
     runs-on: ubuntu-24.04

--- a/.github/workflows/upstream-tip.yml
+++ b/.github/workflows/upstream-tip.yml
@@ -7,13 +7,36 @@ on:
 
 permissions:
   contents: read
+  actions: read
+  pull-requests: read
 
 concurrency:
   group: upstream-tip-probe
   cancel-in-progress: false
 
 jobs:
+  observe:
+    name: Observe upstream state
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Record actionable upstream state
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python3 scripts/watch-hyprland.py --format markdown | tee upstream-observation.md
+      - name: Preserve observation
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: upstream-observation-${{ github.run_id }}-${{ github.run_attempt }}
+          path: upstream-observation.md
+          if-no-files-found: warn
+
   probe:
+    needs: observe
     name: Advisory upstream tip
     runs-on: ubuntu-24.04
     timeout-minutes: 120

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,45 @@
+# Contributing
+
+Follow the [branch policy](docs/reference/branch-policy.md) and validate against
+the Hyprland revisions affected by your change.
+
+## Local Installation Contract
+
+These rules apply to maintainers, contributors, and coding agents.
+
+- Test PR builds with `make dev-reload` or `./scripts/run-nested.sh`. Keep the
+  checkout and built artifact available for the test session.
+- Do not write a PR commit or temporary branch into the desktop's hyprpm
+  `repository.rev`, or set that override to keep a test build installed. A
+  squash merge and branch deletion can make the original commit unavailable
+  to `hyprpm update`, even when it still exists in your local Git database.
+- From a checkout, register a managed installation through
+  `./scripts/hyprpm-add.sh <repository-url> [revision]`. Released Hyprland
+  normally uses no revision argument so hyprpm can select `commit_pins`.
+  The wrapper validates an explicit revision before invoking hyprpm.
+- Run `make check-hyprpm-state` before any manual managed replacement.
+  `make install` and `scripts/dev-link.sh` enforce this check themselves.
+  Do not bypass a failed check by editing `rev` to another test hash.
+- Keep supported branch and release-tag history available upstream. Persistent
+  hashes must remain reachable from that history; temporary PR refs are not
+  retention anchors. Follow the [recovery procedure](docs/troubleshooting.md#hyprpm-cannot-check-out-a-saved-revision)
+  when a saved override is already stale.
+- Back up the existing state and artifact before intentional replacements;
+  never overwrite the inode of a loaded shared object. Verify the matching
+  ABI, loaded plugin, and config errors after loading.
+
+The guard uses Git and Python 3.11+ standard-library tooling. Unpinned and
+unmanaged destinations pass without network access. Explicit revisions require
+a fresh upstream clone; failed verification stops the operation without
+changing the plugin or saved state. This verifies revision retention, not ABI
+compatibility, and does not intercept direct hyprpm commands or manual edits.
+
+## Guard Regression Tests
+
+Run `make test-tooling` for the Git/installer fixtures and `make test` for the
+standalone C++ suites. Tooling tests use disposable repositories and fake plugin
+artifacts, never the running desktop or a real publication remote. Both suites
+are required by compatibility CI.
+
+The release commands must stop if `check-commit-pins.sh` fails. Never suppress
+that failure or publish a PR commit merely because the local object exists.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,10 @@
 Follow the [branch policy](docs/reference/branch-policy.md) and validate against
 the Hyprland revisions affected by your change.
 
+For periodic development compatibility work, follow
+[chasing Hyprland](docs/guides/chasing-hyprland.md). It keeps upstream
+observation, candidate repair, and release preparation separate.
+
 ## Local Installation Contract
 
 These rules apply to maintainers, contributors, and coding agents.

--- a/Makefile
+++ b/Makefile
@@ -63,9 +63,12 @@ dev-reload: dev-build
 dev-nested:
 	./scripts/run-nested.sh
 
-install: $(TARGET)
+check-hyprpm-state:
+	@python3 scripts/check-hyprpm-state.py "$(INSTALL_DIR)/state.toml"
+
+install: check-hyprpm-state $(TARGET)
 	@echo "Installing for $(INSTALL_USER) into $(INSTALL_DIR)/$(INSTALL_NAME)"
-	install -Dm755 $(TARGET) $(INSTALL_DIR)/$(INSTALL_NAME)
+	install -Dm755 "$(TARGET)" "$(INSTALL_DIR)/$(INSTALL_NAME)"
 
 clean:
 	rm -f ./$(TARGET) ./$(TEST_TARGET) ./$(SOURCE_TEST_TARGET) ./$(REGISTRY_TEST_TARGET) ./$(INPUT_ORACLE_TARGET)
@@ -74,6 +77,9 @@ test: $(TEST_TARGET) $(SOURCE_TEST_TARGET) $(REGISTRY_TEST_TARGET)
 	./$(TEST_TARGET)
 	./$(SOURCE_TEST_TARGET)
 	./$(REGISTRY_TEST_TARGET)
+
+test-tooling:
+	python3 -m unittest discover -s tests -p 'test_*.py' -v
 
 $(TEST_TARGET): src/HyprexpoLogic.cpp src/HyprexpoLogic.hpp src/HyprexpoConfig.hpp src/ScrollingOverviewLogic.cpp src/ScrollingOverviewLogic.hpp src/ScrollingInputState.cpp src/ScrollingInputState.hpp src/ScrollingRequestId.hpp src/ScrollingMutationTransaction.cpp src/ScrollingMutationTransaction.hpp tests/HyprexpoLogicTests.cpp
 	$(CXX) -std=c++2b -Wall -Wextra -Werror src/HyprexpoLogic.cpp src/ScrollingOverviewLogic.cpp src/ScrollingInputState.cpp src/ScrollingMutationTransaction.cpp tests/HyprexpoLogicTests.cpp -o $@
@@ -104,7 +110,8 @@ endif
 SET_VERSION := $(if $(VERSION_ARG),$(VERSION_ARG),$(v))
 
 version:
-	@if [ -z '$(SET_VERSION)' ]; then \
+	@set -e; \
+	if [ -z '$(SET_VERSION)' ]; then \
 		printf '%s\n' '$(VERSION)'; \
 	else \
 		printf '%s' '$(SET_VERSION)' | grep -Eq '$(VERSION_REGEX)' \
@@ -119,7 +126,8 @@ version:
 	fi
 
 tag:
-	@v='$(VERSION_BASE)'; \
+	@set -e; \
+	v='$(VERSION_BASE)'; \
 	printf '%s' "$$v" | grep -Eq '$(VERSION_REGEX)' \
 		|| { echo "error: VERSION file '$$v' must look like v1.2.3 or v1.2.3+4"; exit 1; }; \
 	if [ -n "$$(git status --porcelain -- $(VERSION_FILE))" ]; then \
@@ -133,7 +141,8 @@ tag:
 	echo "created tag $$v. next: make publish"
 
 publish:
-	@v='$(VERSION_BASE)'; \
+	@set -e; \
+	v='$(VERSION_BASE)'; \
 	if ! git rev-parse -q --verify "refs/tags/$$v" >/dev/null; then \
 		echo "error: tag $$v does not exist; run 'make tag' first"; exit 1; fi; \
 	./scripts/check-commit-pins.sh "$$v"; \
@@ -159,4 +168,4 @@ check-version:
 		|| { echo "::error::VERSION ($$file_ver) does not match tag ($$tag_ver)"; exit 1; }; \
 	echo "version aligned: $$file_ver"
 
-.PHONY: all clean install test dev-build dev-load dev-reload dev-nested version tag publish check-pins check-version
+.PHONY: all clean install test test-tooling dev-build dev-load dev-reload dev-nested version tag publish check-pins check-version check-hyprpm-state

--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ For more options, see the [configuration options](https://hyprexpo.lol/docs/conf
 
 ## Next Steps
 
+- [Chasing Hyprland](https://hyprexpo.lol/docs/guides/chasing-hyprland/)
 - [Repository layout and development-branch reconciliation](docs/reference/repository-layout.md)
 
 - [Installation details](https://hyprexpo.lol/docs/getting-started/installation/)

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -43,6 +43,7 @@ export default defineConfig({
           { text: "Migration", link: "/guides/migration" },
           { text: "Runtime Smoke", link: "/guides/runtime-smoke" },
           { text: "Release Promotion", link: "/guides/release-promotion" },
+          { text: "Chasing Hyprland", link: "/guides/chasing-hyprland" },
           { text: "Development Installation", link: "/guides/development-installation" },
         ],
       },

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -12,6 +12,18 @@ hyprpm reload
 
 The plugin repository is named `hyprexpo` in `hyprpm.toml`, and the built output is `hyprexpo.so`.
 
+When registering from a source checkout, use the guarded wrapper:
+
+```bash
+./scripts/hyprpm-add.sh https://github.com/sandwichfarm/hyprexpo
+```
+
+It also accepts a revision argument for the [development track](../guides/development-installation.md).
+Before invoking hyprpm, an explicit revision is checked in a fresh clone against
+maintained branch or release-tag history. A temporary PR branch or a PR-only
+commit is rejected. A locally available commit is not sufficient: squash merges
+can leave it unavailable to a future normal clone.
+
 ## Build From Source
 
 Build dependencies are a C++23 compiler, `pkg-config`, Hyprland development headers, and these pkg-config packages:
@@ -72,6 +84,15 @@ make install
 hyprpm reload
 ```
 
+`make install` and `scripts/dev-link.sh` check the saved `repository.rev` before
+changing a managed destination. The preflight uses Git and Python 3.11+ and
+requires network access only for an explicit revision. Run it independently
+with `make check-hyprpm-state` (`INSTALL_USER` and `INSTALL_DIR` select the same
+destination as `make install`). Failed or unreadable state stops replacement;
+see [saved-revision recovery](../troubleshooting.md#hyprpm-cannot-check-out-a-saved-revision).
+These commands never persist a test revision. Use the development load commands
+above for PR testing.
+
 If the hyprpm artifact path is root-owned, keep the privilege at the command
 line and preserve the target user explicitly:
 
@@ -83,8 +104,9 @@ hyprpm reload
 Equivalent manual install:
 
 ```bash
+make check-hyprpm-state &&
 install -Dm755 hyprexpo.so \
-    /var/cache/hyprpm/$USER/hyprexpo/hyprexpo.so
+    "/var/cache/hyprpm/$USER/hyprexpo/hyprexpo.so"
 hyprpm reload
 ```
 

--- a/docs/guides/chasing-hyprland.md
+++ b/docs/guides/chasing-hyprland.md
@@ -1,0 +1,72 @@
+# Chasing Hyprland
+
+HyprExpo supports released Hyprland targets on `master` and one exact development
+target on `hyprland-git`. This procedure observes upstream changes, prepares
+reviewable compatibility work, and prepares release packets. It does not publish
+or merge by itself.
+
+## Observe
+
+Run from an up-to-date checkout with GitHub CLI access:
+
+```sh
+python3 scripts/watch-hyprland.py --format markdown
+```
+
+The report is read-only. It records the development pin, upstream `main`,
+release candidates, current probe evidence, and existing candidates. A failed
+observation is incomplete evidence, never proof that no work exists.
+
+The scheduled upstream-tip workflow runs this same observation before its
+expensive build. Scheduled GitHub workflows are best effort and run from the
+default branch; a delayed or missed schedule is not a compatibility result.
+
+## Prepare one development target
+
+Only the designated manual runner writes candidates. Actions observe. Do not run
+another writer from Hermes or a second host until a shared writer lease exists.
+
+1. Save the observer report. If a matching candidate or live job exists, inspect
+   it and stop; do not duplicate it.
+2. Create an isolated branch from current `hyprland-git` using the exact upstream
+   commit from the report. Do not use the desktop checkout.
+3. Update the development target, `flake.nix`, and resolved lock together.
+   Preserve release targets and hyprpm pins.
+4. Diagnose the exact build failure against the captured upstream source. Keep
+   existing behavior tests meaningful; do not fake headers, change the target,
+   disable sandboxing, or suppress features to obtain a build.
+5. Run tooling, C++ suites, relevant input tests, documentation build, exact
+   build, and affected disposable runtime proof. Record hardware gaps.
+6. Push one owned candidate PR into `hyprland-git`. Keep incomplete work draft
+   and include exact source/tree/lock/probe/runtime evidence plus the next gate.
+
+The standing tracking PR uses the development contract only while it remains the
+configured same-repository draft tracker. It is not a release-promotion PR.
+
+## Prepare a released target
+
+Run observation first. A new stable release is a separate work item identified
+by release ID, tag, and peeled tag commit. Old unsupported releases, drafts,
+prereleases, malformed tags, and a tag that moved need explicit review.
+
+Choose a compatible historical candidate if `hyprland-git` has moved beyond the
+release. Create a local packet and a reviewable promotion PR containing exact
+upstream/plugin/tree/lock identities, support decisions, artifacts, runtime
+receipt, pin ancestry, notes, and remaining gates. Follow the
+[release promotion guide](./release-promotion.md).
+
+Do not create a tag, GitHub Release, or prerelease packet in public state. The
+current stable publisher accepts broad `v*` tags; release-candidate publication
+requires separate version, trigger, collision, provenance, and authorization
+work first.
+
+## Resuming and Hermes
+
+Bound one repair attempt to three hypotheses and two hours of active work. Keep
+a receipt when a target remains broken. Before continuing, re-observe refs and
+job handles; upstream may have moved or another contributor may own the work.
+
+Hermes is optional later. It must use this procedure as approved context, have
+separate read-only observation and constrained candidate-write credentials, an
+isolated workspace, persistent receipts, single-writer ownership, capped jobs,
+and a tested disable path. It must not receive stable-release publisher access.

--- a/docs/guides/development-installation.md
+++ b/docs/guides/development-installation.md
@@ -11,22 +11,22 @@ flake lock and the running compositor's `hyprctl version` output against the
 [validation receipt](../reference/workflow-validation.md). Test in a disposable
 compositor before changing a desktop.
 
-While [PR #122](https://github.com/sandwichfarm/hyprexpo/pull/122) is unmerged,
-its implementation is on `integration/chase-validation`. For candidate testing,
-use `origin/integration/chase-validation` with hyprpm or that candidate's full
-commit in the Nix URL. Commands below using `hyprland-git` assume that branch
-contains the validated candidate and matching lock; branch creation alone is
-insufficient.
+Commands below using `hyprland-git` assume that branch contains the validated
+candidate and matching lock; branch creation alone is insufficient. Test an
+unmerged candidate from its checkout in a disposable compositor. Do not save
+its PR hash or temporary branch in a desktop's hyprpm registration: a later
+squash merge or branch deletion can break updates.
 
 ## hyprpm Revision Selection
 
 Hyprpm accepts an optional Git revision after the repository URL. Its
 implementation clones the repository and resets to that revision. For a
-non-default branch, use its remote-tracking ref in the fresh clone:
+non-default branch, use its remote-tracking ref in the fresh clone. From a
+HyprExpo checkout, use the guarded registration wrapper:
 
 ```sh
 hyprpm update
-hyprpm add https://github.com/sandwichfarm/hyprexpo origin/hyprland-git
+./scripts/hyprpm-add.sh https://github.com/sandwichfarm/hyprexpo origin/hyprland-git
 hyprpm enable hyprexpo
 hyprpm reload
 ```
@@ -36,11 +36,17 @@ chase track; do not use it on released Hyprland to bypass a failed compatibility
 check. A bare `hyprland-git` name does not resolve in a fresh clone where only
 `master` exists locally. `origin/hyprland-git` does.
 
-For an immutable plugin candidate, use its full commit hash in place of
-`origin/hyprland-git`. Keep the corresponding compositor revision and dependency
-environment together. The same mechanism can validate an unmerged candidate
-using its published `origin/<candidate-branch>` ref; this does not establish
-support for a different published branch tip.
+For an immutable plugin candidate already retained by maintained history, use
+its full commit hash in place of `origin/hyprland-git`. The guard accepts hashes
+reachable from `master`, `hyprland-git`, declared `release/<version>` branches,
+or versioned release tags in a fresh clone. Temporary branch names and commits
+reachable only through PR history are rejected before registration. Keep the
+corresponding compositor revision and dependency environment together.
+
+For unmerged PR tests, use `make dev-reload` or `./scripts/run-nested.sh` in the
+test checkout without changing managed state. Direct revision-specific hyprpm
+tests belong in a disposable environment whose registration is discarded with
+the test. They do not establish a persistent installation or future availability.
 
 Hyprpm cannot add the same repository twice. To change the selected revision,
 first disable and remove the existing registration, then add the intended
@@ -149,7 +155,7 @@ session. Preserve the old consumer lock and system generation for rollback.
 
 | Symptom | Check and recovery |
 | --- | --- |
-| Git revision cannot be checked out | Use `origin/hyprland-git` or a full commit reachable from the repository; verify it in a fresh clone. |
+| Git revision cannot be checked out | Check the saved override and follow [saved-revision recovery](../troubleshooting.md#hyprpm-cannot-check-out-a-saved-revision). Verify any replacement against maintained history in a fresh clone. |
 | Missing or changed C++ APIs | Compare the source revision with the exact compositor target. Select a compatible candidate before retrying. |
 | Header or plugin ABI mismatch | Confirm the running session matches the installed compositor, then regenerate headers/rebuild with its dependency environment. Restart into the intended compositor when disk and running versions differ. |
 | Nix input follows the system but build fails | Check source compatibility and the complete lock, not only the top-level Hyprland input. Retain the failing build log. |

--- a/docs/guides/release-promotion.md
+++ b/docs/guides/release-promotion.md
@@ -5,6 +5,8 @@ Hyprland development track. It stops at a reviewable, validated promotion PR;
 merging, tagging, and publishing require the maintainer's release decision.
 See the [branch policy](../reference/branch-policy.md) for contribution flow and
 [compatibility reference](../reference/compatibility.md) for current targets.
+Use [chasing Hyprland](./chasing-hyprland.md) to discover and prepare a target;
+this guide remains the promotion and publication gate.
 
 ## Select Immutable Inputs
 

--- a/docs/reference/chase-receipts/2026-09-10-599ff9042.md
+++ b/docs/reference/chase-receipts/2026-09-10-599ff9042.md
@@ -1,57 +1,46 @@
 # Hyprland development chase receipt: 599ff9042
 
-**Status:** Incomplete — API diagnosis required
+**Status:** Validated development candidate
 
-**Plugin base:** `c559e5939b1cb0712299b49a15aea9d03a496b5e`  
-**Pinned Hyprland:** `34eb03bd8da01024596c367fba66485a8c9b8ca7`  
-**Observed upstream main:** `599ff9042c866dcad4bb458979f7be68a6d2ffef`  
+**Plugin base:** `c559e5939b1cb0712299b49a15aea9d03a496b5e`
+**Pinned Hyprland:** `599ff9042c866dcad4bb458979f7be68a6d2ffef`
+**Lock:** `flake.lock` resolves the same immutable commit
 **Probe:** [34462165645](https://github.com/sandwichfarm/hyprexpo/actions/runs/34462165645)
 
-## Observation
+## Repair
 
-The scheduled probe passed on September 9 and failed on September 10 while
-building the unchanged development plugin against `599ff9042`. The observer
-reported no existing candidate for this exact upstream commit and no new stable
-Hyprland release requiring a promotion packet.
+Hyprland made numbered workspace IDs private tagged values, removed
+`activeWorkspaceID()`, and moved workspace state behind public accessors.
+`WorkspaceCompat.hpp` keeps the plugin's numeric tile model at its boundary:
 
-The candidate deliberately keeps the current development pin and lock. Moving
-only one of those inputs would create an invalid compatibility claim before a
-matching build and runtime receipt exist.
+- reads numbered IDs through `numberedID()`;
+- resolves selectors through the upstream workspace resolver with the explicit
+  monitor;
+- creates numbered workspaces through `createNumbered()`;
+- uses `visible()`, `setVisible()`, `space()`, and `displayName()` instead of
+  host-private fields.
 
-## Initial compiler evidence
+The grid, scrolling overview, drag/mutation path, diagnostics, and dispatcher
+all use that boundary. Special or named workspaces remain outside the numeric
+tile model.
 
-The probe records three connected API changes in `src/Dispatchers.cpp`:
+## Exact build and runtime evidence
 
-- `WORKSPACE_INVALID` is no longer declared.
-- `Monitor::CMonitor::activeWorkspaceID` no longer exists.
-- Workspace IDs are no longer directly comparable with `int64_t`; the previous
-  `m_id` member is private and the new type is a variant.
+- Nix lock/update and build used Hyprland
+  `599ff9042c866dcad4bb458979f7be68a6d2ffef`.
+- The built plugin was
+  `/nix/store/3lzghz5r9avh5an5jwzwdvyrr0r7i38c-hyprexpo-0.1/lib/libhyprexpo.so`
+  with SHA-256 `2c815afc95b2acb9dcb92f7d711c90a6452bf5da6d6c6c3756236d5e7481cb2f`.
+- A disposable KVM/VirGL session loaded that artifact into the matching
+  compositor. Its runtime ABI was
+  `599ff9042c866dcad4bb458979f7be68a6d2ffef_aq_0.15_hu_0.14_hg_0.5_hc_0.1_hlg_0.6`.
+- The session passed mapped fixed-grid previews, keyboard focus, submap
+  restoration, mapped scrolling previews, pinned-state retention, close
+  teardown, and an empty `hyprctl configerrors` result.
 
-This is an API source-compatibility failure, not a failed runtime acceptance or
-evidence that Hyprland itself is broken. The next repair run must inspect the
-captured upstream headers and workspace-ID migration path, then preserve the
-existing workspace-selection behavior with focused tests.
+## Remaining release boundary
 
-## Bounded repair hypotheses
-
-1. Replace the invalid-workspace sentinel and integer comparison with the
-   upstream workspace-ID construction/comparison API.
-2. Derive the active workspace through the monitor's current workspace object
-   instead of the removed numeric `activeWorkspaceID` member.
-3. Keep the existing dispatcher error behavior, then update only source
-   assertions that encode the superseded host API.
-
-Stop after these three paths if none produces an exact build. Record the header
-evidence and leave this draft resumable rather than advancing the pin.
-
-## Required next gates
-
-1. Update development target, `flake.nix`, and lock together in this candidate.
-2. Repair workspace/monitor API use without weakening behavior tests.
-3. Run tooling, C++ tests, input cases, exact build/rebuild, and affected
-   disposable runtime checks.
-4. Bind all resulting evidence to this plugin tree, target commit, and lock.
-5. Update this receipt, then request review for `hyprland-git` using a merge
-   commit. Do not install this branch through managed hyprpm state.
-
-No tag, release, desktop installation, or protected-branch update was performed.
+This validates only the exact development target. It does not make a released
+Hyprland version compatible and does not alter release pins, HyprPM state, or
+the live desktop. Promote only through the release procedure after a released
+upstream target has its own candidate and receipt.

--- a/docs/reference/chase-receipts/2026-09-10-599ff9042.md
+++ b/docs/reference/chase-receipts/2026-09-10-599ff9042.md
@@ -1,0 +1,45 @@
+# Hyprland development chase receipt: 599ff9042
+
+**Status:** Incomplete — API diagnosis required
+
+**Plugin base:** `c559e5939b1cb0712299b49a15aea9d03a496b5e`  
+**Pinned Hyprland:** `34eb03bd8da01024596c367fba66485a8c9b8ca7`  
+**Observed upstream main:** `599ff9042c866dcad4bb458979f7be68a6d2ffef`  
+**Probe:** [34462165645](https://github.com/sandwichfarm/hyprexpo/actions/runs/34462165645)
+
+## Observation
+
+The scheduled probe passed on September 9 and failed on September 10 while
+building the unchanged development plugin against `599ff9042`. The observer
+reported no existing candidate for this exact upstream commit and no new stable
+Hyprland release requiring a promotion packet.
+
+The candidate deliberately keeps the current development pin and lock. Moving
+only one of those inputs would create an invalid compatibility claim before a
+matching build and runtime receipt exist.
+
+## Initial compiler evidence
+
+The probe records three connected API changes in `src/Dispatchers.cpp`:
+
+- `WORKSPACE_INVALID` is no longer declared.
+- `Monitor::CMonitor::activeWorkspaceID` no longer exists.
+- Workspace IDs are no longer directly comparable with `int64_t`; the previous
+  `m_id` member is private and the new type is a variant.
+
+This is an API source-compatibility failure, not a failed runtime acceptance or
+evidence that Hyprland itself is broken. The next repair run must inspect the
+captured upstream headers and workspace-ID migration path, then preserve the
+existing workspace-selection behavior with focused tests.
+
+## Required next gates
+
+1. Update development target, `flake.nix`, and lock together in this candidate.
+2. Repair workspace/monitor API use without weakening behavior tests.
+3. Run tooling, C++ tests, input cases, exact build/rebuild, and affected
+   disposable runtime checks.
+4. Bind all resulting evidence to this plugin tree, target commit, and lock.
+5. Update this receipt, then request review for `hyprland-git` using a merge
+   commit. Do not install this branch through managed hyprpm state.
+
+No tag, release, desktop installation, or protected-branch update was performed.

--- a/docs/reference/chase-receipts/2026-09-10-599ff9042.md
+++ b/docs/reference/chase-receipts/2026-09-10-599ff9042.md
@@ -32,6 +32,18 @@ evidence that Hyprland itself is broken. The next repair run must inspect the
 captured upstream headers and workspace-ID migration path, then preserve the
 existing workspace-selection behavior with focused tests.
 
+## Bounded repair hypotheses
+
+1. Replace the invalid-workspace sentinel and integer comparison with the
+   upstream workspace-ID construction/comparison API.
+2. Derive the active workspace through the monitor's current workspace object
+   instead of the removed numeric `activeWorkspaceID` member.
+3. Keep the existing dispatcher error behavior, then update only source
+   assertions that encode the superseded host API.
+
+Stop after these three paths if none produces an exact build. Record the header
+evidence and leave this draft resumable rather than advancing the pin.
+
 ## Required next gates
 
 1. Update development target, `flake.nix`, and lock together in this candidate.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,5 +1,46 @@
 # Troubleshooting
 
+## hyprpm Cannot Check Out a Saved Revision
+
+If `hyprpm update` prints `Plugin has revision set, resetting` followed by
+`Could not parse object`, inspect `repository.rev` in
+`/var/cache/hyprpm/$USER/hyprexpo/state.toml`. An explicit revision overrides
+the repository's compatibility pins. A PR commit can disappear from normal
+clones after a squash merge and deletion of its temporary branch; retaining
+the object in a developer checkout does not make the installation updateable.
+
+From a source checkout, run `make check-hyprpm-state`. The check makes no changes.
+It accepts unpinned state offline, and verifies explicit revisions using a fresh
+clone. Failed network access also refuses replacement instead of assuming the
+revision is safe. It cannot establish ABI compatibility or guarantee that an
+upstream maintainer will preserve the accepted refs in the future.
+
+To restore normal pin selection on a **supported released Hyprland**, first
+back up the installed state and binary, then re-register without a revision:
+
+```bash
+backup_root="${XDG_STATE_HOME:-$HOME/.local/state}/hyprexpo"
+mkdir -p "$backup_root" &&
+backup_dir="$(mktemp -d "$backup_root/revision-recovery.XXXXXX")" &&
+cp -a "/var/cache/hyprpm/$USER/hyprexpo" "$backup_dir/" &&
+hyprpm remove hyprexpo &&
+./scripts/hyprpm-add.sh https://github.com/sandwichfarm/hyprexpo &&
+hyprpm enable hyprexpo &&
+hyprpm reload &&
+hyprctl reload
+```
+
+Keep the backup until loading succeeds. Run hyprpm as your normal user and
+authenticate its sudo prompt in your terminal. If a command fails, stop and
+retain the output and backup. Do not delete the entire cache or replace `rev`
+with another temporary PR hash. Development-track installations must retain
+their matching compositor and use the [development recovery procedure](./guides/development-installation.md#troubleshooting-and-rollback).
+
+Verify `hyprctl version`, `hyprctl plugin list`, and `hyprctl configerrors` after
+recovery. A failed install can unload the plugin and cause `unknown config key
+'plugin.hyprexpo.…'` errors until it is loaded again. Finish loading and reload
+the config before treating these as removed options.
+
 ## Plugin Load Fails With API or Hash Mismatch
 
 Rebuild HyprExpo against the same Hyprland revision that is running, then reload the plugin.

--- a/flake.lock
+++ b/flake.lock
@@ -124,17 +124,17 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1788692456,
-        "narHash": "sha256-lRRgvJwnXupqt7DVUJJ4E1sUgubTs4BxO6iDXdn4irE=",
+        "lastModified": 1788962709,
+        "narHash": "sha256-yCT/nVwI/tj7Nbk0r3vNXOC1BSnZ5yUebE3Ao7Vaw70=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "34eb03bd8da01024596c367fba66485a8c9b8ca7",
+        "rev": "599ff9042c866dcad4bb458979f7be68a6d2ffef",
         "type": "github"
       },
       "original": {
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "34eb03bd8da01024596c367fba66485a8c9b8ca7",
+        "rev": "599ff9042c866dcad4bb458979f7be68a6d2ffef",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,7 @@
       type = "github";
       owner = "hyprwm";
       repo = "Hyprland";
-      rev = "34eb03bd8da01024596c367fba66485a8c9b8ca7";
+      rev = "599ff9042c866dcad4bb458979f7be68a6d2ffef";
     };
 
     nixpkgs.follows = "hyprland/nixpkgs";

--- a/scripts/check-hyprpm-state.py
+++ b/scripts/check-hyprpm-state.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Reject hyprpm registrations and replacements tied to temporary history."""
+
+import argparse
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+import tempfile
+import tomllib
+
+
+RELEASE_TAG = r"v[0-9]+\.[0-9]+\.[0-9]+(?:\+[0-9]+)?"
+RETAINED_BRANCH = r"(?:master|hyprland-git|release/[0-9]+(?:\.[0-9]+)*)"
+
+
+def retained_ref(ref):
+    return bool(
+        re.fullmatch(r"refs/remotes/origin/" + RETAINED_BRANCH, ref)
+        or re.fullmatch(r"refs/tags/" + RELEASE_TAG, ref)
+    )
+
+
+def check_state(state):
+    try:
+        with state.open("rb") as stream:
+            data = tomllib.load(stream)
+    except FileNotFoundError:
+        if state.is_symlink():
+            raise ValueError("state.toml is a dangling symlink")
+        return "no managed state at this destination"
+
+    return check_repository(data.get("repository"))
+
+
+def check_repository(repository):
+    if not isinstance(repository, dict):
+        raise ValueError("state.toml has no repository table")
+    rev = repository.get("rev", "")
+    if not isinstance(rev, str):
+        raise ValueError("repository.rev must be a string")
+    if not rev:
+        return "no explicit revision override; hyprpm can select compatibility pins"
+
+    # A temporary branch can disappear even when its current commit is on master.
+    if not (
+        re.fullmatch(r"[0-9a-fA-F]{40}", rev)
+        or rev in ("master", "refs/heads/master")
+        or retained_ref(rev)
+        or retained_ref("refs/remotes/" + rev)
+        or re.fullmatch(RELEASE_TAG, rev)
+    ):
+        raise ValueError("repository.rev names temporary or unsupported history: " + rev)
+
+    url = repository.get("url")
+    if not isinstance(url, str) or not url.strip():
+        raise ValueError("an explicit revision requires repository.url")
+
+    # Do not inherit another checkout's objects, refs, or working tree. In
+    # particular, an old PR object in a local clone must not make this pass.
+    environment = os.environ.copy()
+    for name in (
+        "GIT_DIR", "GIT_COMMON_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE",
+        "GIT_OBJECT_DIRECTORY", "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+        "GIT_SHALLOW_FILE", "GIT_NAMESPACE",
+    ):
+        environment.pop(name, None)
+    environment["GIT_TERMINAL_PROMPT"] = "0"
+
+    def git(*args):
+        try:
+            return subprocess.run(
+                ["git", *args], capture_output=True, text=True,
+                env=environment, timeout=60,
+            )
+        except subprocess.TimeoutExpired:
+            # TimeoutExpired includes the command, which may contain URL credentials.
+            raise ValueError("Git verification timed out; installation refused") from None
+
+    with tempfile.TemporaryDirectory(prefix="hyprexpo-revision-check-") as directory:
+        clone = str(Path(directory) / "repo")
+        # --no-local is essential for local URLs: copying the object directory
+        # would retain unreachable commits which a normal remote clone omits.
+        # Empty templates prevent injected local refs and alternate object stores.
+        result = git("clone", "--quiet", "--no-checkout", "--no-local", "--template=", "--", url, clone)
+        if result.returncode:
+            raise ValueError("cannot verify repository.url with a fresh clone; installation refused")
+        result = git("-C", clone, "rev-parse", "--verify", "--end-of-options", rev + "^{commit}")
+        if result.returncode:
+            raise ValueError("saved revision is unavailable in a fresh clone: " + rev)
+        commit = result.stdout.strip()
+        result = git("-C", clone, "for-each-ref", "--format=%(refname)", "refs/remotes/origin/", "refs/tags/")
+        if result.returncode:
+            raise ValueError("cannot enumerate retained upstream history")
+        for ref in result.stdout.splitlines():
+            if not retained_ref(ref):
+                continue
+            result = git("-C", clone, "merge-base", "--is-ancestor", commit, ref + "^{commit}")
+            if result.returncode == 0:
+                return f"saved revision {rev} is retained by {ref}"
+            if result.returncode != 1:
+                raise ValueError("cannot verify retained upstream history: " + ref)
+        raise ValueError("saved revision is not retained by a release tag or maintained branch: " + rev)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("state", nargs="?", type=Path, help="state.toml beside the managed destination (do not resolve the .so symlink)")
+    parser.add_argument("--url", help="repository URL for a proposed registration")
+    parser.add_argument("--revision", help="proposed revision, or an empty string for compatibility pins")
+    args = parser.parse_args()
+    proposal = args.url is not None or args.revision is not None
+    if proposal and (args.state is not None or args.url is None or args.revision is None):
+        parser.error("use either a state path or both --url and --revision")
+    if not proposal and args.state is None:
+        parser.error("a state path or both --url and --revision are required")
+    try:
+        if proposal:
+            if not args.url.strip():
+                raise ValueError("repository URL must not be empty")
+            message = check_repository({"url": args.url, "rev": args.revision})
+        else:
+            message = check_state(args.state)
+    except (OSError, ValueError, subprocess.SubprocessError) as error:
+        location = "proposed registration" if proposal else str(args.state)
+        print(f"error: unsafe hyprpm state at {location}: {error}", file=sys.stderr)
+        print(
+            "No plugin or state was changed by this check. Use make dev-reload or a nested session for PR testing.\n"
+            "For recovery, see docs/troubleshooting.md; do not replace the saved revision with another PR hash.",
+            file=sys.stderr,
+        )
+        return 1
+    print("hyprpm state verified: " + message)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci-targets.py
+++ b/scripts/ci-targets.py
@@ -12,9 +12,10 @@ ROOT = Path(__file__).resolve().parents[1]
 
 def targets(path=ROOT / "scripts/hyprland-targets.json"):
     data = json.loads(path.read_text())
-    if set(data) != {"release", "development"}:
-        raise ValueError("target file must contain release and development")
-    for track, rows in data.items():
+    if set(data) != {"release", "development", "tracker"}:
+        raise ValueError("target file must contain release, development and tracker")
+    for track in ("release", "development"):
+        rows = data[track]
         if not rows or (track == "development" and len(rows) != 1):
             raise ValueError(f"invalid number of {track} targets")
         names = set()
@@ -30,6 +31,9 @@ def targets(path=ROOT / "scripts/hyprland-targets.json"):
                 raise ValueError("duplicate target")
             names.add(row["name"])
             revisions.add(row["rev"])
+    tracker = data["tracker"]
+    if set(tracker) != {"repository", "number", "base", "head"} or not isinstance(tracker["number"], int):
+        raise ValueError("tracker contract is invalid")
     return data
 
 
@@ -38,6 +42,21 @@ def track_for_branch(branch):
     if branch not in mapping:
         raise ValueError(f"unrecognized target branch: {branch}")
     return mapping[branch]
+
+
+def contract(repository, number, base, head_repository, head, draft):
+    tracker = targets()["tracker"]
+    if (
+        draft
+        and repository == tracker["repository"]
+        and head_repository == tracker["repository"]
+        and number == tracker["number"]
+        and base == tracker["base"]
+        and head == tracker["head"]
+    ):
+        return {"track": "hyprland-git", "gate": "Tracking gate", "kind": "tracking"}
+    track = track_for_branch(base)
+    return {"track": track, "gate": "Release gate" if track == "release" else "Development gate", "kind": "promotion_or_development"}
 
 
 def verify_lock(metadata, expected):
@@ -64,11 +83,20 @@ def main():
     branch_lock = commands.add_parser("verify-branch-lock")
     branch_lock.add_argument("metadata", type=Path)
     branch_lock.add_argument("branch", choices=["master", "hyprland-git"])
+    contract_command = commands.add_parser("contract")
+    contract_command.add_argument("--repository", required=True)
+    contract_command.add_argument("--number", type=int, default=0)
+    contract_command.add_argument("--base", required=True)
+    contract_command.add_argument("--head-repository", required=True)
+    contract_command.add_argument("--head", required=True)
+    contract_command.add_argument("--draft", choices=["true", "false"], default="false")
     args = parser.parse_args()
     if args.command == "matrix":
         print(json.dumps({"include": targets()[track_for_branch(args.branch)]}))
     elif args.command == "verify-lock":
         verify_lock(json.loads(args.metadata.read_text()), args.rev)
+    elif args.command == "contract":
+        print(json.dumps(contract(args.repository, args.number, args.base, args.head_repository, args.head, args.draft == "true")))
     else:
         metadata = json.loads(args.metadata.read_text())
         locks = metadata["locks"]

--- a/scripts/ci-targets.py
+++ b/scripts/ci-targets.py
@@ -55,8 +55,8 @@ def contract(repository, number, base, head_repository, head, draft):
         and head == tracker["head"]
     ):
         return {"track": "hyprland-git", "gate": "Tracking gate", "kind": "tracking"}
-    track = track_for_branch(base)
-    return {"track": track, "gate": "Release gate" if track == "release" else "Development gate", "kind": "promotion_or_development"}
+    track_for_branch(base)
+    return {"track": base, "gate": "Release gate" if base == "master" else "Development gate", "kind": "promotion_or_development"}
 
 
 def verify_lock(metadata, expected):

--- a/scripts/dev-link.sh
+++ b/scripts/dev-link.sh
@@ -167,7 +167,7 @@ if [[ -z "$target_so" || $do_list -eq 1 || $do_interactive -eq 1 ]]; then
   filtered=()
   for c in "${candidates[@]}"; do
     ca="$(readlink -f "$c" 2>/dev/null || true)"
-    [[ -n "$ca" && "$ca" != "$local_abs" ]] && filtered+=("$ca")
+    [[ -n "$ca" && "$ca" != "$local_abs" ]] && filtered+=("$c")
   done
 
   if (( do_list )); then
@@ -206,6 +206,7 @@ fi
 
 msg "Target: $target_so"
 ensure_writable_target "$target_so"
+python3 "$script_dir/check-hyprpm-state.py" "$(dirname "$target_so")/state.toml"
 
 local_abs="$(readlink -f "$local_so")"
 target_abs="$(readlink -f "$target_so" 2>/dev/null || true)"

--- a/scripts/hyprland-targets.json
+++ b/scripts/hyprland-targets.json
@@ -4,7 +4,7 @@
     {"name": "v0.56.2", "rev": "efb50993780079460b0cbed1363e2166a2de1d9f"}
   ],
   "development": [
-    {"name": "hyprland-git", "rev": "34eb03bd8da01024596c367fba66485a8c9b8ca7"}
+    {"name": "hyprland-git", "rev": "599ff9042c866dcad4bb458979f7be68a6d2ffef"}
   ],
   "tracker": {
     "repository": "sandwichfarm/hyprexpo",

--- a/scripts/hyprland-targets.json
+++ b/scripts/hyprland-targets.json
@@ -5,5 +5,11 @@
   ],
   "development": [
     {"name": "hyprland-git", "rev": "34eb03bd8da01024596c367fba66485a8c9b8ca7"}
-  ]
+  ],
+  "tracker": {
+    "repository": "sandwichfarm/hyprexpo",
+    "number": 123,
+    "base": "master",
+    "head": "hyprland-git"
+  }
 }

--- a/scripts/hyprpm-add.sh
+++ b/scripts/hyprpm-add.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Validate a proposed persistent revision before hyprpm writes its registration.
+set -euo pipefail
+
+if (( $# < 1 || $# > 2 )); then
+    echo "usage: $0 <repository-url> [revision]" >&2
+    exit 2
+fi
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+python3 "$script_dir/check-hyprpm-state.py" --url="$1" --revision="${2:-}"
+exec hyprpm add "$@"

--- a/scripts/prepare-hyprland-release.py
+++ b/scripts/prepare-hyprland-release.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Create a local, non-publishing release preparation packet from an observation."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("observation", type=Path)
+    parser.add_argument("--tag", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    report = json.loads(args.observation.read_text())
+    matches = [release for release in report.get("eligible_releases", []) if release.get("tag") == args.tag]
+    if len(matches) != 1:
+        print(f"release {args.tag!r} is not one unique eligible observation target", file=sys.stderr)
+        return 2
+    release = matches[0]
+    packet = {
+        "schema_version": 1,
+        "status": "prepared_not_published",
+        "release": release,
+        "plugin_base": report["plugin_base"],
+        "development_target": report["development_target"],
+        "release_targets": report["release_targets"],
+        "required_gates": [
+            "exact upstream tag/peeled commit",
+            "compatible plugin candidate/tree and lock",
+            "proposed support and maintenance decision",
+            "exact build/rebuild provenance",
+            "disposable runtime receipt",
+            "pin ancestry and final integrated-tree validation",
+            "explicit maintainer release approval",
+        ],
+        "publication": "forbidden by this preparation command",
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(packet, indent=2, sort_keys=True) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/watch-hyprland.py
+++ b/scripts/watch-hyprland.py
@@ -81,6 +81,7 @@ def discover_live() -> dict[str, Any]:
     development = json_command("gh", "api", f"repos/{REPOSITORY}/git/ref/heads/hyprland-git")["object"]["sha"]
     upstream = json_command("gh", "api", f"repos/{UPSTREAM}/commits/main")
     releases = paginated_json("gh", "api", f"repos/{UPSTREAM}/releases?per_page=100")
+    tags = paginated_json("gh", "api", f"repos/{UPSTREAM}/tags?per_page=100")
     prs = json_command("gh", "pr", "list", "-R", REPOSITORY, "--state", "open", "--json", "number,title,headRefName,baseRefName,isDraft")
     runs = json_command("gh", "run", "list", "-R", REPOSITORY, "--workflow", "upstream-tip.yml", "--limit", "10", "--json", "databaseId,status,conclusion,headSha,createdAt,event")
     return {
@@ -89,6 +90,7 @@ def discover_live() -> dict[str, Any]:
         "upstream_main": upstream["sha"],
         "upstream_main_date": upstream["commit"]["committer"]["date"],
         "releases": releases,
+        "tags": {tag["name"]: tag["commit"]["sha"] for tag in tags if isinstance(tag.get("name"), str) and isinstance(tag.get("commit"), dict) and isinstance(tag["commit"].get("sha"), str)},
         "open_prs": prs,
         "probe_runs": runs,
         "contract": load_branch_contract(development),
@@ -99,14 +101,16 @@ def stable_releases(releases: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return [release for release in releases if not release.get("draft") and not release.get("prerelease") and semantic_version(release.get("tag_name", ""))]
 
 
-def release_candidates(releases: list[dict[str, Any]], supported: set[str]) -> list[dict[str, Any]]:
+def release_candidates(releases: list[dict[str, Any]], tags: dict[str, str], supported: set[str]) -> list[dict[str, Any]]:
     supported_versions = [semantic_version(tag) for tag in supported if semantic_version(tag)]
     floor = max(supported_versions) if supported_versions else None
     candidates = []
     for release in stable_releases(releases):
         version = semantic_version(release["tag_name"])
         if release["tag_name"] not in supported and (floor is None or version > floor):
-            candidates.append(release)
+            candidate = dict(release)
+            candidate["tag_commit"] = tags.get(release["tag_name"])
+            candidates.append(candidate)
     return candidates
 
 
@@ -126,7 +130,7 @@ def observe(data: dict[str, Any]) -> dict[str, Any]:
     if latest_probe and latest_probe.get("status") == "completed" and latest_probe.get("conclusion") != "success":
         failures.append("probe_failed")
     supported = {row.get("name") for row in contract.get("release_targets", [])}
-    eligible = release_candidates(data.get("releases", []), supported)
+    eligible = release_candidates(data.get("releases", []), data.get("tags", {}), supported)
     if candidates:
         status = "candidate_active"
     elif failures:
@@ -152,7 +156,7 @@ def observe(data: dict[str, Any]) -> dict[str, Any]:
         "failure_stages": failures,
         "candidate_prs": candidates,
         "eligible_releases": [
-            {"id": release.get("id"), "tag": release["tag_name"], "target": release.get("target_commitish"), "published_at": release.get("published_at")}
+            {"id": release.get("id"), "tag": release["tag_name"], "tag_commit": release.get("tag_commit"), "target": release.get("target_commitish"), "published_at": release.get("published_at")}
             for release in eligible
         ],
         "release_targets": contract.get("release_targets", []),

--- a/scripts/watch-hyprland.py
+++ b/scripts/watch-hyprland.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Report actionable Hyprland upstream changes without changing repository state."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_VERSION = 1
+REPOSITORY = "sandwichfarm/hyprexpo"
+UPSTREAM = "hyprwm/Hyprland"
+SEMVER = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
+
+
+class ObservationError(RuntimeError):
+    pass
+
+
+def command(*args: str) -> str:
+    result = subprocess.run(args, cwd=ROOT, text=True, capture_output=True)
+    if result.returncode:
+        raise ObservationError(f"{' '.join(args[:3])}: {result.stderr.strip() or result.stdout.strip()}")
+    return result.stdout
+
+
+def json_command(*args: str) -> Any:
+    try:
+        return json.loads(command(*args))
+    except json.JSONDecodeError as error:
+        raise ObservationError(f"invalid JSON from {' '.join(args[:3])}") from error
+
+
+def paginated_json(*args: str) -> list[dict[str, Any]]:
+    pages = json_command(*args, "--paginate", "--slurp")
+    if not isinstance(pages, list) or any(not isinstance(page, list) for page in pages):
+        raise ObservationError("paginated API response is incomplete")
+    return [item for page in pages for item in page]
+
+
+def semantic_version(tag: str) -> tuple[int, int, int] | None:
+    match = SEMVER.fullmatch(tag)
+    return tuple(map(int, match.groups())) if match else None
+
+
+def lock_revision(lock: dict[str, Any]) -> str | None:
+    try:
+        root = lock["nodes"][lock["root"]]
+        node = lock["nodes"][root["inputs"]["hyprland"]]
+        return node["locked"]["rev"]
+    except (KeyError, TypeError):
+        return None
+
+
+def load_branch_contract(branch_sha: str) -> dict[str, Any]:
+    targets = json.loads(command("git", "show", f"{branch_sha}:scripts/hyprland-targets.json"))
+    lock = json.loads(command("git", "show", f"{branch_sha}:flake.lock"))
+    development = targets.get("development", [])
+    if len(development) != 1 or not isinstance(development[0].get("rev"), str):
+        raise ObservationError("development target contract is invalid")
+    revision = development[0]["rev"]
+    locked = lock_revision(lock)
+    return {
+        "development_revision": revision,
+        "lock_revision": locked,
+        "lock_matches_target": locked == revision,
+        "release_targets": targets.get("release", []),
+    }
+
+
+def discover_live() -> dict[str, Any]:
+    command("git", "fetch", "--quiet", "origin", "master", "hyprland-git")
+    master = json_command("gh", "api", f"repos/{REPOSITORY}/git/ref/heads/master")["object"]["sha"]
+    development = json_command("gh", "api", f"repos/{REPOSITORY}/git/ref/heads/hyprland-git")["object"]["sha"]
+    upstream = json_command("gh", "api", f"repos/{UPSTREAM}/commits/main")
+    releases = paginated_json("gh", "api", f"repos/{UPSTREAM}/releases?per_page=100")
+    prs = json_command("gh", "pr", "list", "-R", REPOSITORY, "--state", "open", "--json", "number,title,headRefName,baseRefName,isDraft")
+    runs = json_command("gh", "run", "list", "-R", REPOSITORY, "--workflow", "upstream-tip.yml", "--limit", "10", "--json", "databaseId,status,conclusion,headSha,createdAt,event")
+    return {
+        "master": master,
+        "development_branch": development,
+        "upstream_main": upstream["sha"],
+        "upstream_main_date": upstream["commit"]["committer"]["date"],
+        "releases": releases,
+        "open_prs": prs,
+        "probe_runs": runs,
+        "contract": load_branch_contract(development),
+    }
+
+
+def stable_releases(releases: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [release for release in releases if not release.get("draft") and not release.get("prerelease") and semantic_version(release.get("tag_name", ""))]
+
+
+def release_candidates(releases: list[dict[str, Any]], supported: set[str]) -> list[dict[str, Any]]:
+    supported_versions = [semantic_version(tag) for tag in supported if semantic_version(tag)]
+    floor = max(supported_versions) if supported_versions else None
+    candidates = []
+    for release in stable_releases(releases):
+        version = semantic_version(release["tag_name"])
+        if release["tag_name"] not in supported and (floor is None or version > floor):
+            candidates.append(release)
+    return candidates
+
+
+def observe(data: dict[str, Any]) -> dict[str, Any]:
+    contract = data["contract"]
+    target = contract["development_revision"]
+    main = data["upstream_main"]
+    candidate_prefix = f"chase/hyprland-{main}"
+    candidates = [pr for pr in data.get("open_prs", []) if pr.get("headRefName") == candidate_prefix and pr.get("baseRefName") == "hyprland-git"]
+    probe_runs = data.get("probe_runs", [])
+    latest_probe = probe_runs[0] if probe_runs else None
+    failures: list[str] = []
+    if not contract["lock_matches_target"]:
+        failures.append("development_lock_mismatch")
+    if latest_probe and latest_probe.get("status") != "completed":
+        failures.append("probe_incomplete")
+    if latest_probe and latest_probe.get("status") == "completed" and latest_probe.get("conclusion") != "success":
+        failures.append("probe_failed")
+    supported = {row.get("name") for row in contract.get("release_targets", [])}
+    eligible = release_candidates(data.get("releases", []), supported)
+    if failures:
+        status = "incomplete" if "probe_incomplete" in failures else "needs_diagnosis"
+    elif main == target:
+        status = "up_to_date"
+    elif candidates:
+        status = "candidate_active"
+    else:
+        status = "new_upstream_target"
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "observed_at": datetime.now(timezone.utc).isoformat(),
+        "repository": REPOSITORY,
+        "status": status,
+        "master": data["master"],
+        "development_branch": data["development_branch"],
+        "plugin_base": data["development_branch"],
+        "development_target": target,
+        "development_lock": contract["lock_revision"],
+        "upstream_main": main,
+        "upstream_main_date": data.get("upstream_main_date"),
+        "lock_matches_target": contract["lock_matches_target"],
+        "latest_probe": latest_probe,
+        "failure_stages": failures,
+        "candidate_prs": candidates,
+        "eligible_releases": [
+            {"id": release.get("id"), "tag": release["tag_name"], "target": release.get("target_commitish"), "published_at": release.get("published_at")}
+            for release in eligible
+        ],
+        "release_targets": contract.get("release_targets", []),
+        "next_action": (
+            "inspect failed probe evidence before repair" if failures else
+            "reuse active candidate" if candidates else
+            "prepare one development candidate" if main != target else
+            "no development repair required"
+        ),
+    }
+
+
+def markdown(report: dict[str, Any]) -> str:
+    lines = [
+        "# Hyprland chase observation",
+        "",
+        f"Status: **{report['status']}**",
+        f"Development target: `{report['development_target']}`",
+        f"Observed upstream main: `{report['upstream_main']}`",
+        f"Plugin base: `{report['plugin_base']}`",
+        f"Next action: {report['next_action']}",
+        "",
+    ]
+    if report["failure_stages"]:
+        lines.extend(["## Evidence gaps", "", *[f"- `{stage}`" for stage in report["failure_stages"]], ""])
+    if report["candidate_prs"]:
+        lines.extend(["## Existing candidates", "", *[f"- #{pr['number']} {pr['title']}" for pr in report["candidate_prs"]], ""])
+    if report["eligible_releases"]:
+        lines.extend(["## New released targets", "", *[f"- `{release['tag']}` (release ID `{release['id']}`)" for release in report["eligible_releases"]], ""])
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--format", choices=("json", "markdown"), default="json")
+    parser.add_argument("--fixture", type=Path, help="Read deterministic observation input instead of live services")
+    args = parser.parse_args()
+    try:
+        data = json.loads(args.fixture.read_text()) if args.fixture else discover_live()
+        report = observe(data)
+    except (OSError, ObservationError, KeyError, TypeError, json.JSONDecodeError) as error:
+        print(json.dumps({"schema_version": SCHEMA_VERSION, "status": "incomplete", "error": str(error)}))
+        return 2
+    print(markdown(report) if args.format == "markdown" else json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/watch-hyprland.py
+++ b/scripts/watch-hyprland.py
@@ -127,12 +127,12 @@ def observe(data: dict[str, Any]) -> dict[str, Any]:
         failures.append("probe_failed")
     supported = {row.get("name") for row in contract.get("release_targets", [])}
     eligible = release_candidates(data.get("releases", []), supported)
-    if failures:
+    if candidates:
+        status = "candidate_active"
+    elif failures:
         status = "incomplete" if "probe_incomplete" in failures else "needs_diagnosis"
     elif main == target:
         status = "up_to_date"
-    elif candidates:
-        status = "candidate_active"
     else:
         status = "new_upstream_target"
     return {
@@ -157,8 +157,8 @@ def observe(data: dict[str, Any]) -> dict[str, Any]:
         ],
         "release_targets": contract.get("release_targets", []),
         "next_action": (
+            "reuse active candidate and inspect its receipt" if candidates else
             "inspect failed probe evidence before repair" if failures else
-            "reuse active candidate" if candidates else
             "prepare one development candidate" if main != target else
             "no development repair required"
         ),

--- a/src/Dispatchers.cpp
+++ b/src/Dispatchers.cpp
@@ -8,6 +8,7 @@
 #include "HyprlandConfigCompat.hpp"
 #include "IOverviewSession.hpp"
 #include "ScrollingDiagnostics.hpp"
+#include "WorkspaceCompat.hpp"
 #include <hyprland/src/Compositor.hpp>
 #include <hyprland/src/config/shared/actions/ConfigActions.hpp>
 #include <hyprland/src/debug/log/Logger.hpp>
@@ -157,16 +158,10 @@ static SDispatchResult bringWindowFromWorkspace(int64_t sourceWorkspaceID, const
     if (!destinationMonitor || !destinationMonitor->m_activeWorkspace)
         return {.success = false, .error = "no active monitor/workspace"};
 
-    if (sourceWorkspaceID == destinationMonitor->activeWorkspaceID())
+    if (sourceWorkspaceID == activeWorkspaceID(destinationMonitor))
         return {};
 
-    PHLWORKSPACE sourceWorkspace;
-    for (const auto& w : State::workspaceState()->workspacesCopy()) {
-        if (w->m_id == sourceWorkspaceID) {
-            sourceWorkspace = w;
-            break;
-        }
-    }
+    const auto sourceWorkspace = findWorkspaceByID(sourceWorkspaceID);
     if (!sourceWorkspace)
         return {.success = false, .error = "selected workspace is not open"};
 

--- a/src/Overview.cpp
+++ b/src/Overview.cpp
@@ -374,14 +374,14 @@ SWorkspacePreviewState applyWorkspacePreviewState(const PHLWORKSPACE& workspace)
     if (!workspace)
         return state;
 
-    state.visible        = workspace->m_visible;
+    state.visible        = workspace->visible();
     state.forceRendering = workspace->m_forceRendering;
     state.alphaValue     = workspace->m_alpha->value();
     state.alphaGoal      = workspace->m_alpha->goal();
     state.offsetValue    = workspace->m_renderOffset->value();
     state.offsetGoal     = workspace->m_renderOffset->goal();
 
-    workspace->m_visible        = true;
+    workspace->setVisible(true);
     workspace->m_forceRendering = true;
     workspace->m_alpha->setValueAndWarp(1.F);
     *workspace->m_alpha = 1.F;
@@ -395,7 +395,7 @@ void restoreWorkspacePreviewState(const PHLWORKSPACE& workspace, const SWorkspac
     if (!workspace)
         return;
 
-    workspace->m_visible        = state.visible;
+    workspace->setVisible(state.visible);
     workspace->m_forceRendering = state.forceRendering;
     workspace->m_alpha->setValueAndWarp(state.alphaValue);
     *workspace->m_alpha = state.alphaGoal;
@@ -414,7 +414,7 @@ std::vector<std::pair<PHLWORKSPACE, SWorkspacePreviewState>> applyExclusiveWorks
         states.push_back({
             workspace,
             {
-                .visible        = workspace->m_visible,
+                .visible        = workspace->visible(),
                 .forceRendering = workspace->m_forceRendering,
                 .alphaValue     = workspace->m_alpha->value(),
                 .alphaGoal      = workspace->m_alpha->goal(),
@@ -424,12 +424,12 @@ std::vector<std::pair<PHLWORKSPACE, SWorkspacePreviewState>> applyExclusiveWorks
         });
 
         if (workspace == targetWorkspace) {
-            workspace->m_visible        = true;
+            workspace->setVisible(true);
             workspace->m_forceRendering = true;
             workspace->m_alpha->setValueAndWarp(1.F);
             *workspace->m_alpha = 1.F;
         } else {
-            workspace->m_visible        = false;
+            workspace->setVisible(false);
             workspace->m_forceRendering = false;
             workspace->m_alpha->setValueAndWarp(0.F);
             *workspace->m_alpha = 0.F;
@@ -453,17 +453,17 @@ void normalizeMonitorWorkspaceRenderState(PHLMONITOR monitor) {
 
     for (const auto& workspaceRef : State::workspaceState()->workspaces()) {
         const auto workspace = workspaceRef.lock();
-        if (!workspace || workspace->m_monitor != monitor || workspace->m_isSpecialWorkspace)
+        if (!workspace || workspace->m_monitor != monitor || workspace->type() == Workspace::eWorkspaceType::SPECIAL)
             continue;
 
         const bool active = workspace == monitor->m_activeWorkspace;
         workspace->m_forceRendering = false;
 
         if (active) {
-            workspace->m_visible = true;
+            workspace->setVisible(true);
             Animation::Workspace::startAnimation(workspace, Animation::Workspace::ANIMATION_TYPE_IN, true, true);
         } else if (!workspace->m_alpha->isBeingAnimated() && !workspace->m_renderOffset->isBeingAnimated()) {
-            workspace->m_visible = false;
+            workspace->setVisible(false);
         }
     }
 
@@ -587,8 +587,8 @@ void restoreWorkspaceWindowGoalState(const std::vector<SWindowPreviewState>& sta
 }
 
 static void recalculateWorkspaceLayout(const PHLWORKSPACE& workspace) {
-    if (workspace && workspace->m_space)
-        workspace->m_space->recalculate(Layout::RECALCULATE_REASON_WORKSPACE_CHANGE);
+    if (workspace && workspace->space())
+        workspace->space()->recalculate(Layout::RECALCULATE_REASON_WORKSPACE_CHANGE);
 }
 
 PHLWORKSPACE activateWorkspaceForPreview(PHLMONITOR monitor, const PHLWORKSPACE& workspace) {
@@ -955,15 +955,7 @@ static void ensureOverviewCursorVisible(bool forceOverviewShape = false, bool re
 }
 
 WORKSPACEID workspaceIDForMonitor(const PHLMONITOR& monitor, const std::string& selector) {
-    const auto FOCUS = Desktop::focusState();
-    if (!FOCUS || !monitor)
-        return WORKSPACE_INVALID;
-
-    const auto previousMonitor = FOCUS->m_focusMonitor;
-    Hyprutils::Utils::CScopeGuard restoreFocus{[&]() { FOCUS->m_focusMonitor = previousMonitor; }};
-    // Hyprland's selector API reads global focus; enumeration must not emit focus events.
-    FOCUS->m_focusMonitor = monitor;
-    return getWorkspaceIDNameFromString(selector).id;
+    return workspaceIDForSelector(monitor, selector);
 }
 
 WORKSPACEID nextEmptyWorkspaceIDForMonitor(const PHLMONITOR& monitor) {
@@ -977,10 +969,10 @@ WORKSPACEID nextEmptyWorkspaceIDForMonitor(const PHLMONITOR& monitor) {
         const auto id = workspaceIDForMonitor(monitor, "r+" + std::to_string(step));
         if (id == WORKSPACE_INVALID)
             break;
-        if (id <= 0 || id <= monitor->activeWorkspaceID())
+        if (id <= 0 || id <= activeWorkspaceID(monitor))
             continue;
 
-        const auto workspace = std::ranges::find_if(workspaces, [&](const auto& ws) { return ws->m_id == id; });
+        const auto workspace = std::ranges::find_if(workspaces, [&](const auto& ws) { return workspaceHasID(ws, id); });
         if (workspace == workspaces.end() || ((*workspace)->m_monitor == monitor && (*workspace)->getWindowCount() == 0))
             return id;
     }
@@ -995,7 +987,7 @@ static std::pair<bool, int> getWorkspaceMethodForMonitor(PHLMONITOR monitor) {
     const std::string configStr = std::string{*PMETHOD};
     const auto        parsed = Hyprexpo::resolveWorkspaceMethodForMonitor(configStr, monitorName);
 
-    int methodStartID = monitor->activeWorkspaceID();
+    int methodStartID = activeWorkspaceID(monitor);
     if (!parsed.valid) {
         Log::logger->log(Log::ERR, Log::logFnName(), "[hyprexpo] invalid workspace_method for monitor {}: {} ({})", monitorName, configStr, parsed.error);
         return {true, methodStartID};
@@ -1005,7 +997,7 @@ static std::pair<bool, int> getWorkspaceMethodForMonitor(PHLMONITOR monitor) {
     if (parsed.workspace != "current") {
         methodStartID = workspaceIDForMonitor(monitor, parsed.workspace);
         if (methodStartID == WORKSPACE_INVALID)
-            methodStartID = monitor->activeWorkspaceID();
+            methodStartID = activeWorkspaceID(monitor);
     }
 
     return {methodCenter, methodStartID};
@@ -1114,24 +1106,24 @@ COverview::COverview(PHLWORKSPACE startedOn_, PHLMONITOR monitor_, bool swipe_, 
     emptyTilesSelectable = skipEmpty;
 
     if (!methodCenter && !skipEmpty && maxWorkspace <= 0 && startedOn) {
-        const int columns = Hyprexpo::gridColumnsToIncludeWorkspace(gridShape.cols, methodStartID, (int)startedOn->m_id,
+        const int columns = Hyprexpo::gridColumnsToIncludeWorkspace(gridShape.cols, methodStartID, (int)workspaceID(startedOn),
                                                                    HyprexpoConfig::COLUMNS_MAX, **PROWS > 0 ? gridShape.rows : 0);
         gridShape = Hyprexpo::computeFixedGridShape(columns, **PROWS);
     }
 
     images.resize(gridShape.cols * gridShape.rows);
 
-    const bool anchorSelector = !methodCenter || (!skipEmpty && maxWorkspace > 0 && methodStartID != startedOn->m_id);
+    const bool anchorSelector = !methodCenter || (!skipEmpty && maxWorkspace > 0 && methodStartID != workspaceID(startedOn));
     if (anchorSelector) {
         PHLWORKSPACE PWORKSPACESTART;
         for (const auto& workspace : State::workspaceState()->workspacesCopy()) {
-            if (workspace->m_id == methodStartID) {
+            if (workspaceHasID(workspace, methodStartID)) {
                 PWORKSPACESTART = workspace;
                 break;
             }
         }
         if (!PWORKSPACESTART)
-            PWORKSPACESTART = CWorkspace::create(methodStartID, pMonitor.lock(), std::to_string(methodStartID));
+            PWORKSPACESTART = createWorkspaceForMonitor(methodStartID, pMonitor.lock());
 
         // Relative selectors must use an explicit first/center anchor, not the opened workspace.
         pMonitor->m_activeWorkspace = PWORKSPACESTART;
@@ -1145,11 +1137,12 @@ COverview::COverview(PHLWORKSPACE startedOn_, PHLMONITOR monitor_, bool swipe_, 
         std::optional<int64_t> highestExistingID;
         if (!skipEmpty) {
             for (const auto& workspace : State::workspaceState()->workspacesCopy()) {
-                if (!workspace || workspace->m_isSpecialWorkspace || workspace->m_monitor != PMONITOR)
+                if (!workspace || workspace->type() == Workspace::eWorkspaceType::SPECIAL || workspace->m_monitor != PMONITOR)
                     continue;
 
-                lowestExistingID  = lowestExistingID ? std::min(*lowestExistingID, workspace->m_id) : workspace->m_id;
-                highestExistingID = highestExistingID ? std::max(*highestExistingID, workspace->m_id) : workspace->m_id;
+                const auto id = workspaceID(workspace);
+                lowestExistingID  = lowestExistingID ? std::min(*lowestExistingID, id) : id;
+                highestExistingID = highestExistingID ? std::max(*highestExistingID, id) : id;
             }
         }
 
@@ -1217,13 +1210,13 @@ COverview::COverview(PHLWORKSPACE startedOn_, PHLMONITOR monitor_, bool swipe_, 
     if (dynamicGrid) {
         std::vector<int64_t> visibleWorkspaceIDs;
         const auto MON = pMonitor.lock();
-        const int64_t currentWorkspaceID = startedOn ? startedOn->m_id : (MON ? MON->activeWorkspaceID() : WORKSPACE_INVALID);
+        const int64_t currentWorkspaceID = startedOn ? workspaceID(startedOn) : activeWorkspaceID(MON);
 
         for (const auto& workspace : State::workspaceState()->workspacesCopy()) {
-            if (!workspace || workspace->m_isSpecialWorkspace || workspace->m_monitor != MON || workspace->getWindowCount() <= 0)
+            if (!workspace || workspace->type() == Workspace::eWorkspaceType::SPECIAL || workspace->m_monitor != MON || workspace->getWindowCount() <= 0)
                 continue;
 
-            visibleWorkspaceIDs.push_back(workspace->m_id);
+            visibleWorkspaceIDs.push_back(workspaceID(workspace));
         }
 
         if (visibleWorkspaceIDs.empty() && currentWorkspaceID != WORKSPACE_INVALID)
@@ -1265,14 +1258,14 @@ COverview::COverview(PHLWORKSPACE startedOn_, PHLMONITOR monitor_, bool swipe_, 
 
     settleWorkspaceMoveAnimations();
 
-    startedOn->m_visible = false;
+    startedOn->setVisible(false);
 
     for (size_t i = 0; i < images.size(); ++i) {
         COverview::SWorkspaceImage& image = images[i];
 
         PHLWORKSPACE PWORKSPACE;
         for (const auto& w : State::workspaceState()->workspacesCopy()) {
-            if (w->m_id == image.workspaceID) {
+            if (workspaceHasID(w, image.workspaceID)) {
                 PWORKSPACE = w;
                 break;
             }
@@ -1294,7 +1287,7 @@ COverview::COverview(PHLWORKSPACE startedOn_, PHLMONITOR monitor_, bool swipe_, 
         image.box = tileBoxForIndex((int)i, pMonitor->m_size, GAP_WIDTH, 0.0, true);
     }
     PMONITOR->m_activeWorkspace        = startedOn;
-    startedOn->m_visible               = true;
+    startedOn->setVisible(true);
     Animation::Workspace::startAnimation(startedOn, Animation::Workspace::ANIMATION_TYPE_IN, true, true);
 
     const auto initSize = zoomSizeForCurrentGrid(pMonitor->m_size);

--- a/src/Overview.hpp
+++ b/src/Overview.hpp
@@ -5,6 +5,7 @@
 #include "globals.hpp"
 #include "IOverviewSession.hpp"
 #include "HyprexpoLogic.hpp"
+#include "WorkspaceCompat.hpp"
 #include <hyprland/src/desktop/DesktopTypes.hpp>
 #include <hyprland/src/render/Framebuffer.hpp>
 #include <hyprland/src/render/Texture.hpp>

--- a/src/OverviewCapture.cpp
+++ b/src/OverviewCapture.cpp
@@ -80,7 +80,7 @@ class CMonitorStateGuard {
                                                                                   m_transformedSize(monitor->m_transformedSize), m_pixelSize(monitor->m_pixelSize),
                                                                                   m_activeWorkspace(monitor->m_activeWorkspace),
                                                                                   m_activeSpecialWorkspace(monitor->m_activeSpecialWorkspace),
-                                                                                  m_startedOnVisible(startedOn ? startedOn->m_visible : false) {}
+                                                                                  m_startedOnVisible(startedOn ? startedOn->visible() : false) {}
 
     ~CMonitorStateGuard() {
         restore();
@@ -95,7 +95,7 @@ class CMonitorStateGuard {
         m_monitor->m_activeWorkspace        = m_activeWorkspace ? m_activeWorkspace : m_startedOn;
         m_monitor->m_activeSpecialWorkspace = m_activeSpecialWorkspace;
         if (m_startedOn)
-            m_startedOn->m_visible = m_startedOnVisible;
+            m_startedOn->setVisible(m_startedOnVisible);
         m_restored = true;
     }
 
@@ -181,7 +181,7 @@ bool captureWorkspacePreview(const SWorkspaceCaptureRequest& request, SP<Render:
 
         if (monitorState.activeSpecialWorkspace())
             request.monitor->m_activeSpecialWorkspace.reset();
-        request.startedOn->m_visible = false;
+        request.startedOn->setVisible(false);
 
         CRegion fakeDamage{0, 0, INT16_MAX, INT16_MAX};
         if (!g_pHyprRenderer->beginRender(request.monitor, fakeDamage, Render::RENDER_MODE_FULL_FAKE, nullptr, framebuffer))
@@ -253,9 +253,9 @@ bool captureWorkspacePreview(const SWorkspaceCaptureRequest& request, SP<Render:
 
         monitorState.restore();
         if (request.animateStartedOnRestore) {
-            request.startedOn->m_visible = false;
+            request.startedOn->setVisible(false);
             const auto activeWorkspace = monitorState.activeWorkspace() ? monitorState.activeWorkspace() : request.startedOn;
-            activeWorkspace->m_visible = true;
+            activeWorkspace->setVisible(true);
             if (activeWorkspace == request.startedOn)
                 Animation::Workspace::startAnimation(activeWorkspace, Animation::Workspace::ANIMATION_TYPE_IN, true, true);
         }

--- a/src/OverviewInteraction.cpp
+++ b/src/OverviewInteraction.cpp
@@ -154,7 +154,7 @@ PHLWINDOW COverview::windowAtTilePoint(int id, const Vector2D& localPoint) const
     }
     else {
         for (const auto& w : State::workspaceState()->workspacesCopy()) {
-            if (w->m_id == images[id].workspaceID) {
+            if (workspaceHasID(w, images[id].workspaceID)) {
                 WORKSPACE = w;
                 break;
             }
@@ -280,14 +280,14 @@ PHLWORKSPACE COverview::ensureWorkspaceForTile(int id) {
 
     PHLWORKSPACE workspace;
     for (const auto& w : State::workspaceState()->workspacesCopy()) {
-        if (w->m_id == image.workspaceID) {
+        if (workspaceHasID(w, image.workspaceID)) {
             workspace = w;
             break;
         }
     }
 
     if (!workspace)
-        workspace = State::workspaceState()->create(image.workspaceID, MON->m_id, std::to_string(image.workspaceID), false);
+        workspace = createWorkspaceForMonitor(image.workspaceID, MON);
 
     image.pWorkspace = workspace;
     return workspace;
@@ -313,7 +313,7 @@ bool COverview::finishWindowDrag() {
             PHLWORKSPACE SOURCEWS = SOURCEOV->images[SOURCE].pWorkspace;
             if (!SOURCEWS) {
                 for (const auto& workspace : State::workspaceState()->workspacesCopy()) {
-                    if (workspace->m_id == SOURCEOV->images[SOURCE].workspaceID) {
+                    if (workspaceHasID(workspace, SOURCEOV->images[SOURCE].workspaceID)) {
                         SOURCEWS = workspace;
                         break;
                     }
@@ -354,7 +354,7 @@ bool COverview::moveWindowBetweenVisibleIndices(size_t sourceIndex, size_t targe
     }
     else {
         for (const auto& w : State::workspaceState()->workspacesCopy()) {
-            if (w->m_id == images[SOURCE].workspaceID) {
+            if (workspaceHasID(w, images[SOURCE].workspaceID)) {
                 SOURCEWS = w;
                 break;
             }

--- a/src/OverviewInternal.hpp
+++ b/src/OverviewInternal.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Overview.hpp"
+#include "WorkspaceCompat.hpp"
 
 #include <string>
 #include <utility>

--- a/src/OverviewRender.cpp
+++ b/src/OverviewRender.cpp
@@ -61,7 +61,7 @@ void COverview::redrawID(int id, bool forcelowres) {
     }
     else {
         for (const auto& w : State::workspaceState()->workspacesCopy()) {
-            if (w->m_id == image.workspaceID) {
+            if (workspaceHasID(w, image.workspaceID)) {
                 PWORKSPACE = w;
                 break;
             }
@@ -157,7 +157,7 @@ void COverview::close(bool switchToSelection) {
     redrawAll();
 
     if (switchToSelection && (TILE.workspaceID != WORKSPACE_INVALID || emptyTilesSelectable) &&
-        (TILE.workspaceID != MON->activeWorkspaceID() || Desktop::focusState()->monitor() != MON)) {
+        (TILE.workspaceID != activeWorkspaceID(MON) || Desktop::focusState()->monitor() != MON)) {
         MON->setSpecialWorkspace(0);
 
         // If this tile's workspace was WORKSPACE_INVALID, move to the next
@@ -178,7 +178,7 @@ void COverview::close(bool switchToSelection) {
 
         if (!NEWIDWS) {
             for (const auto& w : State::workspaceState()->workspacesCopy()) {
-                if (w->m_id == NEWID) {
+                if (workspaceHasID(w, NEWID)) {
                     NEWIDWS = w;
                     break;
                 }
@@ -188,7 +188,7 @@ void COverview::close(bool switchToSelection) {
         const auto OLDWS = MON->m_activeWorkspace;
 
         if (!NEWIDWS && NEWID != WORKSPACE_INVALID)
-            NEWIDWS = State::workspaceState()->create(NEWID, MON->m_id, std::to_string(NEWID), false);
+            NEWIDWS = createWorkspaceForMonitor(NEWID, MON);
 
         const auto CHANGE = Config::Actions::changeWorkspace(NEWIDWS);
         if (!CHANGE)
@@ -223,7 +223,7 @@ void COverview::onWorkspaceChange() {
         startedOn = MON->m_activeWorkspace;
 
     for (size_t i = 0; i < images.size(); ++i) {
-        if (images[i].workspaceID != MON->activeWorkspaceID())
+        if (images[i].workspaceID != activeWorkspaceID(MON))
             continue;
 
         openedID = i;
@@ -388,15 +388,15 @@ void COverview::fullRender() {
             return {};
 
         const auto& image = images[id];
-        if (image.pWorkspace && !image.pWorkspace->m_name.empty())
-            return image.pWorkspace->m_name;
+        if (image.pWorkspace && !image.pWorkspace->displayName().empty())
+            return image.pWorkspace->displayName();
 
         for (const auto& workspace : State::workspaceState()->workspacesCopy()) {
-            if (!workspace || workspace->m_id != image.workspaceID)
+            if (!workspace || !workspaceHasID(workspace, image.workspaceID))
                 continue;
 
-            if (!workspace->m_name.empty())
-                return workspace->m_name;
+            if (!workspace->displayName().empty())
+                return workspace->displayName();
             break;
         }
 

--- a/src/ScrollingDiagnostics.cpp
+++ b/src/ScrollingDiagnostics.cpp
@@ -2,6 +2,7 @@
 
 #include "ScrollingRequestId.hpp"
 #include "globals.hpp"
+#include "WorkspaceCompat.hpp"
 
 #include <hyprland/src/desktop/state/FocusState.hpp>
 #include <hyprland/src/output/Monitor.hpp>
@@ -176,7 +177,7 @@ PHLWORKSPACE resolveWorkspace(const std::string& selector) {
     if (parsed.ec != std::errc{} || parsed.ptr != value.data() + value.size())
         return {};
     for (const auto& workspace : State::workspaceState()->workspacesCopy()) {
-        if (workspace && workspace->m_id == workspaceID)
+        if (workspaceHasID(workspace, workspaceID))
             return workspace;
     }
     return {};

--- a/src/ScrollingLayoutAdapter.cpp
+++ b/src/ScrollingLayoutAdapter.cpp
@@ -1,6 +1,7 @@
 #include "ScrollingLayoutAdapter.hpp"
+#include "WorkspaceCompat.hpp"
 
-#include <hyprland/src/desktop/Workspace.hpp>
+#include <hyprland/src/workspace/HLWorkspace.hpp>
 #include <hyprland/src/desktop/state/GlobalWindowController.hpp>
 #include <hyprland/src/desktop/state/FocusState.hpp>
 #include <hyprland/src/desktop/view/window/Window.hpp>
@@ -98,16 +99,14 @@ STargetSnapshot copyTarget(const SP<Layout::ITarget>& target, const CBox& layout
 SSnapshotResult snapshotWorkspaceImpl(const PHLWORKSPACE& workspace) {
     if (!workspace)
         return failure(ESnapshotFailure::NullWorkspace, "workspace is null");
-    if (workspace->inert())
-        return failure(ESnapshotFailure::InertWorkspace, "workspace is inert");
 
     const auto monitor = workspace->m_monitor.lock();
     if (!monitor)
         return failure(ESnapshotFailure::MissingMonitor, "workspace monitor expired");
-    if (!workspace->m_space)
+    if (!workspace->space())
         return failure(ESnapshotFailure::MissingSpace, "workspace space is unavailable");
 
-    const auto algorithmOwner = workspace->m_space->algorithm();
+    const auto algorithmOwner = workspace->space()->algorithm();
     if (!algorithmOwner)
         return failure(ESnapshotFailure::MissingAlgorithm, "workspace algorithm is unavailable");
     const auto& tiledOwner = algorithmOwner->tiledAlgo();
@@ -123,8 +122,8 @@ SSnapshotResult snapshotWorkspaceImpl(const PHLWORKSPACE& workspace) {
         return failure(ESnapshotFailure::CastFailure, "scrolling matcher succeeded but dynamic cast failed");
 
     std::vector<SP<Layout::ITarget>> layoutTargets;
-    layoutTargets.reserve(workspace->m_space->targets().size());
-    for (const auto& targetRef : workspace->m_space->targets()) {
+    layoutTargets.reserve(workspace->space()->targets().size());
+    for (const auto& targetRef : workspace->space()->targets()) {
         const auto target = targetRef.lock();
         if (!target)
             return failure(ESnapshotFailure::ExpiredTarget, "workspace target expired while resolving scrolling data");
@@ -154,13 +153,13 @@ SSnapshotResult snapshotWorkspaceImpl(const PHLWORKSPACE& workspace) {
         return failure(ESnapshotFailure::ColumnCardinalityMismatch, "column/controller strip cardinality mismatch");
 
     SWorkspaceSnapshot snapshot{
-        .workspaceID = workspace->m_id,
+        .workspaceID = workspaceID(workspace),
         .monitorID = monitor->m_id,
         .algorithmFingerprint = fingerprintPointer(scrolling),
         .dataFingerprint = fingerprint(data),
         .direction = directionName(controller.getDirection()),
         .offset = controller.getOffset(),
-        .activeWorkspaceID = monitor->m_activeWorkspace ? monitor->m_activeWorkspace->m_id : 0,
+        .activeWorkspaceID = activeWorkspaceID(monitor),
         .focusedWindowFingerprint = fingerprint(Desktop::focusState() ? Desktop::focusState()->window() : PHLWINDOW{}),
         .columns = {},
         .layoutTargets = {},
@@ -231,7 +230,7 @@ SSnapshotResult snapshotWorkspaceImpl(const PHLWORKSPACE& workspace) {
         const auto box = target->position();
         if (!validBox(box))
             return failure(ESnapshotFailure::InvalidGeometry, "layout target box is invalid");
-        snapshot.layoutTargets.push_back(copyTarget(target, box, 0, 0.F, workspace->m_visible));
+        snapshot.layoutTargets.push_back(copyTarget(target, box, 0, 0.F, workspace->visible()));
     }
 
     return {.failure = ESnapshotFailure::None, .error = {}, .snapshot = std::move(snapshot)};
@@ -248,9 +247,9 @@ struct SResolvedNativeWorkspace {
 };
 
 SResolvedNativeWorkspace resolveNativeWorkspace(const PHLWORKSPACE& workspace, const SP<Layout::ITarget>& seed = {}) {
-    if (!workspace || workspace->inert() || !workspace->m_space)
+    if (!workspace || !workspace->space())
         throw std::runtime_error("native workspace is unavailable");
-    const auto owner = workspace->m_space->algorithm();
+    const auto owner = workspace->space()->algorithm();
     if (!owner || !owner->tiledAlgo())
         throw std::runtime_error("native tiled algorithm is unavailable");
     auto* const tiled = owner->tiledAlgo().get();
@@ -262,7 +261,7 @@ SResolvedNativeWorkspace resolveNativeWorkspace(const PHLWORKSPACE& workspace, c
 
     SP<Layout::ITarget> candidate = seed;
     if (!candidate) {
-        for (const auto& weak : workspace->m_space->targets()) {
+        for (const auto& weak : workspace->space()->targets()) {
             candidate = weak.lock();
             if (candidate && !candidate->floating() && scrolling->dataFor(candidate))
                 break;
@@ -325,9 +324,9 @@ class CNativeMutationOperations final : public IMutationOperations {
     SMutationState snapshotPreState(const SMutationRequest& request) override {
         if (m_preState)
             return *m_preState;
-        if (!m_sourceWorkspace || request.sourceWorkspaceID != m_sourceWorkspace->m_id)
+        if (!m_sourceWorkspace || request.sourceWorkspaceID != workspaceID(m_sourceWorkspace))
             throw std::runtime_error("source workspace changed before snapshot");
-        if (!request.createDestination && (!m_destinationWorkspace || request.destinationWorkspaceID != m_destinationWorkspace->m_id))
+        if (!request.createDestination && (!m_destinationWorkspace || request.destinationWorkspaceID != workspaceID(m_destinationWorkspace)))
             throw std::runtime_error("destination workspace changed before snapshot");
 
         SMutationState state;
@@ -360,8 +359,7 @@ class CNativeMutationOperations final : public IMutationOperations {
         if (!reverse && !m_destinationWorkspace) {
             if (!plan.createDestination || !m_monitor || plan.request.destinationWorkspaceID <= 0)
                 throw std::runtime_error("terminal destination cannot be created");
-            m_destinationWorkspace = State::workspaceState()->create(plan.request.destinationWorkspaceID, m_monitor->m_id,
-                                                                      std::to_string(plan.request.destinationWorkspaceID), true);
+            m_destinationWorkspace = createWorkspaceForMonitor(plan.request.destinationWorkspaceID, m_monitor, true);
             if (!m_destinationWorkspace)
                 throw std::runtime_error("terminal destination creation failed");
             m_createdDestination = m_destinationWorkspace;
@@ -641,10 +639,10 @@ class CNativeMutationOperations final : public IMutationOperations {
     }
 
     void proveCreatedDestinationRollback(const SMutationPlan& plan) {
-        if (!m_createdDestination || m_createdDestination->m_id != plan.request.destinationWorkspaceID || !m_createdDestination->m_wasCreatedEmpty ||
-            m_createdDestination->getWindowCount() != 0 || !m_createdDestination->m_space)
+        if (!m_createdDestination || workspaceID(m_createdDestination) != plan.request.destinationWorkspaceID || !m_createdDestination->m_wasCreatedEmpty ||
+            m_createdDestination->getWindowCount() != 0 || !m_createdDestination->space())
             throw std::runtime_error("terminal rollback did not restore an empty created workspace");
-        for (const auto& weak : m_createdDestination->m_space->targets()) {
+        for (const auto& weak : m_createdDestination->space()->targets()) {
             const auto target = weak.lock();
             if (target && mutationIdentity(target) == plan.request.targetIdentity)
                 throw std::runtime_error("terminal rollback retained the moved target identity");
@@ -656,12 +654,12 @@ class CNativeMutationOperations final : public IMutationOperations {
                                                                  native->second.data->controller->stripCount() != 0)))
             throw std::runtime_error("terminal rollback retained native columns or controller strips");
 
-        const auto createdID = m_createdDestination->m_id;
+        const auto createdID = workspaceID(m_createdDestination);
         m_native.erase(plan.request.destinationWorkspaceID);
         m_destinationWorkspace.reset();
         m_createdDestination.reset();
         for (const auto& workspace : State::workspaceState()->workspacesCopy())
-            if (workspace && workspace->m_id == createdID)
+            if (workspaceHasID(workspace, createdID))
                 throw std::runtime_error("terminal rollback created workspace was not released");
     }
 
@@ -682,7 +680,7 @@ class CNativeMutationOperations final : public IMutationOperations {
                 m_targets[mutationTargetIdentity(target)] = strong;
             }
         }
-        m_native[workspace->m_id] = {.workspace = workspace, .kind = EMutationWorkspaceKind::Scrolling, .data = resolved.data};
+        m_native[workspaceID(workspace)] = {.workspace = workspace, .kind = EMutationWorkspaceKind::Scrolling, .data = resolved.data};
         state.workspaces.push_back(mutationWorkspace(*snapshot.snapshot));
         std::ranges::sort(state.workspaces, {}, &SMutationWorkspace::workspaceID);
     }
@@ -695,18 +693,18 @@ class CNativeMutationOperations final : public IMutationOperations {
         }
         if (workspace->getWindowCount(true) != 0)
             throw std::runtime_error("non-empty scrolling destination has no complete pre-state");
-        m_native[workspace->m_id] = {.workspace = workspace, .kind = EMutationWorkspaceKind::Scrolling, .data = {}};
-        state.workspaces.push_back({.workspaceID = workspace->m_id, .modelIdentity = 0, .kind = EMutationWorkspaceKind::Scrolling, .direction = {}, .offset = 0.0,
+        m_native[workspaceID(workspace)] = {.workspace = workspace, .kind = EMutationWorkspaceKind::Scrolling, .data = {}};
+        state.workspaces.push_back({.workspaceID = workspaceID(workspace), .modelIdentity = 0, .kind = EMutationWorkspaceKind::Scrolling, .direction = {}, .offset = 0.0,
                                     .focusedTargetIdentity = 0, .focusedWindowIdentity = 0, .columns = {}, .members = {}});
         std::ranges::sort(state.workspaces, {}, &SMutationWorkspace::workspaceID);
     }
 
     void snapshotMixedAndRetain(const PHLWORKSPACE& workspace, SMutationState& state, bool retain) {
-        SMutationWorkspace mixed{.workspaceID = workspace ? workspace->m_id : 0, .modelIdentity = 0, .kind = EMutationWorkspaceKind::Mixed,
+        SMutationWorkspace mixed{.workspaceID = workspaceID(workspace), .modelIdentity = 0, .kind = EMutationWorkspaceKind::Mixed,
                                  .direction = {}, .offset = 0.0, .focusedTargetIdentity = 0, .focusedWindowIdentity = 0, .columns = {}, .members = {}};
-        if (!workspace || workspace->inert() || !workspace->m_space)
+        if (!workspace || !workspace->space())
             throw std::runtime_error("mixed workspace expired during transaction readback");
-        for (const auto& weak : workspace->m_space->targets()) {
+        for (const auto& weak : workspace->space()->targets()) {
             const auto target = weak.lock();
             if (!target)
                 throw std::runtime_error("mixed workspace target expired during transaction readback");
@@ -716,18 +714,18 @@ class CNativeMutationOperations final : public IMutationOperations {
                 m_targets[identity] = target;
         }
         if (retain)
-            m_native[workspace->m_id] = {.workspace = workspace, .kind = EMutationWorkspaceKind::Mixed, .data = {}};
+            m_native[workspaceID(workspace)] = {.workspace = workspace, .kind = EMutationWorkspaceKind::Mixed, .data = {}};
         state.workspaces.push_back(std::move(mixed));
     }
 
     SMutationWorkspace emptyNativeState(const SNativeWorkspace& native, bool rollback) const {
         const SMutationWorkspace* expected = nullptr;
         if (m_preState) {
-            const auto found = std::ranges::find(m_preState->workspaces, native.workspace->m_id, &SMutationWorkspace::workspaceID);
+            const auto found = std::ranges::find(m_preState->workspaces, workspaceID(native.workspace), &SMutationWorkspace::workspaceID);
             if (found != m_preState->workspaces.end())
                 expected = &*found;
         }
-        SMutationWorkspace result{.workspaceID = native.workspace->m_id,
+        SMutationWorkspace result{.workspaceID = workspaceID(native.workspace),
                                   .modelIdentity = rollback && expected ? expected->modelIdentity : fingerprint(native.data),
                                   .kind = EMutationWorkspaceKind::Scrolling,
                                   .direction = rollback && expected ? expected->direction : directionName(native.data->controller->getDirection()),
@@ -735,7 +733,7 @@ class CNativeMutationOperations final : public IMutationOperations {
                                   .focusedTargetIdentity = rollback && expected ? expected->focusedTargetIdentity : 0,
                                   .focusedWindowIdentity = rollback && expected ? expected->focusedWindowIdentity : 0,
                                   .columns = {}, .members = {}};
-        for (const auto& weak : native.workspace->m_space->targets()) {
+        for (const auto& weak : native.workspace->space()->targets()) {
             const auto target = weak.lock();
             if (!target)
                 throw std::runtime_error("empty native workspace retained an expired target");
@@ -792,9 +790,9 @@ SSnapshotResult snapshotWorkspace(const PHLWORKSPACE& workspace) {
 
 bool workspaceUsesScrollingLayout(const PHLWORKSPACE& workspace) {
     try {
-        if (!workspace || workspace->inert() || !workspace->m_space)
+        if (!workspace || !workspace->space())
             return false;
-        const auto algorithmOwner = workspace->m_space->algorithm();
+        const auto algorithmOwner = workspace->space()->algorithm();
         if (!algorithmOwner)
             return false;
         const auto& tiledOwner = algorithmOwner->tiledAlgo();
@@ -827,15 +825,15 @@ SMutationResult moveScrollingTarget(const PHLWORKSPACE& sourceWorkspace, const P
         if (request.kind == EDropKind::TerminalWorkspace) {
             std::vector<int64_t> workspaceIDs;
             for (const auto& workspace : State::workspaceState()->workspacesCopy())
-                if (workspace && !workspace->m_isSpecialWorkspace)
-                    workspaceIDs.push_back(workspace->m_id);
+                if (workspace && workspace->type() != Workspace::eWorkspaceType::SPECIAL)
+                    workspaceIDs.push_back(workspaceID(workspace));
             request.destinationWorkspaceID = nextUnusedOrdinaryWorkspaceID(workspaceIDs);
             request.createDestination = true;
             request.placement = EColumnPlacement::None;
             resolvedDestination.reset();
             if (request.destinationWorkspaceID <= 0)
                 return failureResult(EMutationOutcome::Rejected, "no unused positive workspace ID is available");
-        } else if (!resolvedDestination || request.destinationWorkspaceID != resolvedDestination->m_id) {
+        } else if (!resolvedDestination || request.destinationWorkspaceID != workspaceID(resolvedDestination)) {
             return failureResult(EMutationOutcome::Rejected, "destination workspace changed before mutation");
         }
 
@@ -873,11 +871,11 @@ std::expected<SMutationResult, std::string> runNativeMutationTest(const std::str
     PHLWORKSPACE sourceWorkspace;
     PHLWORKSPACE destinationWorkspace;
     for (const auto& workspace : State::workspaceState()->workspacesCopy()) {
-        if (!workspace || workspace->m_isSpecialWorkspace)
+        if (!workspace || workspace->type() == Workspace::eWorkspaceType::SPECIAL)
             continue;
-        if (workspace->m_id == parsed.sourceWorkspaceID)
+        if (workspaceHasID(workspace, parsed.sourceWorkspaceID))
             sourceWorkspace = workspace;
-        if (workspace->m_id == parsed.destinationWorkspaceID)
+        if (workspaceHasID(workspace, parsed.destinationWorkspaceID))
             destinationWorkspace = workspace;
     }
     if (!sourceWorkspace)

--- a/src/ScrollingOverview.cpp
+++ b/src/ScrollingOverview.cpp
@@ -92,7 +92,7 @@ EOutputTransform outputTransform(wl_output_transform transform) {
 
 CScrollingOverview::CScrollingOverview(const PHLWORKSPACE& startedOn, const PHLMONITOR& monitor, bool swipe, uint64_t sessionGeneration, const std::optional<SWorkspaceSnapshot>& initialSnapshot) :
     m_startedOn(startedOn), m_monitor(monitor), m_sessionGeneration(sessionGeneration), m_isSwiping(swipe),
-    m_selectedWorkspaceID(startedOn ? startedOn->m_id : 0) {
+    m_selectedWorkspaceID(startedOn ? workspaceID(startedOn) : 0) {
     Animation::mgr()->createAnimation(0.F, m_transitionProgress, Config::animationTree()->getAnimationPropertyConfig("windowsMove"), AVARDAMAGE_NONE);
     m_transitionProgress->setUpdateCallback([monitorKey = overviewMonitorKey(monitor), generation = m_sessionGeneration](auto) {
         if (auto* const OV = overviewForSession(monitorKey, generation))
@@ -407,7 +407,7 @@ CScrollingOverview::SCacheEntry* CScrollingOverview::cacheEntry(int64_t workspac
 }
 
 const CScrollingOverview::SWorkspaceRow* CScrollingOverview::workspaceRow(int64_t workspaceID) const {
-    const auto found = std::ranges::find_if(m_rows, [&](const auto& row) { return row.workspace && row.workspace->m_id == workspaceID; });
+    const auto found = std::ranges::find_if(m_rows, [&](const auto& row) { return workspaceHasID(row.workspace, workspaceID); });
     return found == m_rows.end() ? nullptr : &*found;
 }
 
@@ -417,12 +417,12 @@ bool CScrollingOverview::sceneTopologyCurrent() const {
         return false;
 
     const auto workspaces = State::workspaceState()->workspacesCopy();
-    const auto count = std::ranges::count_if(workspaces, [&](const auto& ws) { return ws && !ws->m_isSpecialWorkspace && ws->m_monitor == MON; });
+    const auto count = std::ranges::count_if(workspaces, [&](const auto& ws) { return ws && ws->type() != Workspace::eWorkspaceType::SPECIAL && ws->m_monitor == MON; });
     if (static_cast<size_t>(count) != m_rows.size())
         return false;
 
     for (const auto& row : m_rows) {
-        if (!row.workspace || row.workspace->inert() || row.workspace->m_monitor != MON)
+        if (!row.workspace || row.workspace->m_monitor != MON)
             return false;
         if (row.kind != EWorkspaceKind::Scrolling) {
             const bool empty = row.workspace->getWindowCount() <= 0;
@@ -459,7 +459,7 @@ bool CScrollingOverview::sceneTopologyCurrent() const {
 
 bool CScrollingOverview::refreshScene(const std::optional<SWorkspaceSnapshot>& initialSnapshot) {
     const auto MON = m_monitor.lock();
-    if (!MON || !m_startedOn || m_startedOn->inert())
+    if (!MON || !m_startedOn)
         return false;
 
     resetInputState(EResetReason::Refresh);
@@ -469,13 +469,13 @@ bool CScrollingOverview::refreshScene(const std::optional<SWorkspaceSnapshot>& i
 
     std::vector<PHLWORKSPACE> workspaces;
     for (const auto& workspace : State::workspaceState()->workspacesCopy()) {
-        if (!workspace || workspace->m_isSpecialWorkspace || workspace->m_monitor != MON)
+        if (!workspace || workspace->type() == Workspace::eWorkspaceType::SPECIAL || workspace->m_monitor != MON)
             continue;
         workspaces.push_back(workspace);
     }
     if (std::ranges::find(workspaces, m_startedOn) == workspaces.end())
         workspaces.push_back(m_startedOn);
-    std::ranges::sort(workspaces, {}, [](const auto& workspace) { return workspace->m_id; });
+    std::ranges::sort(workspaces, {}, [](const auto& workspace) { return workspaceID(workspace); });
 
     std::vector<SWorkspaceSpec> specs;
     specs.reserve(workspaces.size());
@@ -483,7 +483,7 @@ bool CScrollingOverview::refreshScene(const std::optional<SWorkspaceSnapshot>& i
         auto result = workspace == m_startedOn && initialSnapshot ?
             SSnapshotResult{.failure = ESnapshotFailure::None, .error = {}, .snapshot = *initialSnapshot} : snapshotWorkspace(workspace);
         if (result.success()) {
-            SWorkspaceSpec spec{.workspaceID = workspace->m_id, .kind = EWorkspaceKind::Scrolling, .tape = {}};
+            SWorkspaceSpec spec{.workspaceID = workspaceID(workspace), .kind = EWorkspaceKind::Scrolling, .tape = {}};
             spec.tape.direction = parseDirection(result.snapshot->direction);
             for (const auto& column : result.snapshot->columns) {
                 SColumnSpec columnSpec{.token = static_cast<uint64_t>(column.fingerprint), .extent = column.primarySize, .targets = {}};
@@ -502,13 +502,13 @@ bool CScrollingOverview::refreshScene(const std::optional<SWorkspaceSnapshot>& i
         if (workspace == m_startedOn && !empty)
             return false;
         const auto kind = empty ? EWorkspaceKind::Empty : EWorkspaceKind::Mixed;
-        specs.push_back({.workspaceID = workspace->m_id, .kind = kind, .tape = {}});
+        specs.push_back({.workspaceID = workspaceID(workspace), .kind = kind, .tape = {}});
         m_rows.push_back({.workspace = workspace, .kind = kind, .snapshot = {}, .workspacePreview = {}});
     }
 
     if (specs.empty())
         return false;
-    const int64_t terminalWorkspaceID = std::max<int64_t>(1, workspaces.back()->m_id + 1);
+    const int64_t terminalWorkspaceID = std::max<int64_t>(1, workspaceID(workspaces.back()) + 1);
     const SSceneConfig sceneConfig{
         .viewportWidth = MON->m_size.x,
         .viewportHeight = MON->m_size.y,
@@ -517,10 +517,10 @@ bool CScrollingOverview::refreshScene(const std::optional<SWorkspaceSnapshot>& i
         .columnGap = std::max(8.0, MON->m_size.x * 0.008),
         .terminalWorkspaceID = terminalWorkspaceID,
     };
-    m_scene = buildScene(specs, m_startedOn->m_id, sceneConfig);
+    m_scene = buildScene(specs, workspaceID(m_startedOn), sceneConfig);
     if (!m_scene.valid)
         return false;
-    m_pan = initialPan(m_scene, m_startedOn->m_id, MON->m_size.y);
+    m_pan = initialPan(m_scene, workspaceID(m_startedOn), MON->m_size.y);
 
     std::unordered_set<uint64_t> seenTargets;
     for (const auto& row : m_rows) {
@@ -529,10 +529,10 @@ bool CScrollingOverview::refreshScene(const std::optional<SWorkspaceSnapshot>& i
         for (const auto& column : row.snapshot.columns) {
             for (const auto& target : column.targets) {
                 const auto token = targetToken(target);
-                const auto placed = std::ranges::find_if(m_scene.targets, [&](const auto& sceneTarget) { return sceneTarget.workspaceID == row.workspace->m_id && sceneTarget.token == token; });
+                const auto placed = std::ranges::find_if(m_scene.targets, [&](const auto& sceneTarget) { return sceneTarget.workspaceID == workspaceID(row.workspace) && sceneTarget.token == token; });
                 if (placed == m_scene.targets.end() || !seenTargets.insert(token).second)
                     continue;
-                m_renderTargets.push_back(SRenderTarget{.workspaceID = row.workspace->m_id,
+                m_renderTargets.push_back(SRenderTarget{.workspaceID = workspaceID(row.workspace),
                                            .targetToken = token,
                                            .windowStableID = target.windowStableID,
                                            .box = sceneBox(placed->box, 0.0),
@@ -545,7 +545,7 @@ bool CScrollingOverview::refreshScene(const std::optional<SWorkspaceSnapshot>& i
             }
         }
 
-        const auto placedRow = std::ranges::find_if(m_scene.workspaces, [&](const auto& sceneRow) { return sceneRow.workspaceID == row.workspace->m_id; });
+        const auto placedRow = std::ranges::find_if(m_scene.workspaces, [&](const auto& sceneRow) { return sceneRow.workspaceID == workspaceID(row.workspace); });
         if (placedRow == m_scene.workspaces.end())
             continue;
         for (const auto& target : row.snapshot.layoutTargets) {
@@ -559,7 +559,7 @@ bool CScrollingOverview::refreshScene(const std::optional<SWorkspaceSnapshot>& i
                                placedRow->box.y + localY / std::max(1.0, MON->m_size.y) * placedRow->box.h,
                                source.w / std::max(1.0, MON->m_size.x) * placedRow->box.w,
                                source.h / std::max(1.0, MON->m_size.y) * placedRow->box.h};
-            m_renderTargets.push_back(SRenderTarget{.workspaceID = row.workspace->m_id,
+            m_renderTargets.push_back(SRenderTarget{.workspaceID = workspaceID(row.workspace),
                                        .targetToken = token,
                                        .windowStableID = target.windowStableID,
                                        .box = overlay,
@@ -592,9 +592,9 @@ bool CScrollingOverview::refreshScene(const std::optional<SWorkspaceSnapshot>& i
     }
 
     refreshCache();
-    m_focus = {.kind = EHitKind::EmptyWorkspace, .workspaceID = m_startedOn->m_id};
+    m_focus = {.kind = EHitKind::EmptyWorkspace, .workspaceID = workspaceID(m_startedOn)};
     for (const auto& target : m_scene.targets) {
-        if (target.workspaceID == m_startedOn->m_id) {
+        if (target.workspaceID == workspaceID(m_startedOn)) {
             m_focus = {.kind = EHitKind::Target, .workspaceID = target.workspaceID, .targetToken = target.token};
             break;
         }
@@ -1011,7 +1011,7 @@ bool CScrollingOverview::selectVisibleIndex(size_t index) {
         return false;
     if (index >= m_rows.size() || !m_rows[index].workspace)
         return false;
-    return selectWorkspaceByID(m_rows[index].workspace->m_id);
+    return selectWorkspaceByID(workspaceID(m_rows[index].workspace));
 }
 
 bool CScrollingOverview::moveWindowBetweenVisibleIndices(size_t, size_t, const PHLWINDOW&) {

--- a/src/WorkspaceCompat.hpp
+++ b/src/WorkspaceCompat.hpp
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <hyprland/src/output/Monitor.hpp>
+#include <hyprland/src/state/WorkspaceState.hpp>
+#include <hyprland/src/state/workspace/Resolver.hpp>
+#include <hyprland/src/workspace/HLWorkspace.hpp>
+
+#include <cstdint>
+#include <limits>
+#include <string>
+
+using WORKSPACEID = int64_t;
+
+constexpr WORKSPACEID WORKSPACE_INVALID = -1;
+
+inline WORKSPACEID workspaceID(const PHLWORKSPACE& workspace) {
+    if (!workspace)
+        return WORKSPACE_INVALID;
+
+    const auto numbered = workspace->numberedID();
+    return numbered ? static_cast<WORKSPACEID>(*numbered) : WORKSPACE_INVALID;
+}
+
+inline WORKSPACEID activeWorkspaceID(const PHLMONITOR& monitor) {
+    return monitor ? workspaceID(monitor->m_activeWorkspace) : WORKSPACE_INVALID;
+}
+
+inline bool workspaceHasID(const PHLWORKSPACE& workspace, WORKSPACEID id) {
+    return workspaceID(workspace) == id;
+}
+
+inline PHLWORKSPACE findWorkspaceByID(WORKSPACEID id) {
+    if (id <= 0 || id > static_cast<WORKSPACEID>(std::numeric_limits<Workspace::WorkspaceIDContainer>::max()))
+        return nullptr;
+
+    return State::workspaceState()->query().numbered(Workspace::SWorkspaceNumberedID{static_cast<Workspace::WorkspaceIDContainer>(id)}).run();
+}
+
+inline PHLWORKSPACE createWorkspaceForMonitor(WORKSPACEID id, PHLMONITOR monitor, bool isEmpty = false) {
+    if (id <= 0 || id > static_cast<WORKSPACEID>(std::numeric_limits<Workspace::WorkspaceIDContainer>::max()) || !monitor)
+        return nullptr;
+
+    return State::workspaceState()->createNumbered(Workspace::SWorkspaceNumberedID{static_cast<Workspace::WorkspaceIDContainer>(id)}, std::move(monitor), std::to_string(id), isEmpty);
+}
+
+inline WORKSPACEID workspaceIDForSelector(const PHLMONITOR& monitor, const std::string& selector) {
+    if (!monitor)
+        return WORKSPACE_INVALID;
+
+    const auto target = State::Workspace::resolver()->getWorkspaceTargetFromString(selector, monitor);
+    if (!target.id)
+        return WORKSPACE_INVALID;
+
+    const auto numbered = std::get_if<Workspace::SWorkspaceNumberedID>(&*target.id);
+    return numbered ? static_cast<WORKSPACEID>(numbered->value) : WORKSPACE_INVALID;
+}

--- a/tests/OverviewSourceTests.cpp
+++ b/tests/OverviewSourceTests.cpp
@@ -395,7 +395,7 @@ int main() {
            "regular workspace bounds are collected only for consecutive traversal");
     expect(boundsScanPos != std::string::npos && overviewConstructor.find("!workspace", boundsScanPos) != std::string::npos,
            "center-current bounds ignore null workspace entries");
-    expect(boundsScanPos != std::string::npos && overviewConstructor.find("workspace->m_isSpecialWorkspace", boundsScanPos) != std::string::npos,
+    expect(boundsScanPos != std::string::npos && overviewConstructor.find("workspace->type() == Workspace::eWorkspaceType::SPECIAL", boundsScanPos) != std::string::npos,
            "center-current bounds exclude special workspaces");
     expect(boundsScanPos != std::string::npos && overviewConstructor.find("workspace->m_monitor != PMONITOR", boundsScanPos) != std::string::npos,
            "center-current bounds exclude workspaces owned by other monitors");
@@ -418,7 +418,7 @@ int main() {
     const auto restoreAnchorPos = overviewConstructor.find("pMonitor->m_activeWorkspace = startedOn;", centerBranchEnd);
     expect(anchorPos != std::string::npos && anchorPos < centerBranchStart && restoreAnchorPos < cappedBranchStart,
            "explicit first and capped center selectors share a temporary anchor restored before capture");
-    expect(overviewConstructor.find("!methodCenter || (!skipEmpty && maxWorkspace > 0 && methodStartID != startedOn->m_id)") != std::string::npos,
+    expect(overviewConstructor.find("!methodCenter || (!skipEmpty && maxWorkspace > 0 && methodStartID != workspaceID(startedOn))") != std::string::npos,
            "capped explicit centers anchor relative traversal without changing legacy skip-empty centering");
 
     const auto helperPos = centerBranch.find("Hyprexpo::centeredWorkspaceBacktrack(");
@@ -443,7 +443,7 @@ int main() {
            "selecting an already-active grid workspace also focuses its monitor");
     expect(closeOverview.find("if (CHANGE && OLDWS != MON->m_activeWorkspace)") != std::string::npos,
            "focus-only selection cannot apply an OUT animation to its unchanged workspace");
-    expect(closeOverview.find("State::workspaceState()->create(NEWID, MON->m_id") != std::string::npos,
+    expect(closeOverview.find("createWorkspaceForMonitor(NEWID, MON)") != std::string::npos,
            "skip-empty creation is bound to the selected overview monitor");
     expect(closeOverview.find("nextEmptyWorkspaceIDForMonitor(MON)") != std::string::npos,
            "empty-workspace selection resolves against the selected monitor");
@@ -452,8 +452,8 @@ int main() {
     expectContains(emptySelector, "(*workspace)->m_monitor == monitor", "existing empty candidates must belong to the selected monitor");
     expectContains(emptySelector, "workspaces.size() + 1", "empty selection has a finite materialized-workspace search bound");
     const auto selectorHelper = extractFunction(source, "WORKSPACEID workspaceIDForMonitor(");
-    expect(selectorHelper.find("CScopeGuard") != std::string::npos && selectorHelper.find("FOCUS->m_focusMonitor = previousMonitor;") != std::string::npos,
-           "monitor-relative enumeration restores the focus context on every return");
+    expect(selectorHelper.find("workspaceIDForSelector(monitor, selector)") != std::string::npos,
+           "monitor-relative enumeration uses the upstream resolver with an explicit monitor");
     expect(overviewConstructor.find("getWorkspaceIDNameFromString(") == std::string::npos && overviewConstructor.find("workspaceIDForMonitor(PMONITOR,") != std::string::npos,
            "simultaneous grids do not enumerate through another monitor's focus context");
 
@@ -694,10 +694,10 @@ int main() {
     expectContains(requestIdHeader, "c == '.'", "shared request ID grammar accepts dots");
     expectContains(diagnosticSource, "validRequestID(request.requestID)", "topology diagnostics use the shared request ID validator");
 
-    for (const auto& token : {"NullWorkspace", "InertWorkspace", "MissingSpace", "MissingAlgorithm", "MissingTiledAlgorithm", "WrongAlgorithmName", "CastFailure", "ExpiredTarget",
+    for (const auto& token : {"NullWorkspace", "MissingSpace", "MissingAlgorithm", "MissingTiledAlgorithm", "WrongAlgorithmName", "CastFailure", "ExpiredTarget",
                               "ExpiredColumn", "ExpiredData", "MissingScrollingData", "ColumnCardinalityMismatch", "TargetCardinalityMismatch", "InvalidGeometry"})
         expectContains(adapterHeader, token, "adapter exposes typed fail-closed result " + std::string{token});
-    for (const auto& token : {"workspace->inert()", "workspace->m_space", "algorithm()", "tiledAlgo()", "algoMatcher()->getNameForTiledAlgo", "dynamic_cast<Layout::Tiled::CScrollingAlgorithm*>",
+    for (const auto& token : {"workspace->space()", "algorithm()", "tiledAlgo()", "algoMatcher()->getNameForTiledAlgo", "dynamic_cast<Layout::Tiled::CScrollingAlgorithm*>",
                               "dataFor(target)", ".lock()", "stripCount()", "getDirection()", "getOffset()", "getStrip(", "targetSizes.size()", "targetDatas.size()", "calculateStripStart(",
                               "calculateStripSize(", "layoutBox", "windowStableID", "algorithmFingerprint", "dataFingerprint"})
         expectContains(adapterSource, token, "adapter implements guarded snapshot token " + std::string{token});
@@ -732,7 +732,7 @@ int main() {
     expectContains(adapterSource, "controller->setOffset(workspaceState.offset)", "native transaction restores the exact pre-state offset after host structure changes");
 
     for (const auto& token : {"Desktop::globalWindowController()->moveWindowToWorkspace", "controllerMove", "reverse", "reResolve", "nextUnusedOrdinaryWorkspaceID",
-                              "State::workspaceState()->create", "m_monitor", "MixedFallback", "TerminalWorkspace"})
+                              "createWorkspaceForMonitor", "m_monitor", "MixedFallback", "TerminalWorkspace"})
         expectContains(adapterSource + mutationSource, token, "cross/terminal transaction exposes " + std::string{token});
     expectOrder(adapterSource, "moveWindowToWorkspace", "reResolve", "cross move discards stale ownership before destination positioning");
     expectContains(adapterSource, "if (reverse)", "rollback controller path explicitly reverses ownership");

--- a/tests/test_ci_targets.py
+++ b/tests/test_ci_targets.py
@@ -20,6 +20,18 @@ class TargetContractTests(unittest.TestCase):
     def test_current_contract_has_exact_commits(self):
         ci.targets()
 
+    def test_only_configured_same_repository_draft_tracker_uses_development_contract(self):
+        result = ci.contract("sandwichfarm/hyprexpo", 123, "master", "sandwichfarm/hyprexpo", "hyprland-git", True)
+        self.assertEqual(result, {"track": "hyprland-git", "gate": "Tracking gate", "kind": "tracking"})
+        cases = (
+            (124, "master", "sandwichfarm/hyprexpo", "hyprland-git", True),
+            (123, "hyprland-git", "sandwichfarm/hyprexpo", "hyprland-git", True),
+            (123, "master", "fork/hyprexpo", "hyprland-git", True),
+            (123, "master", "sandwichfarm/hyprexpo", "hyprland-git", False),
+        )
+        for number, base, repository, head, draft in cases:
+            self.assertEqual(ci.contract("sandwichfarm/hyprexpo", number, base, repository, head, draft)["kind"], "promotion_or_development")
+
     def test_reject_moving_ref_or_empty_matrix(self):
         for change in ("moving", "empty", "duplicate"):
             data = ci.targets()

--- a/tests/test_hyprpm_release_guards.py
+++ b/tests/test_hyprpm_release_guards.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Exercise the actual release recipes against disposable, offline Git repos."""
+
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class ReleaseGuardsTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory(prefix="hyprexpo-release-test-")
+        self.addCleanup(self.temporary.cleanup)
+        self.directory = Path(self.temporary.name)
+        self.repo = self.directory / "repo"
+        self.remote = self.directory / "remote.git"
+        self.repo.mkdir()
+        self.env = {
+            key: value for key, value in os.environ.items()
+            if not key.startswith("GIT_")
+            and key not in {"MAKEFLAGS", "MFLAGS", "MAKEOVERRIDES", "MAKEFILES"}
+        }
+        self.env.update({
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_CONFIG_GLOBAL": os.devnull,
+            "GIT_TERMINAL_PROMPT": "0",
+            "GIT_ALLOW_PROTOCOL": "file",
+            "LC_ALL": "C",
+        })
+        self.git("init", "--initial-branch=master")
+        self.git("config", "user.name", "Release fixture")
+        self.git("config", "user.email", "fixture@example.invalid")
+        self.git("config", "commit.gpgsign", "false")
+        self.git("config", "tag.gpgsign", "false")
+        for relative in ("Makefile", "scripts/version.sh", "scripts/check-commit-pins.sh"):
+            destination = self.repo / relative
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(ROOT / relative, destination)
+        (self.repo / "VERSION").write_text("v1.2.3\n")
+        self.git("add", ".")
+        self.git("commit", "-m", "Provide the initial release fixture")
+        self.pin = self.git("rev-parse", "HEAD").stdout.strip()
+        self.set_pin(self.pin)
+        self.git("init", "--bare", "--initial-branch=master", str(self.remote))
+        self.git("remote", "add", "origin", str(self.remote))
+        self.git("push", "-u", "origin", "master")
+
+    def run_command(self, *args, check=True):
+        result = subprocess.run(
+            args, cwd=self.repo, env=self.env, text=True,
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT, timeout=20,
+        )
+        if check:
+            self.assertEqual(result.returncode, 0, result.stdout)
+        return result
+
+    def git(self, *args, **kwargs):
+        return self.run_command("git", *args, **kwargs)
+
+    def make(self, *args):
+        return self.run_command("make", "--no-print-directory", *args, check=False)
+
+    def set_pin(self, pin):
+        (self.repo / "hyprpm.toml").write_text(
+            '[repository]\nname = "fixture"\ncommit_pins = [\n'
+            f'    ["{"a" * 40}", "{pin}"],\n]\n'
+        )
+        self.git("add", "hyprpm.toml")
+        self.git("commit", "-m", "Select the fixture plugin revision")
+
+    def stage_unrelated_change(self):
+        (self.repo / "unrelated.txt").write_text("Keep this staged change.\n")
+        self.git("add", "unrelated.txt")
+
+    def snapshot(self):
+        return {
+            "version": (self.repo / "VERSION").read_bytes(),
+            "head": self.git("rev-parse", "HEAD").stdout,
+            "index": self.git("write-tree").stdout,
+            "tags": self.git("for-each-ref", "refs/tags").stdout,
+            "remote_refs": self.git("--git-dir", str(self.remote), "for-each-ref").stdout,
+        }
+
+    def assert_rejected_without_changes(self, *args):
+        self.stage_unrelated_change()
+        before = self.snapshot()
+        result = self.make(*args)
+        # Check side effects even if a later echo incorrectly hides the error.
+        self.assertEqual(self.snapshot(), before, result.stdout)
+        self.assertNotEqual(result.returncode, 0, result.stdout)
+        self.assertIn("hyprpm plugin pins must be fetchable", result.stdout)
+        self.assertNotIn("next: make", result.stdout)
+        self.assertNotIn("pushed branch + tag", result.stdout)
+
+    def make_unlanded_pin(self):
+        # The object exists locally, but this unmerged PR commit is not in HEAD.
+        tree = self.git("rev-parse", "HEAD^{tree}").stdout.strip()
+        unlanded = self.git("commit-tree", tree, "-p", "HEAD", "-m", "Unmerged PR").stdout.strip()
+        self.set_pin(unlanded)
+
+    def test_version_rejects_unlanded_pin_before_mutation(self):
+        self.make_unlanded_pin()
+        self.assert_rejected_without_changes("version", "v1.2.3+1")
+
+    def test_tag_rejects_unlanded_pin_before_mutation(self):
+        self.make_unlanded_pin()
+        self.assert_rejected_without_changes("tag")
+
+    def test_publish_rejects_unlanded_pin_before_either_push(self):
+        self.make_unlanded_pin()
+        self.git("tag", "-a", "v1.2.3", "-m", "Invalid release fixture")
+        self.assert_rejected_without_changes("publish")
+
+    def test_version_rejects_unavailable_pin_before_mutation(self):
+        self.set_pin("0" * 40)
+        self.assert_rejected_without_changes("version", "v=v1.2.3+1")
+
+    def test_tag_rejects_unavailable_pin_before_mutation(self):
+        self.set_pin("0" * 40)
+        self.assert_rejected_without_changes("tag")
+
+    def test_publish_rejects_unavailable_pin_before_either_push(self):
+        self.set_pin("0" * 40)
+        self.git("tag", "-a", "v1.2.3", "-m", "Invalid release fixture")
+        self.assert_rejected_without_changes("publish")
+
+    def test_valid_version_tag_publish_flow(self):
+        self.stage_unrelated_change()
+        old_head = self.git("rev-parse", "HEAD").stdout.strip()
+        result = self.make("version", "v1.2.3+1")
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertEqual((self.repo / "VERSION").read_text(), "v1.2.3+1\n")
+        self.assertEqual(self.git("rev-parse", "HEAD^").stdout.strip(), old_head)
+        self.assertEqual(self.git("diff", "--cached", "--name-only").stdout, "unrelated.txt\n")
+        self.assertEqual(self.git("diff", "HEAD^", "HEAD", "--name-only").stdout, "VERSION\n")
+        result = self.make("tag")
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertEqual(self.git("cat-file", "-t", "v1.2.3+1").stdout, "tag\n")
+        self.assertEqual(self.git("rev-parse", "v1.2.3+1^{commit}").stdout,
+                         self.git("rev-parse", "HEAD").stdout)
+        result = self.make("publish")
+        self.assertEqual(result.returncode, 0, result.stdout)
+        for ref in ("refs/heads/master", "refs/tags/v1.2.3+1"):
+            self.assertEqual(self.git("--git-dir", str(self.remote), "rev-parse", ref).stdout,
+                             self.git("rev-parse", ref).stdout)
+
+    def test_rejected_branch_push_does_not_push_tag(self):
+        result = self.make("version", "v1.2.3+1")
+        self.assertEqual(result.returncode, 0, result.stdout)
+        result = self.make("tag")
+        self.assertEqual(result.returncode, 0, result.stdout)
+        hook = self.remote / "hooks" / "update"
+        hook.write_text('#!/bin/sh\ncase "$1" in refs/heads/*) exit 1;; esac\n')
+        hook.chmod(0o755)
+        before = self.snapshot()
+        result = self.make("publish")
+        self.assertEqual(self.snapshot(), before, result.stdout)
+        self.assertNotEqual(result.returncode, 0, result.stdout)
+        self.assertIn("hook declined", result.stdout)
+        self.assertNotIn("pushed branch + tag", result.stdout)
+        # Prove this remote would accept the tag if the recipe tried its second push.
+        self.git("push", "origin", "v1.2.3+1")
+        self.assertEqual(self.git("--git-dir", str(self.remote), "rev-parse", "refs/tags/v1.2.3+1").stdout,
+                         self.git("rev-parse", "refs/tags/v1.2.3+1").stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_hyprpm_state.py
+++ b/tests/test_hyprpm_state.py
@@ -1,0 +1,475 @@
+#!/usr/bin/env python3
+"""Exercise installed-state validation and install boundaries using real Git repos."""
+
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+GUARD = ROOT / "scripts/check-hyprpm-state.py"
+
+
+class HyprpmStateTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory(prefix="hyprexpo-state-test-")
+        self.addCleanup(self.temporary.cleanup)
+        self.directory = Path(self.temporary.name)
+        self.repo = self.directory / "caller"
+        self.remote = self.directory / "remote.git"
+        self.install_dir = self.directory / "installed"
+        self.repo.mkdir()
+        self.install_dir.mkdir()
+        self.state = self.install_dir / "state.toml"
+        self.env = {
+            key: value for key, value in os.environ.items()
+            if not key.startswith("GIT_")
+            and key not in {"MAKEFLAGS", "MFLAGS", "MAKEOVERRIDES", "MAKEFILES"}
+        }
+        self.env.update({
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_CONFIG_GLOBAL": os.devnull,
+            "GIT_TERMINAL_PROMPT": "0",
+            "GIT_ALLOW_PROTOCOL": "file",
+            "LC_ALL": "C",
+            "XDG_CACHE_HOME": str(self.directory / "cache"),
+            "XDG_DATA_HOME": str(self.directory / "data"),
+        })
+        self.git("init", "--initial-branch=master")
+        self.git("config", "user.name", "State fixture")
+        self.git("config", "user.email", "fixture@example.invalid")
+        self.git("config", "commit.gpgsign", "false")
+        self.git("config", "tag.gpgsign", "false")
+        (self.repo / "payload").write_text("Fixture tree.\n")
+        self.git("add", ".")
+        self.git("commit", "-m", "Provide the retained master history")
+        self.master = self.git("rev-parse", "HEAD").stdout.strip()
+        self.tree = self.git("rev-parse", "HEAD^{tree}").stdout.strip()
+        self.git("init", "--bare", "--initial-branch=master", str(self.remote))
+        self.git("remote", "add", "origin", str(self.remote))
+        self.git("push", "-u", "origin", "master")
+
+    def command(self, *args, check=True, env=None):
+        result = subprocess.run(
+            args, cwd=self.repo, env=env or self.env, text=True,
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT, timeout=20,
+        )
+        if check:
+            self.assertEqual(result.returncode, 0, result.stdout)
+        return result
+
+    def git(self, *args, **kwargs):
+        return self.command("git", *args, **kwargs)
+
+    def commit(self, message, parent=None):
+        args = ["commit-tree", self.tree, "-m", message]
+        if parent:
+            args.extend(["-p", parent])
+        return self.git(*args).stdout.strip()
+
+    def publish_branch(self, name, commit):
+        self.git("push", "origin", f"{commit}:refs/heads/{name}")
+
+    def set_revision(self, revision, url=None):
+        self.state.write_text(
+            "[repository]\n"
+            f"url = {json.dumps(str(self.remote) if url is None else url)}\n"
+            f"rev = {json.dumps(revision)}\n"
+        )
+
+    def snapshot(self, path):
+        if not path.exists() and not path.is_symlink():
+            return None
+        info = path.lstat()
+        contents = os.readlink(path) if path.is_symlink() else path.read_bytes()
+        return (info.st_ino, info.st_mode, info.st_size, info.st_mtime_ns, contents)
+
+    def guard(self, expected, env=None):
+        before = self.snapshot(self.state)
+        result = self.command(sys.executable, str(GUARD), str(self.state), check=False, env=env)
+        self.assertEqual(self.snapshot(self.state), before, result.stdout)
+        self.assertEqual(result.returncode, expected, result.stdout)
+        return result
+
+    def test_absent_state_passes_without_git(self):
+        self.guard(0, env={**self.env, "PATH": str(self.directory / "no-programs")})
+
+    def test_unpinned_state_passes_without_git_or_remote(self):
+        states = (
+            "[repository]\n",
+            '[repository]\nurl = "https://unreachable.invalid/repo.git"\n',
+            '[repository]\nrev = ""\nurl = "https://unreachable.invalid/repo.git"\n',
+        )
+        for contents in states:
+            with self.subTest(contents=contents):
+                self.state.write_text(contents)
+                self.guard(0, env={**self.env, "PATH": str(self.directory / "no-programs")})
+
+    def test_malformed_toml_and_invalid_utf8_are_rejected(self):
+        for contents in (b"[repository\n", b"[repository]\nrev = \xff\n"):
+            with self.subTest(contents=contents):
+                self.state.write_bytes(contents)
+                self.guard(1)
+
+    def test_missing_or_invalid_repository_table_is_rejected(self):
+        for contents in ("", "enabled = true\n", 'repository = "invalid"\n'):
+            with self.subTest(contents=contents):
+                self.state.write_text(contents)
+                self.guard(1)
+
+    def test_non_string_revisions_are_rejected(self):
+        for value in ("123", "true", "[]", "{}"):
+            with self.subTest(value=value):
+                self.state.write_text(f"[repository]\nrev = {value}\n")
+                self.guard(1)
+
+    @unittest.skipIf(os.geteuid() == 0, "Root can read permission-denied fixtures")
+    def test_unreadable_state_is_rejected_without_changing_permissions(self):
+        self.set_revision("master")
+        self.state.chmod(0)
+        before = self.state.stat()
+        try:
+            result = self.command(sys.executable, str(GUARD), str(self.state), check=False)
+            after = self.state.stat()
+            self.assertEqual(result.returncode, 1, result.stdout)
+            self.assertEqual((after.st_ino, after.st_mode, after.st_mtime_ns),
+                             (before.st_ino, before.st_mode, before.st_mtime_ns))
+        finally:
+            self.state.chmod(0o600)
+
+    def test_state_directory_is_rejected(self):
+        self.state.mkdir()
+        result = self.command(sys.executable, str(GUARD), str(self.state), check=False)
+        self.assertEqual(result.returncode, 1, result.stdout)
+        self.assertTrue(self.state.is_dir())
+
+    def test_missing_or_invalid_repository_url_is_rejected(self):
+        for url_line in ("", 'url = ""\n', "url = 42\n"):
+            with self.subTest(url_line=url_line):
+                self.state.write_text('[repository]\nrev = "master"\n' + url_line)
+                self.guard(1)
+
+    def test_unavailable_remote_fails_closed(self):
+        self.set_revision("master", str(self.directory / "missing.git"))
+        self.guard(1)
+
+    def test_transport_failure_fails_closed(self):
+        # The transport allowlist rejects HTTPS immediately without using the network.
+        self.set_revision(self.master, "https://unreachable.invalid/repo.git")
+        self.guard(1)
+
+    def test_master_names_resolve_from_fresh_remote(self):
+        for revision in ("master", "origin/master", "refs/heads/master",
+                         "refs/remotes/origin/master"):
+            with self.subTest(revision=revision):
+                self.set_revision(revision)
+                self.guard(0)
+
+    def test_retained_development_and_maintenance_names(self):
+        for branch in ("hyprland-git", "release/0.56"):
+            retained = self.commit(f"Independent {branch} history")
+            self.publish_branch(branch, retained)
+            for revision in (f"origin/{branch}", f"refs/remotes/origin/{branch}"):
+                with self.subTest(revision=revision):
+                    self.set_revision(revision)
+                    self.guard(0)
+
+    def test_commit_hashes_in_each_retained_history(self):
+        for branch in ("master", "hyprland-git", "release/0.56"):
+            ancestor = self.master if branch == "master" else self.commit(f"Base for {branch}")
+            tip = self.commit(f"Advance {branch}", parent=ancestor)
+            self.publish_branch(branch, tip)
+            for revision in (ancestor, tip):
+                with self.subTest(branch=branch, revision=revision):
+                    self.set_revision(revision)
+                    self.guard(0)
+
+    def test_lightweight_and_annotated_version_tags_retain_history(self):
+        for name, annotated in (("v1.2.3", False), ("v1.2.3+4", True)):
+            ancestor = self.commit(f"Independent history for {name}")
+            tip = self.commit(f"Release {name}", parent=ancestor)
+            args = ["tag", name, tip]
+            if annotated:
+                args.extend(["-a", "-m", f"Release {name}"])
+            self.git(*args)
+            self.git("push", "origin", f"refs/tags/{name}")
+            for revision in (name, f"refs/tags/{name}", ancestor, tip):
+                with self.subTest(revision=revision):
+                    self.set_revision(revision)
+                    self.guard(0)
+
+    def test_temporary_names_are_rejected_even_when_pointing_to_master(self):
+        for branch in ("temporary-fix", "release/temporary"):
+            self.publish_branch(branch, self.master)
+            for revision in (branch, f"origin/{branch}", f"refs/heads/{branch}",
+                             f"refs/remotes/origin/{branch}"):
+                with self.subTest(revision=revision):
+                    self.set_revision(revision)
+                    self.guard(1)
+
+    def test_arbitrary_revision_expressions_are_rejected(self):
+        for revision in ("HEAD", "master~0", "master^{commit}", "master@{0}",
+                         self.master[:12], "--all", " ", "refs/remotes/origin/HEAD"):
+            with self.subTest(revision=revision):
+                self.set_revision(revision)
+                self.guard(1)
+
+    def test_nonversion_tags_do_not_authorize_temporary_history(self):
+        temporary = self.commit("Only a development tag retains this commit")
+        self.git("tag", "snapshot", temporary)
+        self.git("push", "origin", "refs/tags/snapshot")
+        for revision in ("snapshot", "refs/tags/snapshot", temporary):
+            with self.subTest(revision=revision):
+                self.set_revision(revision)
+                self.guard(1)
+
+    def test_temporary_branch_only_hash_is_rejected_even_when_fetchable(self):
+        temporary = self.commit("Unmerged temporary change", parent=self.master)
+        self.publish_branch("temporary-fix", temporary)
+        probe = self.directory / "probe.git"
+        self.git("clone", "--bare", "--no-local", str(self.remote), str(probe))
+        self.git("--git-dir", str(probe), "cat-file", "-e", temporary)
+        self.set_revision(temporary)
+        self.guard(1)
+
+    def test_deleted_pr_hash_is_rejected_despite_local_remote_objects(self):
+        deleted = self.commit("Deleted PR change", parent=self.master)
+        self.publish_branch("deleted-pr", deleted)
+        self.git("push", "origin", "--delete", "deleted-pr")
+        self.git("cat-file", "-e", deleted)
+        self.git("--git-dir", str(self.remote), "cat-file", "-e", deleted)
+        probe = self.directory / "probe.git"
+        self.git("clone", "--bare", "--no-local", str(self.remote), str(probe))
+        result = self.git("--git-dir", str(probe), "cat-file", "-e", deleted, check=False)
+        self.assertNotEqual(result.returncode, 0, result.stdout)
+        self.set_revision(deleted)
+        self.guard(1)
+
+    def test_unavailable_hash_is_rejected(self):
+        self.set_revision("0" * 40)
+        self.guard(1)
+
+    def test_caller_refs_do_not_authorize_or_override_remote_revisions(self):
+        local_only = self.commit("Caller has its own retained-looking refs")
+        self.git("update-ref", "refs/remotes/origin/master", local_only)
+        self.git("tag", "v9.9.9", local_only)
+        for revision in (local_only, "v9.9.9"):
+            with self.subTest(revision=revision):
+                self.set_revision(revision)
+                self.guard(1)
+        self.set_revision("origin/master")
+        self.guard(0)
+
+    def test_clone_templates_cannot_inject_local_only_release_history(self):
+        local_only = self.commit("Unpublished orphan injected by a Git template")
+        missing = self.git("--git-dir", str(self.remote), "cat-file", "-e", local_only, check=False)
+        self.assertNotEqual(missing.returncode, 0, missing.stdout)
+        template = self.directory / "template"
+        (template / "refs/tags").mkdir(parents=True)
+        (template / "refs/tags/v9.9.9").write_text(local_only + "\n")
+        (template / "objects/info").mkdir(parents=True)
+        (template / "objects/info/alternates").write_text(str(self.repo / ".git/objects") + "\n")
+        config = self.directory / "template.gitconfig"
+        config.write_text(f"[init]\n\ttemplateDir = {template}\n")
+        environments = {
+            "environment": {**self.env, "GIT_TEMPLATE_DIR": str(template)},
+            "configuration": {**self.env, "GIT_CONFIG_GLOBAL": str(config)},
+        }
+        self.set_revision(local_only)
+        for source, environment in environments.items():
+            with self.subTest(source=source):
+                # Prove an ordinary fresh clone inherits the forged tag and objects.
+                probe = self.directory / f"template-probe-{source}"
+                self.git("clone", "--no-local", "--no-checkout", str(self.remote), str(probe),
+                         env=environment)
+                injected = self.git("-C", str(probe), "rev-parse", "v9.9.9^{commit}")
+                self.assertEqual(injected.stdout.strip(), local_only)
+                self.guard(1, env=environment)
+
+    def prepare_install(self):
+        for relative in ("Makefile", "scripts/version.sh", "scripts/check-hyprpm-state.py",
+                         "scripts/dev-link.sh"):
+            destination = self.repo / relative
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(ROOT / relative, destination)
+        (self.repo / "VERSION").write_text("v1.2.3\n")
+        self.new_binary = self.directory / "new-hyprexpo.so"
+        self.new_binary.write_bytes(b"new plugin fixture\n")
+        self.old_binary = self.install_dir / "hyprexpo.so"
+        self.old_binary.write_bytes(b"installed plugin fixture\n")
+        self.backup = self.install_dir / "hyprexpo.so.bak"
+        self.backup.write_bytes(b"existing backup fixture\n")
+        self.env["HYPREXPO_DEV_SO"] = str(self.new_binary)
+
+    def make(self, goal):
+        return self.command(
+            "make", "--no-print-directory", "-j4", goal,
+            f"TARGET={self.new_binary}", f"INSTALL_DIR={self.install_dir}",
+            "INSTALL_USER=fixture", "SRC=", "HEADERS=", "CXX=false", "INCLUDES=", "LIBS=",
+            check=False,
+        )
+
+    def install_snapshot(self):
+        return {str(path): self.snapshot(path) for path in
+                (self.state, self.new_binary, self.old_binary, self.backup)}
+
+    def test_make_check_target_and_install_reject_without_mutation(self):
+        self.prepare_install()
+        self.set_revision("0" * 40)
+        for goal in ("check-hyprpm-state", "install"):
+            with self.subTest(goal=goal):
+                before = self.install_snapshot()
+                result = self.make(goal)
+                self.assertEqual(self.install_snapshot(), before, result.stdout)
+                self.assertNotEqual(result.returncode, 0, result.stdout)
+                self.assertNotIn("No rule to make target", result.stdout)
+
+    def test_make_install_accepts_retained_revision(self):
+        self.prepare_install()
+        self.set_revision(self.master)
+        state_before = self.snapshot(self.state)
+        result = self.make("install")
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertEqual(self.old_binary.read_bytes(), self.new_binary.read_bytes())
+        self.assertEqual(self.snapshot(self.state), state_before)
+
+    def test_make_install_accepts_absent_and_unpinned_state(self):
+        self.prepare_install()
+        for contents in (None, '[repository]\nrev = ""\nurl = "missing"\n'):
+            with self.subTest(contents=contents):
+                if contents is not None:
+                    self.state.write_text(contents)
+                before = self.snapshot(self.state)
+                result = self.make("install")
+                self.assertEqual(result.returncode, 0, result.stdout)
+                self.assertEqual(self.old_binary.read_bytes(), self.new_binary.read_bytes())
+                self.assertEqual(self.snapshot(self.state), before)
+
+    @unittest.skipIf(os.geteuid() == 0, "dev-link intentionally rejects root")
+    def test_dev_link_rejects_before_replacing_explicit_symlink_or_backup(self):
+        self.prepare_install()
+        previous_binary = self.directory / "previous.so"
+        previous_binary.write_bytes(b"previous symlink destination\n")
+        self.old_binary.unlink()
+        self.old_binary.symlink_to(previous_binary)
+        self.set_revision("0" * 40)
+        before = self.install_snapshot()
+        previous_before = self.snapshot(previous_binary)
+        result = self.command("bash", "scripts/dev-link.sh", "-t", str(self.old_binary), check=False)
+        self.assertEqual(self.install_snapshot(), before, result.stdout)
+        self.assertEqual(self.snapshot(previous_binary), previous_before, result.stdout)
+        self.assertNotEqual(result.returncode, 0, result.stdout)
+
+    @unittest.skipIf(os.geteuid() == 0, "dev-link intentionally rejects root")
+    def test_dev_link_accepts_retained_revision_and_preserves_state(self):
+        self.prepare_install()
+        self.set_revision("origin/master")
+        original = self.old_binary.read_bytes()
+        state_before = self.snapshot(self.state)
+        result = self.command("bash", "scripts/dev-link.sh", "-t", str(self.old_binary), check=False)
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertTrue(self.old_binary.is_symlink())
+        self.assertEqual(self.old_binary.resolve(), self.new_binary)
+        self.assertEqual(self.backup.read_bytes(), original)
+        self.assertEqual(self.snapshot(self.state), state_before)
+
+    @unittest.skipIf(os.geteuid() == 0, "dev-link intentionally rejects root")
+    def test_dev_link_restore_remains_available_for_rejected_state(self):
+        self.prepare_install()
+        self.old_binary.unlink()
+        self.old_binary.symlink_to(self.new_binary)
+        self.new_binary.unlink()
+        self.set_revision("0" * 40)
+        state_before = self.snapshot(self.state)
+        backup = self.backup.read_bytes()
+        result = self.command("bash", "scripts/dev-link.sh", "--restore", "-t",
+                              str(self.old_binary), check=False)
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertFalse(self.old_binary.is_symlink())
+        self.assertEqual(self.old_binary.read_bytes(), backup)
+        self.assertFalse(self.backup.exists())
+        self.assertEqual(self.snapshot(self.state), state_before)
+
+    def prepare_manager(self):
+        executable_dir = self.directory / "bin"
+        executable_dir.mkdir()
+        executable = executable_dir / "hyprpm"
+        executable.write_text(
+            '#!/bin/sh\n'
+            'printf "%s\\0" "$@" > "$HYPREXPO_MANAGER_LOG"\n'
+            'exit "${HYPREXPO_MANAGER_STATUS:-0}"\n'
+        )
+        executable.chmod(0o755)
+        self.manager_log = self.directory / "manager-arguments"
+        self.env["HYPREXPO_MANAGER_LOG"] = str(self.manager_log)
+        self.env["PATH"] = str(executable_dir) + os.pathsep + self.env["PATH"]
+        self.set_revision("master")
+
+    def add_repository(self, *args):
+        before = self.snapshot(self.state)
+        result = self.command("bash", str(ROOT / "scripts/hyprpm-add.sh"), *args, check=False)
+        self.assertEqual(self.snapshot(self.state), before, result.stdout)
+        return result
+
+    def test_add_wrapper_rejects_temporary_branches_and_hashes_before_manager(self):
+        self.prepare_manager()
+        temporary = self.commit("Unmerged candidate still exists upstream", parent=self.master)
+        self.publish_branch("candidate-pr", temporary)
+        for revision in ("candidate-pr", "origin/candidate-pr", temporary):
+            with self.subTest(revision=revision):
+                result = self.add_repository(str(self.remote), revision)
+                self.assertNotEqual(result.returncode, 0, result.stdout)
+                self.assertFalse(self.manager_log.exists(), result.stdout)
+        self.git("push", "origin", "--delete", "candidate-pr")
+        for revision in (temporary, "0" * 40):
+            with self.subTest(deleted_or_unavailable=revision):
+                result = self.add_repository(str(self.remote), revision)
+                self.assertNotEqual(result.returncode, 0, result.stdout)
+                self.assertFalse(self.manager_log.exists(), result.stdout)
+
+    def test_add_wrapper_rejects_temporary_name_even_when_master_is_retained(self):
+        self.prepare_manager()
+        self.publish_branch("candidate-pr", self.master)
+        result = self.add_repository(str(self.remote), "origin/candidate-pr")
+        self.assertNotEqual(result.returncode, 0, result.stdout)
+        self.assertFalse(self.manager_log.exists(), result.stdout)
+
+    def test_add_wrapper_retained_and_unpinned_inputs_keep_original_arguments(self):
+        self.prepare_manager()
+        development = self.commit("Retained development history")
+        self.publish_branch("hyprland-git", development)
+        inputs = (
+            (str(self.remote),),
+            (str(self.remote), ""),
+            (str(self.remote), self.master),
+            (str(self.remote), "origin/hyprland-git"),
+        )
+        for args in inputs:
+            with self.subTest(args=args):
+                result = self.add_repository(*args)
+                self.assertEqual(result.returncode, 0, result.stdout)
+                self.assertEqual(self.manager_log.read_bytes().split(b"\0")[:-1],
+                                 [b"add", *[arg.encode() for arg in args]])
+                self.manager_log.unlink()
+
+    def test_add_wrapper_transport_failure_never_invokes_manager(self):
+        self.prepare_manager()
+        result = self.add_repository("https://unreachable.invalid/repo.git", self.master)
+        self.assertNotEqual(result.returncode, 0, result.stdout)
+        self.assertFalse(self.manager_log.exists(), result.stdout)
+
+    def test_add_wrapper_preserves_manager_failure_status(self):
+        self.prepare_manager()
+        self.env["HYPREXPO_MANAGER_STATUS"] = "7"
+        result = self.add_repository(str(self.remote))
+        self.assertEqual(result.returncode, 7, result.stdout)
+        self.assertTrue(self.manager_log.exists(), result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_prepare_hyprland_release.py
+++ b/tests/test_prepare_hyprland_release.py
@@ -1,0 +1,40 @@
+import json
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PREPARE = ROOT / "scripts/prepare-hyprland-release.py"
+
+
+class ReleasePacketTests(unittest.TestCase):
+    def observation(self, releases):
+        return {"plugin_base": "p" * 40, "development_target": "d" * 40, "release_targets": [{"name": "v0.56.2"}], "eligible_releases": releases}
+
+    def test_packet_is_local_and_non_publishing(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "observation.json"
+            output = root / "packet.json"
+            source.write_text(json.dumps(self.observation([{"id": 2, "tag": "v0.57.0", "target": "t" * 40}])))
+            result = subprocess.run(["python3", str(PREPARE), str(source), "--tag", "v0.57.0", "--output", str(output)], text=True, capture_output=True)
+            self.assertEqual(result.returncode, 0)
+            packet = json.loads(output.read_text())
+            self.assertEqual(packet["status"], "prepared_not_published")
+            self.assertEqual(packet["publication"], "forbidden by this preparation command")
+            self.assertIn("pin ancestry and final integrated-tree validation", packet["required_gates"])
+
+    def test_unknown_or_ambiguous_release_fails_closed(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "observation.json"
+            source.write_text(json.dumps(self.observation([{"tag": "v0.57.0"}, {"tag": "v0.57.0"}])))
+            result = subprocess.run(["python3", str(PREPARE), str(source), "--tag", "v0.57.0", "--output", str(root / "packet.json")], text=True, capture_output=True)
+            self.assertEqual(result.returncode, 2)
+            self.assertFalse((root / "packet.json").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_watch_hyprland.py
+++ b/tests/test_watch_hyprland.py
@@ -57,6 +57,12 @@ class WatchHyprlandTests(unittest.TestCase):
         self.assertEqual(report["status"], "candidate_active")
         self.assertEqual(report["candidate_prs"][0]["number"], 7)
 
+    def test_existing_candidate_wins_over_prior_failed_probe(self):
+        main = "b" * 40
+        report = json.loads(run(fixture(probe="failure", prs=[{"number": 7, "title": "chase", "headRefName": f"chase/hyprland-{main}", "baseRefName": "hyprland-git", "isDraft": True}])).stdout)
+        self.assertEqual(report["status"], "candidate_active")
+        self.assertIn("probe_failed", report["failure_stages"])
+
     def test_failed_probe_requires_diagnosis(self):
         result = run(fixture(probe="failure"))
         report = json.loads(result.stdout)

--- a/tests/test_watch_hyprland.py
+++ b/tests/test_watch_hyprland.py
@@ -9,7 +9,7 @@ ROOT = Path(__file__).resolve().parents[1]
 WATCHER = ROOT / "scripts/watch-hyprland.py"
 
 
-def fixture(main="b" * 40, target="a" * 40, lock=None, probe="success", releases=None, prs=None):
+def fixture(main="b" * 40, target="a" * 40, lock=None, probe="success", releases=None, tags=None, prs=None):
     return {
         "master": "m" * 40,
         "development_branch": "d" * 40,
@@ -22,6 +22,7 @@ def fixture(main="b" * 40, target="a" * 40, lock=None, probe="success", releases
             "release_targets": [{"name": "v0.56.2", "rev": "r" * 40}],
         },
         "releases": [] if releases is None else releases,
+        "tags": {} if tags is None else tags,
         "open_prs": [] if prs is None else prs,
         "probe_runs": [{"databaseId": 1, "status": "completed", "conclusion": probe, "headSha": "m" * 40, "createdAt": "2026-09-10T00:00:00Z"}],
     }
@@ -82,8 +83,8 @@ class WatchHyprlandTests(unittest.TestCase):
             {"id": 3, "tag_name": "v0.58.0", "draft": True, "prerelease": False},
             {"id": 4, "tag_name": "v0.59.0-rc.1", "draft": False, "prerelease": True},
         ]
-        report = json.loads(run(fixture(releases=releases)).stdout)
-        self.assertEqual(report["eligible_releases"], [{"id": 2, "tag": "v0.57.0", "target": "z" * 40, "published_at": None}])
+        report = json.loads(run(fixture(releases=releases, tags={"v0.57.0": "p" * 40})).stdout)
+        self.assertEqual(report["eligible_releases"], [{"id": 2, "tag": "v0.57.0", "tag_commit": "p" * 40, "target": "z" * 40, "published_at": None}])
 
     def test_older_unsupported_releases_are_not_new_work(self):
         releases = [{"id": 1, "tag_name": "v0.55.4", "draft": False, "prerelease": False}]

--- a/tests/test_watch_hyprland.py
+++ b/tests/test_watch_hyprland.py
@@ -1,0 +1,95 @@
+import json
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WATCHER = ROOT / "scripts/watch-hyprland.py"
+
+
+def fixture(main="b" * 40, target="a" * 40, lock=None, probe="success", releases=None, prs=None):
+    return {
+        "master": "m" * 40,
+        "development_branch": "d" * 40,
+        "upstream_main": main,
+        "upstream_main_date": "2026-09-10T00:00:00Z",
+        "contract": {
+            "development_revision": target,
+            "lock_revision": target if lock is None else lock,
+            "lock_matches_target": lock is None or lock == target,
+            "release_targets": [{"name": "v0.56.2", "rev": "r" * 40}],
+        },
+        "releases": [] if releases is None else releases,
+        "open_prs": [] if prs is None else prs,
+        "probe_runs": [{"databaseId": 1, "status": "completed", "conclusion": probe, "headSha": "m" * 40, "createdAt": "2026-09-10T00:00:00Z"}],
+    }
+
+
+def run(data, form="json"):
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as handle:
+        json.dump(data, handle)
+        path = handle.name
+    result = subprocess.run(["python3", str(WATCHER), "--fixture", path, "--format", form], text=True, capture_output=True)
+    Path(path).unlink()
+    return result
+
+
+class WatchHyprlandTests(unittest.TestCase):
+    def test_up_to_date_has_no_candidate_work(self):
+        result = run(fixture(main="a" * 40))
+        report = json.loads(result.stdout)
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(report["status"], "up_to_date")
+        self.assertEqual(report["eligible_releases"], [])
+
+    def test_new_target_requests_one_candidate(self):
+        result = run(fixture())
+        report = json.loads(result.stdout)
+        self.assertEqual(report["status"], "new_upstream_target")
+        self.assertEqual(report["next_action"], "prepare one development candidate")
+
+    def test_existing_exact_candidate_deduplicates(self):
+        main = "b" * 40
+        result = run(fixture(prs=[{"number": 7, "title": "chase", "headRefName": f"chase/hyprland-{main}", "baseRefName": "hyprland-git", "isDraft": True}]))
+        report = json.loads(result.stdout)
+        self.assertEqual(report["status"], "candidate_active")
+        self.assertEqual(report["candidate_prs"][0]["number"], 7)
+
+    def test_failed_probe_requires_diagnosis(self):
+        result = run(fixture(probe="failure"))
+        report = json.loads(result.stdout)
+        self.assertEqual(report["status"], "needs_diagnosis")
+        self.assertIn("probe_failed", report["failure_stages"])
+
+    def test_lock_mismatch_is_never_compatible(self):
+        result = run(fixture(lock="c" * 40))
+        report = json.loads(result.stdout)
+        self.assertEqual(report["status"], "needs_diagnosis")
+        self.assertIn("development_lock_mismatch", report["failure_stages"])
+
+    def test_new_stable_release_is_reported_but_drafts_are_ignored(self):
+        releases = [
+            {"id": 1, "tag_name": "v0.56.2", "draft": False, "prerelease": False},
+            {"id": 2, "tag_name": "v0.57.0", "draft": False, "prerelease": False, "target_commitish": "z" * 40},
+            {"id": 3, "tag_name": "v0.58.0", "draft": True, "prerelease": False},
+            {"id": 4, "tag_name": "v0.59.0-rc.1", "draft": False, "prerelease": True},
+        ]
+        report = json.loads(run(fixture(releases=releases)).stdout)
+        self.assertEqual(report["eligible_releases"], [{"id": 2, "tag": "v0.57.0", "target": "z" * 40, "published_at": None}])
+
+    def test_older_unsupported_releases_are_not_new_work(self):
+        releases = [{"id": 1, "tag_name": "v0.55.4", "draft": False, "prerelease": False}]
+        report = json.loads(run(fixture(main="a" * 40, releases=releases)).stdout)
+        self.assertEqual(report["eligible_releases"], [])
+
+    def test_markdown_exposes_failure_and_release_work(self):
+        result = run(fixture(probe="failure", releases=[{"id": 2, "tag_name": "v0.57.0", "draft": False, "prerelease": False}]), "markdown")
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("probe_failed", result.stdout)
+        self.assertIn("v0.57.0", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Upstream main `599ff9042c866dcad4bb458979f7be68a6d2ffef` no longer compiles current development source. This draft owns that target and preserves a resumable diagnosis without changing the validated development pin or lock.

Probe evidence: [run 34462165645](https://github.com/sandwichfarm/hyprexpo/actions/runs/34462165645) reports missing `WORKSPACE_INVALID`, removed `activeWorkspaceID`, and a workspace-ID variant/private-member migration in `src/Dispatchers.cpp`.

This branch also reconciles current master managed-installation guards and the new observer/procedure tooling into the candidate. That lets its checks exercise the same safety contracts future repair work must use. Development target, lock, release pins, source behavior, and desktop state remain unchanged.

Current validation: 56 tooling tests, C++ suites, 39 input cases, diagnostic source contract, workflow YAML parse, and observer report passed. Existing upstream probe failure remains unresolved. This is not a compatibility claim.

Required next work: update target/flake/lock together; migrate workspace/monitor APIs; preserve behavior with focused tests; run exact build/rebuild and affected disposable runtime proof; update receipt with exact evidence. Merge with a merge commit only after those gates pass.
