### PR TITLE
Classify Hyprland probe evidence by tested tree

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -93,6 +93,7 @@ jobs:
         env:
           UPSTREAM_REV: ${{ matrix.rev }}
           CI_TARGET_BRANCH: ${{ needs.targets.outputs.contract }}
+          EVIDENCE_KIND: compatibility
           EVIDENCE_DIR: ${{ runner.temp }}/evidence-${{ matrix.name }}
         run: ./scripts/ci-build.sh "$UPSTREAM_REV" "$EVIDENCE_DIR"
       - name: Preserve artifacts and failure logs

--- a/.github/workflows/upstream-tip.yml
+++ b/.github/workflows/upstream-tip.yml
@@ -62,6 +62,7 @@ jobs:
       - name: Probe without changing the development pin
         env:
           UPSTREAM_REV: ${{ steps.upstream.outputs.rev }}
+          EVIDENCE_KIND: upstream-tip
         run: ./scripts/ci-build.sh "$UPSTREAM_REV" "$RUNNER_TEMP/upstream-tip-evidence"
       - name: Explain advisory failure
         if: failure()

--- a/scripts/ci-build.sh
+++ b/scripts/ci-build.sh
@@ -13,14 +13,49 @@ trap 'rm -rf "$snapshot"' EXIT
 git -C "$root" archive HEAD | tar -x -C "$snapshot"
 cd "$snapshot"
 
+branch_lock=$(python3 - <<'PY'
+import json
+lock = json.load(open("flake.lock"))
+root = lock["nodes"][lock["root"]]
+print(lock["nodes"][root["inputs"]["hyprland"]]["locked"]["rev"])
+PY
+)
+export root rev branch_lock
+
 {
     printf 'plugin_commit=%s\n' "$(git -C "$root" rev-parse HEAD)"
     printf 'plugin_tree=%s\n' "$(git -C "$root" rev-parse HEAD^{tree})"
     printf 'hyprland_commit=%s\n' "$rev"
+    printf 'branch_lock_revision=%s\n' "$branch_lock"
     printf 'run_url=%s/%s/actions/runs/%s\n' "${GITHUB_SERVER_URL:-local}" "${GITHUB_REPOSITORY:-local}" "${GITHUB_RUN_ID:-local}"
+    printf 'run_attempt=%s\n' "${GITHUB_RUN_ATTEMPT:-local}"
+    printf 'workflow_head=%s\n' "${GITHUB_SHA:-local}"
+    printf 'job=%s\n' "${GITHUB_JOB:-local}"
     nix --version
     uname -a
 } > "$evidence/provenance.txt"
+
+python3 - "$evidence/evidence.json" <<'PY'
+import json
+import os
+import subprocess
+import sys
+
+root = subprocess.check_output(["git", "-C", os.environ["root"], "rev-parse", "HEAD"], text=True).strip()
+tree = subprocess.check_output(["git", "-C", os.environ["root"], "rev-parse", "HEAD^{tree}"], text=True).strip()
+json.dump({
+    "schema_version": 1,
+    "plugin_commit": root,
+    "plugin_tree": tree,
+    "hyprland_commit": os.environ["rev"],
+    "branch_lock_revision": os.environ["branch_lock"],
+    "run_url": f"{os.environ.get('GITHUB_SERVER_URL', 'local')}/{os.environ.get('GITHUB_REPOSITORY', 'local')}/actions/runs/{os.environ.get('GITHUB_RUN_ID', 'local')}",
+    "run_attempt": os.environ.get("GITHUB_RUN_ATTEMPT", "local"),
+    "workflow_head": os.environ.get("GITHUB_SHA", "local"),
+    "job": os.environ.get("GITHUB_JOB", "local"),
+    "kind": os.environ.get("EVIDENCE_KIND", "local"),
+}, open(sys.argv[1], "w"), indent=2, sort_keys=True)
+PY
 
 flake_args=(--override-input hyprland "github:hyprwm/Hyprland/$rev" --no-write-lock-file)
 if [[ -n ${CI_TARGET_BRANCH:-} ]]; then

--- a/scripts/watch-hyprland.py
+++ b/scripts/watch-hyprland.py
@@ -152,12 +152,15 @@ def discover_live() -> dict[str, Any]:
     evidence: list[dict[str, Any]] = []
     for workflow in ("upstream-tip.yml", "compatibility.yml"):
         runs = json_command("gh", "run", "list", "-R", REPOSITORY, "--workflow", workflow, "--limit", "10", "--json", "databaseId,status,conclusion,headSha,createdAt,event,url")
+        inspected = 0
         for run in runs:
             if run.get("status") == "completed":
                 records = artifact_evidence(run, workflow)
                 evidence.extend(records)
                 if records:
-                    break
+                    inspected += 1
+                    if inspected == 3:
+                        break
             else:
                 evidence.append({"run_id": run["databaseId"], "run_url": run.get("url"), "workflow": workflow, "run_status": run.get("status"), "conclusion": run.get("conclusion"), "state": "insufficient", "reason": "run_incomplete"})
     return {

--- a/scripts/watch-hyprland.py
+++ b/scripts/watch-hyprland.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Report actionable Hyprland upstream changes without changing repository state."""
+"""Report Hyprland chase work from immutable build evidence."""
 
 from __future__ import annotations
 
@@ -7,17 +7,18 @@ import argparse
 import json
 import re
 import subprocess
-import sys
+import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 
 ROOT = Path(__file__).resolve().parents[1]
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 REPOSITORY = "sandwichfarm/hyprexpo"
 UPSTREAM = "hyprwm/Hyprland"
 SEMVER = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
+ATTEMPT = re.compile(r"-(\d+)$")
 
 
 class ObservationError(RuntimeError):
@@ -71,8 +72,73 @@ def load_branch_contract(branch_sha: str) -> dict[str, Any]:
         "development_revision": revision,
         "lock_revision": locked,
         "lock_matches_target": locked == revision,
+        "branch_tree": command("git", "rev-parse", f"{branch_sha}^{{tree}}").strip(),
         "release_targets": targets.get("release", []),
     }
+
+
+def parse_provenance(path: Path) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for line in path.read_text().splitlines():
+        key, separator, value = line.partition("=")
+        if separator:
+            values[key] = value
+    return values
+
+
+def artifact_attempt(name: str) -> int | None:
+    match = ATTEMPT.search(name)
+    return int(match.group(1)) if match else None
+
+
+def artifact_evidence(run: dict[str, Any], workflow: str) -> list[dict[str, Any]]:
+    run_id = run["databaseId"]
+    artifacts = json_command("gh", "api", f"repos/{REPOSITORY}/actions/runs/{run_id}/artifacts").get("artifacts", [])
+    records: list[dict[str, Any]] = []
+    for artifact in artifacts:
+        name = artifact.get("name", "")
+        if artifact.get("expired") or not (name.startswith("upstream-tip-") or name.startswith("compatibility-")):
+            continue
+        with tempfile.TemporaryDirectory(prefix="hyprexpo-observation-") as directory:
+            try:
+                result = subprocess.run(["gh", "run", "download", str(run_id), "-R", REPOSITORY, "--name", name, "--dir", directory], cwd=ROOT, text=True, capture_output=True, timeout=20)
+            except subprocess.TimeoutExpired:
+                records.append({"run_id": run_id, "run_url": run.get("url"), "workflow": workflow, "state": "insufficient", "reason": "artifact_download_timed_out"})
+                continue
+            if result.returncode:
+                records.append({"run_id": run_id, "run_url": run.get("url"), "workflow": workflow, "state": "insufficient", "reason": "artifact_download_failed"})
+                continue
+            root = Path(directory)
+            manifest = root / "evidence.json"
+            provenance = root / "provenance.txt"
+            lock = root / "flake.lock"
+            if manifest.exists():
+                values = json.loads(manifest.read_text())
+                provenance_kind = "structured"
+            elif provenance.exists() and lock.exists():
+                values = parse_provenance(provenance)
+                values["branch_lock_revision"] = lock_revision(json.loads(lock.read_text()))
+                provenance_kind = "legacy"
+            else:
+                records.append({"run_id": run_id, "run_url": run.get("url"), "workflow": workflow, "state": "insufficient", "reason": "provenance_missing"})
+                continue
+            records.append({
+                "run_id": run_id,
+                "run_url": run.get("url"),
+                "workflow": workflow,
+                "run_status": run.get("status"),
+                "conclusion": run.get("conclusion"),
+                "workflow_head": run.get("headSha"),
+                "created_at": run.get("createdAt"),
+                "attempt": values.get("run_attempt", artifact_attempt(name)),
+                "job": values.get("job"),
+                "plugin_commit": values.get("plugin_commit"),
+                "plugin_tree": values.get("plugin_tree"),
+                "hyprland_commit": values.get("hyprland_commit"),
+                "branch_lock_revision": values.get("branch_lock_revision"),
+                "provenance": provenance_kind,
+            })
+    return records
 
 
 def discover_live() -> dict[str, Any]:
@@ -83,7 +149,17 @@ def discover_live() -> dict[str, Any]:
     releases = paginated_json("gh", "api", f"repos/{UPSTREAM}/releases?per_page=100")
     tags = paginated_json("gh", "api", f"repos/{UPSTREAM}/tags?per_page=100")
     prs = json_command("gh", "pr", "list", "-R", REPOSITORY, "--state", "open", "--json", "number,title,headRefName,baseRefName,isDraft")
-    runs = json_command("gh", "run", "list", "-R", REPOSITORY, "--workflow", "upstream-tip.yml", "--limit", "10", "--json", "databaseId,status,conclusion,headSha,createdAt,event")
+    evidence: list[dict[str, Any]] = []
+    for workflow in ("upstream-tip.yml", "compatibility.yml"):
+        runs = json_command("gh", "run", "list", "-R", REPOSITORY, "--workflow", workflow, "--limit", "10", "--json", "databaseId,status,conclusion,headSha,createdAt,event,url")
+        for run in runs:
+            if run.get("status") == "completed":
+                records = artifact_evidence(run, workflow)
+                evidence.extend(records)
+                if records:
+                    break
+            else:
+                evidence.append({"run_id": run["databaseId"], "run_url": run.get("url"), "workflow": workflow, "run_status": run.get("status"), "conclusion": run.get("conclusion"), "state": "insufficient", "reason": "run_incomplete"})
     return {
         "master": master,
         "development_branch": development,
@@ -92,7 +168,7 @@ def discover_live() -> dict[str, Any]:
         "releases": releases,
         "tags": {tag["name"]: tag["commit"]["sha"] for tag in tags if isinstance(tag.get("name"), str) and isinstance(tag.get("commit"), dict) and isinstance(tag["commit"].get("sha"), str)},
         "open_prs": prs,
-        "probe_runs": runs,
+        "evidence": evidence,
         "contract": load_branch_contract(development),
     }
 
@@ -114,27 +190,56 @@ def release_candidates(releases: list[dict[str, Any]], tags: dict[str, str], sup
     return candidates
 
 
+def classify_evidence(records: list[dict[str, Any]], contract: dict[str, Any], target: str) -> list[dict[str, Any]]:
+    classified = []
+    for record in records:
+        current = all(record.get(key) == value for key, value in {
+            "plugin_tree": contract["branch_tree"],
+            "hyprland_commit": target,
+            "branch_lock_revision": target,
+        }.items())
+        item = dict(record)
+        if record.get("state") == "insufficient":
+            item["reason"] = record["reason"]
+        elif not all(record.get(key) for key in ("plugin_tree", "hyprland_commit", "branch_lock_revision")):
+            item["state"] = "insufficient"
+            item["reason"] = "identity_incomplete"
+        elif current:
+            item["state"] = "current"
+            item["reason"] = "tree_target_and_lock_match"
+        else:
+            item["state"] = "historical"
+            item["reason"] = "tree_target_or_lock_changed"
+        classified.append(item)
+    return classified
+
+
 def observe(data: dict[str, Any]) -> dict[str, Any]:
     contract = data["contract"]
     target = contract["development_revision"]
     main = data["upstream_main"]
-    candidate_prefix = f"chase/hyprland-{main}"
-    candidates = [pr for pr in data.get("open_prs", []) if pr.get("headRefName") == candidate_prefix and pr.get("baseRefName") == "hyprland-git"]
-    probe_runs = data.get("probe_runs", [])
-    latest_probe = probe_runs[0] if probe_runs else None
+    candidates = [pr for pr in data.get("open_prs", []) if pr.get("headRefName") == f"chase/hyprland-{main}" and pr.get("baseRefName") == "hyprland-git"]
+    evidence = classify_evidence(data.get("evidence", []), contract, target)
+    current = sorted((row for row in evidence if row.get("state") == "current"), key=lambda row: (row.get("created_at") or "", row.get("run_id", 0)), reverse=True)
+    selected = current[0] if current else None
     failures: list[str] = []
     if not contract["lock_matches_target"]:
         failures.append("development_lock_mismatch")
-    if latest_probe and latest_probe.get("status") != "completed":
-        failures.append("probe_incomplete")
-    if latest_probe and latest_probe.get("status") == "completed" and latest_probe.get("conclusion") != "success":
-        failures.append("probe_failed")
+    if selected:
+        if selected.get("run_status") != "completed":
+            failures.append("validation_pending")
+        elif selected.get("conclusion") == "cancelled":
+            failures.append("validation_cancelled")
+        elif selected.get("conclusion") != "success":
+            failures.append("validation_failed")
+    elif main == target:
+        failures.append("validation_missing")
     supported = {row.get("name") for row in contract.get("release_targets", [])}
     eligible = release_candidates(data.get("releases", []), data.get("tags", {}), supported)
-    if candidates:
+    if failures:
+        status = "incomplete" if any(stage in failures for stage in ("validation_pending", "validation_cancelled", "validation_missing")) else "needs_diagnosis"
+    elif candidates:
         status = "candidate_active"
-    elif failures:
-        status = "incomplete" if "probe_incomplete" in failures else "needs_diagnosis"
     elif main == target:
         status = "up_to_date"
     else:
@@ -152,36 +257,26 @@ def observe(data: dict[str, Any]) -> dict[str, Any]:
         "upstream_main": main,
         "upstream_main_date": data.get("upstream_main_date"),
         "lock_matches_target": contract["lock_matches_target"],
-        "latest_probe": latest_probe,
+        "selected_validation": selected,
+        "evidence": evidence,
         "failure_stages": failures,
         "candidate_prs": candidates,
-        "eligible_releases": [
-            {"id": release.get("id"), "tag": release["tag_name"], "tag_commit": release.get("tag_commit"), "target": release.get("target_commitish"), "published_at": release.get("published_at")}
-            for release in eligible
-        ],
+        "eligible_releases": [{"id": release.get("id"), "tag": release["tag_name"], "tag_commit": release.get("tag_commit"), "target": release.get("target_commitish"), "published_at": release.get("published_at")} for release in eligible],
         "release_targets": contract.get("release_targets", []),
-        "next_action": (
-            "reuse active candidate and inspect its receipt" if candidates else
-            "inspect failed probe evidence before repair" if failures else
-            "prepare one development candidate" if main != target else
-            "no development repair required"
-        ),
+        "next_action": "inspect current validation evidence" if failures else "reuse active candidate" if candidates else "prepare one development candidate" if main != target else "no development repair required",
     }
 
 
 def markdown(report: dict[str, Any]) -> str:
-    lines = [
-        "# Hyprland chase observation",
-        "",
-        f"Status: **{report['status']}**",
-        f"Development target: `{report['development_target']}`",
-        f"Observed upstream main: `{report['upstream_main']}`",
-        f"Plugin base: `{report['plugin_base']}`",
-        f"Next action: {report['next_action']}",
-        "",
-    ]
+    lines = ["# Hyprland chase observation", "", f"Status: **{report['status']}**", f"Development target: `{report['development_target']}`", f"Observed upstream main: `{report['upstream_main']}`", f"Plugin base: `{report['plugin_base']}`", f"Next action: {report['next_action']}", ""]
     if report["failure_stages"]:
         lines.extend(["## Evidence gaps", "", *[f"- `{stage}`" for stage in report["failure_stages"]], ""])
+    if report["selected_validation"]:
+        item = report["selected_validation"]
+        lines.extend(["## Selected validation", "", f"- [{item['workflow']} run {item['run_id']}]({item['run_url']})", f"- `{item['reason']}`; attempt `{item.get('attempt')}`, job `{item.get('job') or 'legacy artifact'}`", ""])
+    historical = [item for item in report["evidence"] if item.get("state") == "historical"]
+    if historical:
+        lines.extend(["## Historical evidence", "", *[f"- [{item.get('workflow')} run {item.get('run_id')}]({item.get('run_url')}): `{item.get('reason')}`" for item in historical], ""])
     if report["candidate_prs"]:
         lines.extend(["## Existing candidates", "", *[f"- #{pr['number']} {pr['title']}" for pr in report["candidate_prs"]], ""])
     if report["eligible_releases"]:

--- a/tests/test_watch_hyprland.py
+++ b/tests/test_watch_hyprland.py
@@ -9,7 +9,27 @@ ROOT = Path(__file__).resolve().parents[1]
 WATCHER = ROOT / "scripts/watch-hyprland.py"
 
 
-def fixture(main="b" * 40, target="a" * 40, lock=None, probe="success", releases=None, tags=None, prs=None):
+def evidence(tree, target, conclusion="success", status="completed", run_id=1, lock=None, **extra):
+    return {
+        "run_id": run_id,
+        "run_url": f"https://example.test/runs/{run_id}",
+        "workflow": "compatibility.yml",
+        "run_status": status,
+        "conclusion": conclusion,
+        "workflow_head": "h" * 40,
+        "created_at": f"2026-09-10T00:00:{run_id:02}Z",
+        "attempt": 1,
+        "job": "build",
+        "plugin_commit": "c" * 40,
+        "plugin_tree": tree,
+        "hyprland_commit": target,
+        "branch_lock_revision": target if lock is None else lock,
+        "provenance": "structured",
+        **extra,
+    }
+
+
+def fixture(main="a" * 40, target="a" * 40, lock=None, records=None, prs=None):
     return {
         "master": "m" * 40,
         "development_branch": "d" * 40,
@@ -19,12 +39,13 @@ def fixture(main="b" * 40, target="a" * 40, lock=None, probe="success", releases
             "development_revision": target,
             "lock_revision": target if lock is None else lock,
             "lock_matches_target": lock is None or lock == target,
+            "branch_tree": "t" * 40,
             "release_targets": [{"name": "v0.56.2", "rev": "r" * 40}],
         },
-        "releases": [] if releases is None else releases,
-        "tags": {} if tags is None else tags,
+        "releases": [],
+        "tags": {},
         "open_prs": [] if prs is None else prs,
-        "probe_runs": [{"databaseId": 1, "status": "completed", "conclusion": probe, "headSha": "m" * 40, "createdAt": "2026-09-10T00:00:00Z"}],
+        "evidence": [] if records is None else records,
     }
 
 
@@ -38,64 +59,72 @@ def run(data, form="json"):
 
 
 class WatchHyprlandTests(unittest.TestCase):
-    def test_up_to_date_has_no_candidate_work(self):
-        result = run(fixture(main="a" * 40))
-        report = json.loads(result.stdout)
-        self.assertEqual(result.returncode, 0)
+    def test_validated_merged_repair_makes_old_failed_probe_historical(self):
+        target = "a" * 40
+        current = evidence("t" * 40, target, run_id=2)
+        old_failed = evidence("o" * 40, target, conclusion="failure", run_id=1, workflow="upstream-tip.yml")
+        report = json.loads(run(fixture(records=[old_failed, current])).stdout)
         self.assertEqual(report["status"], "up_to_date")
-        self.assertEqual(report["eligible_releases"], [])
+        self.assertEqual(report["selected_validation"]["run_id"], 2)
+        self.assertEqual(report["evidence"][0]["state"], "historical")
 
-    def test_new_target_requests_one_candidate(self):
-        result = run(fixture())
-        report = json.loads(result.stdout)
-        self.assertEqual(report["status"], "new_upstream_target")
-        self.assertEqual(report["next_action"], "prepare one development candidate")
-
-    def test_existing_exact_candidate_deduplicates(self):
-        main = "b" * 40
-        result = run(fixture(prs=[{"number": 7, "title": "chase", "headRefName": f"chase/hyprland-{main}", "baseRefName": "hyprland-git", "isDraft": True}]))
-        report = json.loads(result.stdout)
-        self.assertEqual(report["status"], "candidate_active")
-        self.assertEqual(report["candidate_prs"][0]["number"], 7)
-
-    def test_existing_candidate_wins_over_prior_failed_probe(self):
-        main = "b" * 40
-        report = json.loads(run(fixture(probe="failure", prs=[{"number": 7, "title": "chase", "headRefName": f"chase/hyprland-{main}", "baseRefName": "hyprland-git", "isDraft": True}])).stdout)
-        self.assertEqual(report["status"], "candidate_active")
-        self.assertIn("probe_failed", report["failure_stages"])
-
-    def test_failed_probe_requires_diagnosis(self):
-        result = run(fixture(probe="failure"))
-        report = json.loads(result.stdout)
+    def test_current_failure_beats_earlier_success(self):
+        target = "a" * 40
+        old_success = evidence("t" * 40, target, run_id=1)
+        current_failure = evidence("t" * 40, target, conclusion="failure", run_id=2)
+        report = json.loads(run(fixture(records=[old_success, current_failure])).stdout)
         self.assertEqual(report["status"], "needs_diagnosis")
-        self.assertIn("probe_failed", report["failure_stages"])
+        self.assertEqual(report["failure_stages"], ["validation_failed"])
 
-    def test_lock_mismatch_is_never_compatible(self):
-        result = run(fixture(lock="c" * 40))
-        report = json.loads(result.stdout)
+    def test_upstream_advance_needs_new_candidate_even_with_prior_validation(self):
+        target = "a" * 40
+        report = json.loads(run(fixture(main="b" * 40, records=[evidence("t" * 40, target)])).stdout)
+        self.assertEqual(report["status"], "new_upstream_target")
+
+    def test_plugin_tree_change_rejects_same_target_success(self):
+        target = "a" * 40
+        report = json.loads(run(fixture(records=[evidence("o" * 40, target)])).stdout)
+        self.assertEqual(report["status"], "incomplete")
+        self.assertIn("validation_missing", report["failure_stages"])
+        self.assertEqual(report["evidence"][0]["state"], "historical")
+
+    def test_workflow_head_does_not_decide_identity(self):
+        target = "a" * 40
+        report = json.loads(run(fixture(records=[evidence("t" * 40, target, workflow_head="m" * 40)])).stdout)
+        self.assertEqual(report["status"], "up_to_date")
+        self.assertEqual(report["selected_validation"]["workflow_head"], "m" * 40)
+
+    def test_missing_pending_and_cancelled_provenance_stay_explicit(self):
+        target = "a" * 40
+        missing = {"run_id": 1, "run_url": "https://example.test/runs/1", "workflow": "upstream-tip.yml", "state": "insufficient", "reason": "provenance_missing"}
+        pending = evidence("t" * 40, target, status="in_progress", conclusion=None, run_id=2)
+        report = json.loads(run(fixture(records=[missing, pending])).stdout)
+        self.assertEqual(report["status"], "incomplete")
+        self.assertIn("validation_pending", report["failure_stages"])
+        self.assertEqual(report["evidence"][0]["state"], "insufficient")
+
+    def test_cancelled_current_validation_is_incomplete(self):
+        target = "a" * 40
+        cancelled = evidence("t" * 40, target, status="completed", conclusion="cancelled")
+        report = json.loads(run(fixture(records=[cancelled])).stdout)
+        self.assertEqual(report["status"], "incomplete")
+        self.assertEqual(report["failure_stages"], ["validation_cancelled"])
+
+    def test_lock_mismatch_never_uses_matching_build(self):
+        target = "a" * 40
+        report = json.loads(run(fixture(lock="b" * 40, records=[evidence("t" * 40, target)])).stdout)
         self.assertEqual(report["status"], "needs_diagnosis")
         self.assertIn("development_lock_mismatch", report["failure_stages"])
 
-    def test_new_stable_release_is_reported_but_drafts_are_ignored(self):
-        releases = [
-            {"id": 1, "tag_name": "v0.56.2", "draft": False, "prerelease": False},
-            {"id": 2, "tag_name": "v0.57.0", "draft": False, "prerelease": False, "target_commitish": "z" * 40},
-            {"id": 3, "tag_name": "v0.58.0", "draft": True, "prerelease": False},
-            {"id": 4, "tag_name": "v0.59.0-rc.1", "draft": False, "prerelease": True},
-        ]
-        report = json.loads(run(fixture(releases=releases, tags={"v0.57.0": "p" * 40})).stdout)
-        self.assertEqual(report["eligible_releases"], [{"id": 2, "tag": "v0.57.0", "tag_commit": "p" * 40, "target": "z" * 40, "published_at": None}])
-
-    def test_older_unsupported_releases_are_not_new_work(self):
-        releases = [{"id": 1, "tag_name": "v0.55.4", "draft": False, "prerelease": False}]
-        report = json.loads(run(fixture(main="a" * 40, releases=releases)).stdout)
-        self.assertEqual(report["eligible_releases"], [])
-
-    def test_markdown_exposes_failure_and_release_work(self):
-        result = run(fixture(probe="failure", releases=[{"id": 2, "tag_name": "v0.57.0", "draft": False, "prerelease": False}]), "markdown")
+    def test_candidate_detection_and_markdown_evidence(self):
+        target = "a" * 40
+        main = "b" * 40
+        candidate = {"number": 7, "title": "chase", "headRefName": f"chase/hyprland-{main}", "baseRefName": "hyprland-git", "isDraft": True}
+        result = run(fixture(main=main, records=[evidence("t" * 40, target)], prs=[candidate]), "markdown")
         self.assertEqual(result.returncode, 0)
-        self.assertIn("probe_failed", result.stdout)
-        self.assertIn("v0.57.0", result.stdout)
+        self.assertIn("candidate_active", result.stdout)
+        self.assertIn("Selected validation", result.stdout)
+        self.assertIn("run 1", result.stdout)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The chase observer now selects validation from artifact provenance: tested plugin tree, exact upstream commit, and source lock. Historical probe failures remain visible without blocking an already validated merged repair.

Validation: make -B test; make test-tooling; scrolling source contracts; live observer against existing #129 evidence.