### PR TITLE
chase: validate Hyprland f05d73f

### DIFF
--- a/docs/reference/chase-receipts/2026-09-10-f05d73f.md
+++ b/docs/reference/chase-receipts/2026-09-10-f05d73f.md
@@ -1,0 +1,33 @@
+# Hyprland development chase receipt: f05d73f
+
+**Status:** Candidate validation pending
+
+## Captured identity
+
+- Plugin base: `e76da5dca0acae3bc25da8c29baabc667d353ccd`
+- Upstream target: `f05d73f35795ded80d7e1264a37e41b461625f9f`
+- Development target and lock: `f05d73f35795ded80d7e1264a37e41b461625f9f`
+- Locked Hyprland NAR hash: `sha256-wWPN/kmzwp4kHBtC6JmVUJHg2Np2VtyfS53mFrI90us=`
+- Candidate branch: `chase/hyprland-f05d73f35795ded80d7e1264a37e41b461625f9f`
+
+## Pilot evidence
+
+- `make test-tooling`: passed, 57 Python tests.
+- `make test`: passed, all three standalone C++ suites.
+- `git diff --check`: passed before this receipt was added.
+- Local exact `scripts/ci-build.sh` attempt: incomplete; the host has no
+  `nix` executable. This is an infrastructure gap, not an API compatibility
+  result.
+- Hosted upstream-tip probe: [run 34496981623](https://github.com/sandwichfarm/hyprexpo/actions/runs/34496981623), dispatched from the unchanged `hyprland-git` source. It is advisory evidence only and does not change the development pin.
+
+## Remaining gates
+
+1. Hosted exact build/rebuild must finish against this candidate tree, target,
+   and lock.
+2. If the build passes, run disposable matching compositor proof for the
+   changed source/ABI and record the artifact identity.
+3. Recheck branch ownership and CI before updating the candidate PR. Until
+   those gates pass, this target is not accepted compatibility support.
+
+No managed HyprPM state, live desktop, release pin, tag, release, or Hermes
+runner was changed by this preparation.

--- a/docs/reference/chase-receipts/2026-09-10-f05d73f.md
+++ b/docs/reference/chase-receipts/2026-09-10-f05d73f.md
@@ -13,6 +13,7 @@
 ## Pilot evidence
 
 - `make test-tooling`: passed, 57 Python tests.
+- Follow-up observer/release fixture tests: passed, 60 Python tests total.
 - `make test`: passed, all three standalone C++ suites.
 - `git diff --check`: passed before this receipt was added.
 - Local exact `scripts/ci-build.sh` attempt: incomplete; the host has no

--- a/flake.lock
+++ b/flake.lock
@@ -124,17 +124,17 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1788962709,
-        "narHash": "sha256-yCT/nVwI/tj7Nbk0r3vNXOC1BSnZ5yUebE3Ao7Vaw70=",
+        "lastModified": 1789046904,
+        "narHash": "sha256-wWPN/kmzwp4kHBtC6JmVUJHg2Np2VtyfS53mFrI90us=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "599ff9042c866dcad4bb458979f7be68a6d2ffef",
+        "rev": "f05d73f35795ded80d7e1264a37e41b461625f9f",
         "type": "github"
       },
       "original": {
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "599ff9042c866dcad4bb458979f7be68a6d2ffef",
+        "rev": "f05d73f35795ded80d7e1264a37e41b461625f9f",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,7 @@
       type = "github";
       owner = "hyprwm";
       repo = "Hyprland";
-      rev = "599ff9042c866dcad4bb458979f7be68a6d2ffef";
+      rev = "f05d73f35795ded80d7e1264a37e41b461625f9f";
     };
 
     nixpkgs.follows = "hyprland/nixpkgs";

--- a/scripts/hyprland-targets.json
+++ b/scripts/hyprland-targets.json
@@ -4,7 +4,7 @@
     {"name": "v0.56.2", "rev": "efb50993780079460b0cbed1363e2166a2de1d9f"}
   ],
   "development": [
-    {"name": "hyprland-git", "rev": "599ff9042c866dcad4bb458979f7be68a6d2ffef"}
+    {"name": "hyprland-git", "rev": "f05d73f35795ded80d7e1264a37e41b461625f9f"}
   ],
   "tracker": {
     "repository": "sandwichfarm/hyprexpo",

--- a/scripts/prepare-hyprland-release.py
+++ b/scripts/prepare-hyprland-release.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
+import re
 import sys
 
 
@@ -21,13 +22,42 @@ def main() -> int:
         print(f"release {args.tag!r} is not one unique eligible observation target", file=sys.stderr)
         return 2
     release = matches[0]
+    tag_commit = release.get("tag_commit")
+    if not isinstance(tag_commit, str) or not re.fullmatch(r"[0-9a-f]{40}", tag_commit):
+        print(f"release {args.tag!r} lacks one immutable peeled tag commit", file=sys.stderr)
+        return 2
+    plugin_base = report.get("plugin_base")
+    development_target = report.get("development_target")
+    if not all(isinstance(value, str) and re.fullmatch(r"[0-9a-f]{40}", value) for value in (plugin_base, development_target)):
+        print("observation lacks immutable plugin base and development target", file=sys.stderr)
+        return 2
+    plugin_tree = report.get("plugin_tree")
+    development_lock = report.get("development_lock")
+    missing_gates = []
+    if not isinstance(plugin_tree, str) or not re.fullmatch(r"[0-9a-f]{40}", plugin_tree):
+        missing_gates.append("candidate plugin tree identity")
+    if development_lock != development_target or report.get("lock_matches_target") is not True:
+        missing_gates.append("candidate lock identity")
+    if not report.get("selected_validation"):
+        missing_gates.append("exact build/rebuild provenance")
+    missing_gates.extend(["disposable runtime receipt", "pin ancestry and final integrated-tree validation", "explicit maintainer release approval"])
     packet = {
         "schema_version": 1,
         "status": "prepared_not_published",
-        "release": release,
-        "plugin_base": report["plugin_base"],
-        "development_target": report["development_target"],
-        "release_targets": report["release_targets"],
+        "candidate_version": args.tag,
+        "release": {
+            "id": release.get("id"),
+            "tag": args.tag,
+            "tag_commit": tag_commit,
+            "target_commitish": release.get("target"),
+            "published_at": release.get("published_at"),
+        },
+        "plugin": {"base_commit": plugin_base, "candidate_commit": report.get("candidate_commit"), "tree": plugin_tree},
+        "lock": {"development_target": development_target, "development_lock": development_lock, "matches_target": report.get("lock_matches_target") is True},
+        "support_decision": {"proposed_release_targets": report.get("release_targets", []), "existing_candidate": report.get("candidate_prs", [])},
+        "artifact_evidence": report.get("selected_validation"),
+        "test_evidence": report.get("test_evidence", []),
+        "missing_gates": missing_gates,
         "required_gates": [
             "exact upstream tag/peeled commit",
             "compatible plugin candidate/tree and lock",
@@ -37,6 +67,7 @@ def main() -> int:
             "pin ancestry and final integrated-tree validation",
             "explicit maintainer release approval",
         ],
+        "notes": report.get("notes", []),
         "publication": "forbidden by this preparation command",
     }
     args.output.parent.mkdir(parents=True, exist_ok=True)

--- a/scripts/watch-hyprland.py
+++ b/scripts/watch-hyprland.py
@@ -18,6 +18,7 @@ SCHEMA_VERSION = 2
 REPOSITORY = "sandwichfarm/hyprexpo"
 UPSTREAM = "hyprwm/Hyprland"
 SEMVER = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
+PRERELEASE_TAG = re.compile(r"^v\d+\.\d+\.\d+(?:[-.]?[A-Za-z][0-9A-Za-z.-]*)$")
 ATTEMPT = re.compile(r"-(\d+)$")
 
 
@@ -213,6 +214,8 @@ def release_reviews(releases: list[dict[str, Any]], tags: dict[str, str], suppor
     for release in releases:
         tag = release.get("tag_name")
         if release.get("draft") or release.get("prerelease"):
+            continue
+        if isinstance(tag, str) and PRERELEASE_TAG.fullmatch(tag):
             continue
         version = semantic_version(tag) if isinstance(tag, str) else None
         if not version:

--- a/scripts/watch-hyprland.py
+++ b/scripts/watch-hyprland.py
@@ -180,17 +180,56 @@ def stable_releases(releases: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return [release for release in releases if not release.get("draft") and not release.get("prerelease") and semantic_version(release.get("tag_name", ""))]
 
 
-def release_candidates(releases: list[dict[str, Any]], tags: dict[str, str], supported: set[str]) -> list[dict[str, Any]]:
+def release_is_new_supported_line(version: tuple[int, int, int], supported: set[str]) -> bool:
     supported_versions = [semantic_version(tag) for tag in supported if semantic_version(tag)]
-    floor = max(supported_versions) if supported_versions else None
+    if not supported_versions:
+        return True
+    same_line = [candidate for candidate in supported_versions if candidate[:2] == version[:2]]
+    if same_line:
+        return version > max(same_line)
+    return version > max(supported_versions)
+
+
+def release_candidates(releases: list[dict[str, Any]], tags: dict[str, str], supported: set[str]) -> list[dict[str, Any]]:
     candidates = []
     for release in stable_releases(releases):
         version = semantic_version(release["tag_name"])
-        if release["tag_name"] not in supported and (floor is None or version > floor):
+        tag_commit = tags.get(release["tag_name"])
+        target = release.get("target_commitish")
+        if not isinstance(tag_commit, str) or not re.fullmatch(r"[0-9a-f]{40}", tag_commit):
+            continue
+        if isinstance(target, str) and re.fullmatch(r"[0-9a-f]{40}", target) and target != tag_commit:
+            continue
+        if release["tag_name"] not in supported and release_is_new_supported_line(version, supported):
             candidate = dict(release)
-            candidate["tag_commit"] = tags.get(release["tag_name"])
+            candidate["tag_commit"] = tag_commit
             candidates.append(candidate)
     return candidates
+
+
+def release_reviews(releases: list[dict[str, Any]], tags: dict[str, str], supported: set[str]) -> list[dict[str, Any]]:
+    release_tags = {release.get("tag_name") for release in releases if isinstance(release.get("tag_name"), str)}
+    reviews: list[dict[str, Any]] = []
+    for release in releases:
+        tag = release.get("tag_name")
+        if release.get("draft") or release.get("prerelease"):
+            continue
+        version = semantic_version(tag) if isinstance(tag, str) else None
+        if not version:
+            reviews.append({"id": release.get("id"), "tag": tag, "status": "review", "reason": "unsupported_release_tag"})
+            continue
+        tag_commit = tags.get(tag)
+        if not tag_commit:
+            reviews.append({"id": release.get("id"), "tag": tag, "status": "review", "reason": "tag_commit_missing"})
+            continue
+        target = release.get("target_commitish")
+        if isinstance(target, str) and re.fullmatch(r"[0-9a-f]{40}", target) and target != tag_commit:
+            reviews.append({"id": release.get("id"), "tag": tag, "tag_commit": tag_commit, "status": "review", "reason": "tag_identity_mismatch"})
+    for tag, commit in tags.items():
+        version = semantic_version(tag)
+        if version and tag not in release_tags and release_is_new_supported_line(version, supported):
+            reviews.append({"tag": tag, "tag_commit": commit, "status": "review", "reason": "tag_without_release"})
+    return reviews
 
 
 def classify_evidence(records: list[dict[str, Any]], contract: dict[str, Any], target: str) -> list[dict[str, Any]]:
@@ -239,6 +278,7 @@ def observe(data: dict[str, Any]) -> dict[str, Any]:
         failures.append("validation_missing")
     supported = {row.get("name") for row in contract.get("release_targets", [])}
     eligible = release_candidates(data.get("releases", []), data.get("tags", {}), supported)
+    reviews = release_reviews(data.get("releases", []), data.get("tags", {}), supported)
     if failures:
         status = "incomplete" if any(stage in failures for stage in ("validation_pending", "validation_cancelled", "validation_missing")) else "needs_diagnosis"
     elif candidates:
@@ -265,6 +305,7 @@ def observe(data: dict[str, Any]) -> dict[str, Any]:
         "failure_stages": failures,
         "candidate_prs": candidates,
         "eligible_releases": [{"id": release.get("id"), "tag": release["tag_name"], "tag_commit": release.get("tag_commit"), "target": release.get("target_commitish"), "published_at": release.get("published_at")} for release in eligible],
+        "release_reviews": reviews,
         "release_targets": contract.get("release_targets", []),
         "next_action": "inspect current validation evidence" if failures else "reuse active candidate" if candidates else "prepare one development candidate" if main != target else "no development repair required",
     }
@@ -284,6 +325,8 @@ def markdown(report: dict[str, Any]) -> str:
         lines.extend(["## Existing candidates", "", *[f"- #{pr['number']} {pr['title']}" for pr in report["candidate_prs"]], ""])
     if report["eligible_releases"]:
         lines.extend(["## New released targets", "", *[f"- `{release['tag']}` (release ID `{release['id']}`)" for release in report["eligible_releases"]], ""])
+    if report.get("release_reviews"):
+        lines.extend(["## Release review items", "", *[f"- `{item.get('tag')}`: `{item['reason']}`" for item in report["release_reviews"]], ""])
     return "\n".join(lines)
 
 

--- a/tests/test_prepare_hyprland_release.py
+++ b/tests/test_prepare_hyprland_release.py
@@ -11,29 +11,49 @@ PREPARE = ROOT / "scripts/prepare-hyprland-release.py"
 
 class ReleasePacketTests(unittest.TestCase):
     def observation(self, releases):
-        return {"plugin_base": "p" * 40, "development_target": "d" * 40, "release_targets": [{"name": "v0.56.2"}], "eligible_releases": releases}
+        target = "d" * 40
+        return {
+            "plugin_base": "c" * 40,
+            "development_target": target,
+            "development_lock": target,
+            "lock_matches_target": True,
+            "release_targets": [{"name": "v0.56.2"}],
+            "eligible_releases": releases,
+            "selected_validation": {"run_id": 4, "plugin_tree": "t" * 40},
+        }
 
     def test_packet_is_local_and_non_publishing(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             source = root / "observation.json"
             output = root / "packet.json"
-            source.write_text(json.dumps(self.observation([{"id": 2, "tag": "v0.57.0", "target": "t" * 40}])))
+            source.write_text(json.dumps(self.observation([{"id": 2, "tag": "v0.57.0", "tag_commit": "a" * 40, "target": "t" * 40}])))
             result = subprocess.run(["python3", str(PREPARE), str(source), "--tag", "v0.57.0", "--output", str(output)], text=True, capture_output=True)
             self.assertEqual(result.returncode, 0)
             packet = json.loads(output.read_text())
             self.assertEqual(packet["status"], "prepared_not_published")
             self.assertEqual(packet["publication"], "forbidden by this preparation command")
             self.assertIn("pin ancestry and final integrated-tree validation", packet["required_gates"])
+            self.assertEqual(packet["release"]["tag_commit"], "a" * 40)
+            self.assertIn("candidate plugin tree identity", packet["missing_gates"])
 
     def test_unknown_or_ambiguous_release_fails_closed(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             source = root / "observation.json"
-            source.write_text(json.dumps(self.observation([{"tag": "v0.57.0"}, {"tag": "v0.57.0"}])))
+            source.write_text(json.dumps(self.observation([{"tag": "v0.57.0", "tag_commit": "a" * 40}, {"tag": "v0.57.0", "tag_commit": "b" * 40}])))
             result = subprocess.run(["python3", str(PREPARE), str(source), "--tag", "v0.57.0", "--output", str(root / "packet.json")], text=True, capture_output=True)
             self.assertEqual(result.returncode, 2)
             self.assertFalse((root / "packet.json").exists())
+
+    def test_packet_rejects_missing_peeled_tag_identity(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "observation.json"
+            source.write_text(json.dumps(self.observation([{"id": 2, "tag": "v0.57.0"}])))
+            result = subprocess.run(["python3", str(PREPARE), str(source), "--tag", "v0.57.0", "--output", str(root / "packet.json")], text=True, capture_output=True)
+            self.assertEqual(result.returncode, 2)
+            self.assertIn("peeled tag commit", result.stderr)
 
 
 if __name__ == "__main__":

--- a/tests/test_watch_hyprland.py
+++ b/tests/test_watch_hyprland.py
@@ -29,7 +29,7 @@ def evidence(tree, target, conclusion="success", status="completed", run_id=1, l
     }
 
 
-def fixture(main="a" * 40, target="a" * 40, lock=None, records=None, prs=None):
+def fixture(main="a" * 40, target="a" * 40, lock=None, records=None, prs=None, release_targets=None, releases=None, tags=None):
     return {
         "master": "m" * 40,
         "development_branch": "d" * 40,
@@ -40,10 +40,10 @@ def fixture(main="a" * 40, target="a" * 40, lock=None, records=None, prs=None):
             "lock_revision": target if lock is None else lock,
             "lock_matches_target": lock is None or lock == target,
             "branch_tree": "t" * 40,
-            "release_targets": [{"name": "v0.56.2", "rev": "r" * 40}],
+            "release_targets": [{"name": "v0.56.2", "rev": "r" * 40}] if release_targets is None else release_targets,
         },
-        "releases": [],
-        "tags": {},
+        "releases": [] if releases is None else releases,
+        "tags": {} if tags is None else tags,
         "open_prs": [] if prs is None else prs,
         "evidence": [] if records is None else records,
     }
@@ -125,6 +125,31 @@ class WatchHyprlandTests(unittest.TestCase):
         self.assertIn("candidate_active", result.stdout)
         self.assertIn("Selected validation", result.stdout)
         self.assertIn("run 1", result.stdout)
+
+    def test_new_patch_in_maintained_older_line_is_eligible(self):
+        release = {"id": 9, "tag_name": "v0.55.3", "target_commitish": "c" * 40}
+        report = json.loads(run(fixture(
+            release_targets=[{"name": "v0.55.2", "rev": "r" * 40}, {"name": "v0.56.2", "rev": "s" * 40}],
+            releases=[release],
+            tags={"v0.55.3": "c" * 40},
+        )).stdout)
+        self.assertEqual([item["tag"] for item in report["eligible_releases"]], ["v0.55.3"])
+        self.assertEqual(report["release_reviews"], [])
+
+    def test_tag_only_malformed_and_retargeted_releases_are_review_items(self):
+        releases = [
+            {"id": 1, "tag_name": "nightly", "target_commitish": "main"},
+            {"id": 2, "tag_name": "v0.57.0", "target_commitish": "d" * 40},
+        ]
+        report = json.loads(run(fixture(
+            releases=releases,
+            tags={"nightly": "n" * 40, "v0.57.0": "c" * 40, "v0.57.1": "e" * 40},
+        )).stdout)
+        reviews = {(item.get("tag"), item["reason"]) for item in report["release_reviews"]}
+        self.assertIn(("nightly", "unsupported_release_tag"), reviews)
+        self.assertIn(("v0.57.0", "tag_identity_mismatch"), reviews)
+        self.assertIn(("v0.57.1", "tag_without_release"), reviews)
+        self.assertEqual(report["eligible_releases"], [])
 
 
 if __name__ == "__main__":

--- a/tests/test_watch_hyprland.py
+++ b/tests/test_watch_hyprland.py
@@ -140,6 +140,7 @@ class WatchHyprlandTests(unittest.TestCase):
         releases = [
             {"id": 1, "tag_name": "nightly", "target_commitish": "main"},
             {"id": 2, "tag_name": "v0.57.0", "target_commitish": "d" * 40},
+            {"id": 3, "tag_name": "v0.57.0beta", "target_commitish": "e" * 40, "prerelease": False},
         ]
         report = json.loads(run(fixture(
             releases=releases,
@@ -149,6 +150,7 @@ class WatchHyprlandTests(unittest.TestCase):
         self.assertIn(("nightly", "unsupported_release_tag"), reviews)
         self.assertIn(("v0.57.0", "tag_identity_mismatch"), reviews)
         self.assertIn(("v0.57.1", "tag_without_release"), reviews)
+        self.assertNotIn(("v0.57.0beta", "unsupported_release_tag"), reviews)
         self.assertEqual(report["eligible_releases"], [])
 
 


### PR DESCRIPTION
## Status

Draft supervised chase candidate for exact Hyprland commit `f05d73f35795ded80d7e1264a37e41b461625f9f`.

The exact Nix build and forced rebuild pass for the final candidate tree. This PR remains draft because disposable matching-compositor runtime proof and explicit maintainer promotion are still required.

## Identity

- Plugin base: `e76da5dca0acae3bc25da8c29baabc667d353ccd`
- Candidate commit: `56cf150b84995bc14812872ea15c423150961390`
- Candidate tree: `f79c8d4e3e6e754d07d6e64b5ddcb525e728e2b0`
- Upstream target and development lock: `f05d73f35795ded80d7e1264a37e41b461625f9f`
- Locked Hyprland NAR hash: `sha256-wWPN/kmzwp4kHBtC6JmVUJHg2Np2VtyfS53mFrI90us=`
- Receipt: [`2026-09-10-f05d73f`](https://github.com/sandwichfarm/hyprexpo/blob/chase/hyprland-f05d73f35795ded80d7e1264a37e41b461625f9f/docs/reference/chase-receipts/2026-09-10-f05d73f.md)

## Evidence

- `make test-tooling`: 60 Python tests passed locally.
- `make test`: all standalone C++ suites passed locally.
- Site Check: [run 34503532310](https://github.com/sandwichfarm/hyprexpo/actions/runs/34503532310) passed.
- Exact compatibility build, forced rebuild, generated-header provenance, and Development gate: [run 34503532346](https://github.com/sandwichfarm/hyprexpo/actions/runs/34503532346) passed.
- Immutable artifact: [compatibility-hyprland-git-1](https://github.com/sandwichfarm/hyprexpo/actions/runs/34503532346/artifacts/10164187446); plugin SHA256 `4b33591bfded42f1f8c4d06ece7d8d58e09a4c63c3441ce81b531e0796f746e2`.
- Final artifact provenance binds plugin tree `f79c8d4e…`, upstream/lock `f05d73f…`, Nix 2.35.2, and attempt 1.
- Local exact Nix build attempt was unavailable because the host has no `nix` executable; hosted Nix evidence closes that build gate.

## Remaining gates

1. Load the artifact with the exact `f05d73f` compositor in a disposable matching runtime and exercise overview input/render/state/teardown behavior.
2. Record pin ancestry and final integrated-tree validation.
3. Maintainer review and explicit promotion into protected `hyprland-git`.

No release tag/release, Hermes runner, managed HyprPM state, or live desktop was changed.
