### PR TITLE
docs(troubleshooting): document recovery from a sticky failed plugin load

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -43,7 +43,21 @@ the config before treating these as removed options.
 
 ## Plugin Load Fails With API or Hash Mismatch
 
-Rebuild HyprExpo against the same Hyprland revision that is running, then reload the plugin.
+Rebuild HyprExpo against the same Hyprland revision that is running, then load
+the rebuilt plugin explicitly and reload the config:
+
+```
+hyprctl plugin load /var/cache/hyprpm/$USER/hyprexpo/hyprexpo.so   # hyprpm install
+hyprctl plugin load ~/.local/lib/hyprland-plugins/hyprexpo.so      # local install
+hyprctl reload
+```
+
+A plain `hyprctl reload` does not retry a config-declared load that already
+failed earlier in the session. Hyprland only re-attempts config-managed plugin
+loads when the declared plugin list changes, so a failed attempt stays sticky
+until the next session. Loading the rebuilt plugin manually clears the failure
+immediately, and the following `hyprctl reload` applies the plugin options and
+binds again.
 
 ## Plugin Load Fails Because Dependencies Are Missing
 


### PR DESCRIPTION
## Summary

- spell out the recovery steps after rebuilding HyprExpo following a Hyprland update
- explain that a plain `hyprctl reload` does not retry a config-declared plugin load that already failed earlier in the session

## Why

Hyprland only re-attempts config-managed plugin loads when the declared plugin
list changes, so a failed attempt stays sticky until the next session. After
rebuilding against updated headers, users who only run `hyprctl reload` see
nothing happen and no log output. The reliable recovery is an explicit
`hyprctl plugin load <path>` followed by `hyprctl reload`; the next session
picks the plugin up from the config as usual.

Observed on Hyprland 0.56.2 (commit `efb5099…`) after a distro package rebuild
changed the API hash.

## Validation

- `git diff --check`
- `npm --prefix docs run docs:build`
